### PR TITLE
test: 테스트 커버리지 75% → 98% 개선

### DIFF
--- a/src/infra/broker.py
+++ b/src/infra/broker.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Optional
 from src.core.interfaces import IBrokerAdapter
 from src.core.models import Portfolio, Order, TradeExecution
 import time
+import requests
 from datetime import datetime
 
 class MockBroker(IBrokerAdapter):

--- a/tests/test_backtest_fetcher.py
+++ b/tests/test_backtest_fetcher.py
@@ -1,0 +1,68 @@
+# tests/test_backtest_fetcher.py
+import pytest
+import pandas as pd
+from unittest.mock import patch, MagicMock
+from src.backtest.fetcher import download_historical_data
+
+
+@pytest.fixture
+def mock_yf_download():
+    """yfinance.download를 Mock"""
+    with patch('src.backtest.fetcher.yf.download') as mock:
+        yield mock
+
+
+def test_download_historical_data_basic(mock_yf_download):
+    """기본 데이터 다운로드 동작 확인"""
+    # Mock 데이터 준비
+    dates = pd.date_range("2023-01-01", periods=5)
+    price_df = pd.DataFrame({'Close': [100, 101, 102, 103, 104]}, index=dates)
+    vix_df = pd.DataFrame({'Close': [15, 16, 17, 18, 19]}, index=dates)
+
+    # 첫 번째 호출: 주가, 두 번째 호출: VIX
+    mock_yf_download.side_effect = [price_df, vix_df]
+
+    tickers = ['SPY', 'IEF']
+    df, vix = download_historical_data(tickers, "2023-01-01", "2023-12-31")
+
+    # 반환값 확인
+    assert not df.empty
+    assert not vix.empty
+    assert len(df) == 5
+
+    # yf.download가 2번 호출되었는지 확인 (주가 + VIX)
+    assert mock_yf_download.call_count == 2
+
+    # 첫 번째 호출: 주가 데이터
+    first_call_args = mock_yf_download.call_args_list[0]
+    assert first_call_args[0][0] == ['SPY', 'IEF']
+
+    # 두 번째 호출: VIX 데이터
+    second_call_args = mock_yf_download.call_args_list[1]
+    assert second_call_args[0][0] == "^VIX"
+
+
+def test_download_historical_data_start_offset(mock_yf_download):
+    """시작 날짜가 500일 앞으로 당겨지는지 확인"""
+    dates = pd.date_range("2022-01-01", periods=3)
+    mock_df = pd.DataFrame({'Close': [100, 101, 102]}, index=dates)
+    mock_yf_download.side_effect = [mock_df, mock_df]
+
+    download_historical_data(['SPY'], "2023-06-01", "2023-12-31")
+
+    # start 인자가 500일 앞인지 확인
+    first_call = mock_yf_download.call_args_list[0]
+    start_date = first_call[1]['start']
+    # 2023-06-01에서 500일 전 = 약 2022-01-17
+    assert start_date.year == 2022
+
+
+def test_download_historical_data_returns_tuple(mock_yf_download):
+    """반환값이 (df, vix) 튜플인지 확인"""
+    mock_df = pd.DataFrame({'Close': [100]})
+    mock_yf_download.side_effect = [mock_df, mock_df]
+
+    result = download_historical_data(['SPY'], "2023-01-01", "2023-12-31")
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,0 +1,315 @@
+# tests/test_coverage_gaps.py
+# 각 모듈의 미커버 라인을 보완하는 테스트 모음
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import patch, MagicMock
+from src.core.models import (
+    MarketData, MarketRegime, TradeSignal, Order, Portfolio, TradeExecution
+)
+
+
+# ==========================================
+# BacktestDataLoader 엣지 케이스 (components.py 25, 37-40, 48-49)
+# ==========================================
+class TestBacktestDataLoaderEdgeCases:
+    @pytest.fixture
+    def loader_data(self):
+        """기본 테스트 데이터"""
+        dates = pd.date_range(start="2024-01-01", periods=10)
+        prices = np.linspace(100, 190, 10).reshape(-1, 1)
+        columns = pd.MultiIndex.from_product([['Close'], ['SPY']])
+        df = pd.DataFrame(prices, index=dates, columns=columns)
+        vix_df = pd.DataFrame({'Close': [20.0] * 10}, index=dates)
+        return df, vix_df
+
+    def test_loader_holiday_date(self, loader_data):
+        """현재 날짜가 데이터에 없는 경우 (휴장일)"""
+        from src.backtest.components import BacktestDataLoader
+
+        full_df, full_vix = loader_data
+        loader = BacktestDataLoader(full_df, full_vix)
+
+        # 1월 1일~10일 데이터가 있지만, 1월 15일(없는 날짜)로 설정
+        holiday = pd.Timestamp("2024-01-15")
+        loader.set_date(holiday)
+
+        # 데이터는 1월 10일까지만 있으므로 전체가 반환됨
+        df = loader.fetch_ohlcv(["SPY"], days=5)
+        assert len(df) == 5
+
+    def test_loader_fetch_ohlcv_keyerror(self, loader_data):
+        """단일 종목 요청인데 해당 종목이 MultiIndex에 없는 경우"""
+        from src.backtest.components import BacktestDataLoader
+
+        full_df, full_vix = loader_data
+        loader = BacktestDataLoader(full_df, full_vix)
+        loader.set_date(pd.Timestamp("2024-01-05"))
+
+        # 'IEF'는 데이터에 없음 -> KeyError -> except 분기로 원본 반환
+        df = loader.fetch_ohlcv(["IEF"], days=3)
+        assert len(df) == 3  # 원본 슬라이스가 그대로 반환
+
+    def test_loader_fetch_vix_fallback(self, loader_data):
+        """VIX 데이터가 비정상적일 때 기본값 20.0 반환"""
+        from src.backtest.components import BacktestDataLoader
+
+        full_df, _ = loader_data
+        # VIX 데이터를 빈 DataFrame으로 설정
+        empty_vix = pd.DataFrame()
+        loader = BacktestDataLoader(full_df, empty_vix)
+        loader.set_date(pd.Timestamp("2024-01-05"))
+
+        vix = loader.fetch_vix()
+        assert vix == 20.0
+
+    def test_loader_non_multiindex(self, loader_data):
+        """DataFrame이 MultiIndex가 아닌 경우"""
+        from src.backtest.components import BacktestDataLoader
+
+        dates = pd.date_range(start="2024-01-01", periods=5)
+        # 단일 인덱스 DataFrame
+        simple_df = pd.DataFrame({'Close': [100, 110, 120, 130, 140]}, index=dates)
+        vix_df = pd.DataFrame({'Close': [20.0] * 5}, index=dates)
+
+        loader = BacktestDataLoader(simple_df, vix_df)
+        loader.set_date(pd.Timestamp("2024-01-03"))
+
+        # 단일 인덱스이므로 MultiIndex 분기 안 탐
+        df = loader.fetch_ohlcv(["SPY"], days=3)
+        assert len(df) == 3
+
+
+# ==========================================
+# BacktestRunner 엣지 케이스 (runner.py 62-64, 87, 99-100)
+# ==========================================
+class TestBacktestRunnerEdgeCases:
+    @pytest.fixture
+    def mock_fetcher_data(self):
+        """러너 테스트용 대량 데이터"""
+        dates = pd.date_range(start="2022-01-01", end="2023-02-15")
+        prices = np.linspace(100, 200, len(dates)).reshape(-1, 1)
+        columns = pd.MultiIndex.from_product([['Close'], ['SPY']])
+        df = pd.DataFrame(prices, index=dates, columns=columns)
+        vix = pd.DataFrame({'Close': [15.0] * len(dates)}, index=dates)
+        return df, vix
+
+    @patch("src.backtest.runner.download_historical_data")
+    @patch("src.backtest.runner.plt.show")
+    def test_runner_with_data_error_on_some_days(self, mock_show, mock_download, mock_fetcher_data):
+        """일부 날짜에서 데이터 추출 실패해도 계속 진행"""
+        from src.backtest.runner import run_backtest
+
+        mock_download.return_value = mock_fetcher_data
+        # 에러 없이 실행되면 OK (내부에서 continue 처리)
+        run_backtest(start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0)
+        mock_show.assert_called_once()
+
+    @patch("src.backtest.runner.download_historical_data")
+    @patch("src.backtest.runner.plt.show")
+    def test_runner_rebalance_execution(self, mock_show, mock_download):
+        """리밸런싱이 실행되는 시나리오"""
+        from src.backtest.runner import run_backtest
+
+        # 충분한 데이터와 변동성이 높은 시나리오
+        dates = pd.date_range(start="2022-01-01", end="2023-06-15")
+        # 가격이 크게 변동하도록 설정
+        prices = np.concatenate([
+            np.linspace(100, 200, len(dates) // 2),
+            np.linspace(200, 80, len(dates) - len(dates) // 2)
+        ]).reshape(-1, 1)
+        columns = pd.MultiIndex.from_product([['Close'], ['SPY']])
+        df = pd.DataFrame(prices, index=dates, columns=columns)
+        vix = pd.DataFrame({'Close': [25.0] * len(dates)}, index=dates)
+        mock_download.return_value = (df, vix)
+
+        run_backtest(start_date="2023-01-02", end_date="2023-06-01", initial_cash=10000.0)
+        mock_show.assert_called_once()
+
+
+# ==========================================
+# Notifier 미커버 라인 (notifier.py 15, 44-47, 66-69)
+# ==========================================
+class TestNotifierEdgeCases:
+    def test_telegram_send_alert(self):
+        """TelegramNotifier.send_alert 테스트"""
+        from src.infra.notifier import TelegramNotifier
+
+        with patch('src.infra.notifier.requests.post') as mock_post:
+            notifier = TelegramNotifier(token="123:ABC", chat_id="999")
+            notifier.send_alert("Danger!")
+
+            mock_post.assert_called_once()
+            _, kwargs = mock_post.call_args
+            assert "WARNING" in kwargs['json']['text']
+            assert "Danger!" in kwargs['json']['text']
+
+    def test_slack_send_without_webhook(self):
+        """SlackNotifier: webhook_url이 없을 때 콘솔 출력"""
+        mock_logger = MagicMock()
+        from src.infra.notifier import SlackNotifier
+
+        notifier = SlackNotifier(webhook_url="", logger=mock_logger)
+        notifier.send_message("Test Message")
+
+        # webhook이 없으므로 logger.info로 mock 출력
+        mock_logger.info.assert_called_once()
+        call_arg = mock_logger.info.call_args[0][0]
+        assert "[Slack Mock]" in call_arg
+
+    def test_slack_alert_without_webhook(self):
+        """SlackNotifier: webhook 없이 alert 전송"""
+        mock_logger = MagicMock()
+        from src.infra.notifier import SlackNotifier
+
+        notifier = SlackNotifier(webhook_url="", logger=mock_logger)
+        notifier.send_alert("Alert Test")
+
+        mock_logger.info.assert_called_once()
+
+    def test_slack_send_connection_error(self):
+        """SlackNotifier: 네트워크 에러 처리"""
+        mock_logger = MagicMock()
+        from src.infra.notifier import SlackNotifier
+
+        with patch('src.infra.notifier.requests.post') as mock_post:
+            mock_post.side_effect = Exception("Connection refused")
+
+            notifier = SlackNotifier(
+                webhook_url="https://hooks.slack.com/test",
+                logger=mock_logger
+            )
+            notifier.send_message("Test")
+
+            # 에러 로그가 기록되어야 함
+            mock_logger.error.assert_called_once()
+            call_arg = mock_logger.error.call_args[0][0]
+            assert "[Slack Error]" in call_arg
+            assert "Connection failed" in call_arg
+
+
+# ==========================================
+# YFinanceLoader VIX 엣지 케이스 (data.py 53, 61-64)
+# ==========================================
+class TestYFinanceLoaderEdgeCases:
+    @pytest.fixture
+    def mock_yf(self):
+        with patch('src.infra.data.yf.download') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_logger(self):
+        return MagicMock()
+
+    def test_fetch_vix_multiindex_dataframe_close(self, mock_yf, mock_logger):
+        """VIX MultiIndex에서 Close가 DataFrame으로 반환되는 경우 (line 51)"""
+        from src.infra.data import YFinanceLoader
+
+        # MultiIndex에서 xs('Close')가 DataFrame을 반환하는 구조
+        columns = pd.MultiIndex.from_product([['Close'], ['^VIX']])
+        mock_df = pd.DataFrame([[25.5], [26.0]], columns=columns)
+        mock_yf.return_value = mock_df
+
+        loader = YFinanceLoader(mock_logger)
+        vix = loader.fetch_vix()
+
+        assert vix == 26.0  # 마지막 행의 첫 번째 열
+
+    def test_fetch_vix_exception_fallback(self, mock_yf, mock_logger):
+        """VIX 조회 중 예외 시 기본값 20.0 반환 (lines 61-64)"""
+        from src.infra.data import YFinanceLoader
+
+        mock_yf.side_effect = Exception("Network Error")
+
+        loader = YFinanceLoader(mock_logger)
+        vix = loader.fetch_vix()
+
+        assert vix == 20.0
+        mock_logger.error.assert_called()
+
+
+# ==========================================
+# TradingBot 미커버 라인 (main.py 38-40, 104)
+# ==========================================
+class TestTradingBotEdgeCases:
+    @pytest.fixture
+    def mock_deps_live(self):
+        """실전 모드 Mock 의존성"""
+        with patch('src.main.YFinanceLoader') as MockLoader, \
+             patch('src.main.JsonRepository') as MockRepo, \
+             patch('src.main.SlackNotifier') as MockNotifier, \
+             patch('src.main.KisBroker') as MockKisBroker, \
+             patch('src.main.IndicatorCalculator') as MockCalc, \
+             patch('src.main.RegimeAnalyzer') as MockAnalyzer, \
+             patch('src.main.VolatilityTargeter') as MockTargeter, \
+             patch('src.main.Rebalancer') as MockRebalancer, \
+             patch.dict('os.environ', {'IS_LIVE_TRADING': 'true'}):
+
+            loader = MockLoader.return_value
+            repo = MockRepo.return_value
+            notifier = MockNotifier.return_value
+            broker = MockKisBroker.return_value
+            calc = MockCalc.return_value
+            analyzer = MockAnalyzer.return_value
+            targeter = MockTargeter.return_value
+            rebalancer = MockRebalancer.return_value
+
+            broker.get_portfolio.return_value = Portfolio(
+                total_cash=10000.0,
+                holdings={'SPY': 10},
+                current_prices={'SPY': 100.0}
+            )
+
+            yield {
+                'loader': loader,
+                'repo': repo,
+                'notifier': notifier,
+                'broker': broker,
+                'calc': calc,
+                'analyzer': analyzer,
+                'targeter': targeter,
+                'rebalancer': rebalancer
+            }
+
+    @patch('src.main.time.sleep')
+    def test_bot_live_trading_mode_init(self, mock_sleep, mock_deps_live):
+        """실전 모드에서 KisBroker가 초기화되는지 확인 (lines 38-40)"""
+        from src.main import TradingBot
+
+        mock_deps_live['calc'].calculate.return_value = MarketData(
+            "2024-01-01", 100, 90, 0.1, 0.1, -0.05, 15.0
+        )
+        mock_deps_live['analyzer'].analyze.return_value = MarketRegime.BULL
+        mock_deps_live['targeter'].calculate_exposure.return_value = 1.0
+        mock_deps_live['rebalancer'].generate_signal.return_value = TradeSignal(
+            1.0, False, [], "Hold"
+        )
+
+        bot = TradingBot()
+        bot.run()
+
+        # KisBroker가 사용되었는지 확인
+        mock_deps_live['repo'].save_daily_summary.assert_called()
+
+    @patch('src.main.time.sleep')
+    def test_bot_live_trading_with_execution(self, mock_sleep, mock_deps_live):
+        """실전 모드에서 매매 실행 후 sleep(3) 호출 확인 (line 104)"""
+        from src.main import TradingBot
+
+        mock_deps_live['calc'].calculate.return_value = MarketData(
+            "2024-01-01", 100, 90, 0.1, 0.1, -0.05, 15.0
+        )
+        mock_deps_live['analyzer'].analyze.return_value = MarketRegime.BULL
+        mock_deps_live['targeter'].calculate_exposure.return_value = 1.0
+        mock_deps_live['rebalancer'].generate_signal.return_value = TradeSignal(
+            1.0, True, [MagicMock()], "Rebalance"
+        )
+        mock_deps_live['broker'].execute_orders.return_value = [MagicMock()]
+        mock_deps_live['broker'].fetch_current_prices.return_value = {'SPY': 101.0}
+
+        bot = TradingBot()
+        bot.run()
+
+        # 실전 모드에서 sleep(3) 호출 확인
+        mock_sleep.assert_called_with(3)
+        mock_deps_live['notifier'].send_message.assert_called()

--- a/tests/test_infra_broker_kis.py
+++ b/tests/test_infra_broker_kis.py
@@ -1,0 +1,628 @@
+# tests/test_infra_broker_kis.py
+import pytest
+import logging
+from unittest.mock import patch, MagicMock
+from src.infra.broker import KisBroker, MockBroker
+from src.core.models import Order, Portfolio
+
+
+# ==========================================
+# KisBroker 테스트 (외부 API는 모두 Mock)
+# ==========================================
+
+@pytest.fixture
+def mock_requests():
+    """requests 모듈 전체를 Mock"""
+    with patch('src.infra.broker.requests') as mock_req:
+        yield mock_req
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def kis_broker(mock_requests, mock_logger):
+    """KisBroker 인스턴스 (인증 Mock 포함)"""
+    # _auth가 호출될 때 성공적으로 토큰을 반환하도록 설정
+    auth_response = MagicMock()
+    auth_response.json.return_value = {'access_token': 'test_token_123'}
+    mock_requests.post.return_value = auth_response
+
+    broker = KisBroker(
+        app_key='test_key',
+        app_secret='test_secret',
+        acc_no='1234567890',
+        logger=mock_logger,
+        is_real=False
+    )
+    # post mock 초기화 (auth 호출 후)
+    mock_requests.post.reset_mock()
+    mock_requests.get.reset_mock()
+    return broker
+
+
+@pytest.fixture
+def kis_broker_real(mock_requests, mock_logger):
+    """실전 모드 KisBroker"""
+    auth_response = MagicMock()
+    auth_response.json.return_value = {'access_token': 'real_token_456'}
+    mock_requests.post.return_value = auth_response
+
+    broker = KisBroker(
+        app_key='real_key',
+        app_secret='real_secret',
+        acc_no='9876543210',
+        logger=mock_logger,
+        is_real=True
+    )
+    mock_requests.post.reset_mock()
+    mock_requests.get.reset_mock()
+    return broker
+
+
+# --- __init__ 테스트 ---
+
+def test_kis_broker_init_paper(mock_requests, mock_logger):
+    """모의투자 모드 초기화"""
+    auth_response = MagicMock()
+    auth_response.json.return_value = {'access_token': 'token123'}
+    mock_requests.post.return_value = auth_response
+
+    broker = KisBroker('key', 'secret', '1234567890', mock_logger, is_real=False)
+
+    assert broker.base_url == "https://openapivts.koreainvestment.com:29443"
+    assert broker.cano == '12345678'
+    assert broker.acnt_prdt_cd == '90'
+    assert broker.access_token == 'token123'
+
+
+def test_kis_broker_init_real(mock_requests, mock_logger):
+    """실전 모드 초기화"""
+    auth_response = MagicMock()
+    auth_response.json.return_value = {'access_token': 'real_token'}
+    mock_requests.post.return_value = auth_response
+
+    broker = KisBroker('key', 'secret', '1234567890', mock_logger, is_real=True)
+
+    assert broker.base_url == "https://openapi.koreainvestment.com:9443"
+    assert broker.access_token == 'real_token'
+
+
+# --- _auth 테스트 ---
+
+def test_kis_broker_auth_failure(mock_requests, mock_logger):
+    """인증 실패 시 예외 발생"""
+    auth_response = MagicMock()
+    auth_response.json.return_value = {'error': 'invalid credentials'}
+    mock_requests.post.return_value = auth_response
+
+    with pytest.raises(Exception, match="Auth Failed"):
+        KisBroker('bad_key', 'bad_secret', '1234567890', mock_logger)
+
+
+def test_kis_broker_auth_network_error(mock_requests, mock_logger):
+    """인증 중 네트워크 에러"""
+    mock_requests.post.side_effect = Exception("Network Error")
+
+    with pytest.raises(Exception, match="Network Error"):
+        KisBroker('key', 'secret', '1234567890', mock_logger)
+
+
+# --- _get_header / _get_hashkey 테스트 ---
+
+def test_kis_broker_get_header_without_data(kis_broker, mock_requests):
+    """데이터 없이 헤더 생성 (GET 요청용)"""
+    headers = kis_broker._get_header("FHKST01010100")
+
+    assert headers['authorization'] == 'Bearer test_token_123'
+    assert headers['tr_id'] == 'FHKST01010100'
+    assert headers['appkey'] == 'test_key'
+    assert 'hashkey' not in headers
+
+
+def test_kis_broker_get_header_with_data(kis_broker, mock_requests):
+    """데이터 포함 헤더 생성 (POST 요청용, HashKey 포함)"""
+    hash_response = MagicMock()
+    hash_response.json.return_value = {'HASH': 'abc123hash'}
+    mock_requests.post.return_value = hash_response
+
+    data = {"CANO": "12345678", "PDNO": "SPY"}
+    headers = kis_broker._get_header("VTTT1002U", data)
+
+    assert headers['hashkey'] == 'abc123hash'
+    assert headers['tr_id'] == 'VTTT1002U'
+
+
+def test_kis_broker_get_hashkey_failure(kis_broker, mock_requests):
+    """HashKey 조회 실패 시 빈 문자열 반환"""
+    mock_requests.post.side_effect = Exception("Hash Error")
+
+    result = kis_broker._get_hashkey({"test": "data"})
+    assert result == ""
+
+
+# --- fetch_current_prices 테스트 ---
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_fetch_prices_success(mock_sleep, kis_broker, mock_requests):
+    """현재가 조회 성공"""
+    price_response = MagicMock()
+    price_response.json.return_value = {
+        'rt_cd': '0',
+        'output': {'last': '150.50'}
+    }
+    mock_requests.get.return_value = price_response
+
+    prices = kis_broker.fetch_current_prices(['SPY', 'IEF'])
+
+    assert prices['SPY'] == 150.50
+    assert prices['IEF'] == 150.50
+    assert mock_requests.get.call_count == 2
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_fetch_prices_api_error(mock_sleep, kis_broker, mock_requests):
+    """현재가 조회 API 에러 (rt_cd != 0)"""
+    price_response = MagicMock()
+    price_response.json.return_value = {
+        'rt_cd': '1',
+        'msg1': 'Invalid ticker'
+    }
+    mock_requests.get.return_value = price_response
+
+    prices = kis_broker.fetch_current_prices(['INVALID'])
+
+    assert prices['INVALID'] == 0.0
+    mock_logger = kis_broker.logger
+    mock_logger.warning.assert_called()
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_fetch_prices_exception(mock_sleep, kis_broker, mock_requests):
+    """현재가 조회 중 예외 발생"""
+    mock_requests.get.side_effect = Exception("Timeout")
+
+    prices = kis_broker.fetch_current_prices(['SPY'])
+
+    assert prices['SPY'] == 0.0
+    kis_broker.logger.error.assert_called()
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_fetch_prices_real_mode(mock_sleep, kis_broker_real, mock_requests):
+    """실전 모드에서 TR_ID가 올바른지 확인"""
+    price_response = MagicMock()
+    price_response.json.return_value = {
+        'rt_cd': '0',
+        'output': {'last': '200.00'}
+    }
+    mock_requests.get.return_value = price_response
+
+    kis_broker_real.fetch_current_prices(['SPY'])
+
+    args, kwargs = mock_requests.get.call_args
+    # 실전 TR_ID: HHDFS00000300
+    assert kwargs['headers']['tr_id'] == 'HHDFS00000300'
+
+
+# --- get_portfolio 테스트 ---
+
+def test_kis_broker_get_portfolio_success(kis_broker, mock_requests):
+    """잔고 조회 성공"""
+    portfolio_response = MagicMock()
+    portfolio_response.json.return_value = {
+        'rt_cd': '0',
+        'output1': [
+            {'ovrs_pdno': 'SPY', 'ovrs_cblc_qty': '10', 'now_pric2': '150.0'},
+            {'ovrs_pdno': 'IEF', 'ovrs_cblc_qty': '5', 'now_pric2': '100.0'},
+            {'ovrs_pdno': 'OLD', 'ovrs_cblc_qty': '0', 'now_pric2': '50.0'},  # 0주 -> 제외
+        ],
+        'output2': {'ovrs_ord_psbl_amt': '5000.50'}
+    }
+    mock_requests.get.return_value = portfolio_response
+
+    pf = kis_broker.get_portfolio()
+
+    assert pf.total_cash == 5000.50
+    assert pf.holdings['SPY'] == 10
+    assert pf.holdings['IEF'] == 5
+    assert 'OLD' not in pf.holdings  # 0주는 제외
+    assert pf.current_prices['SPY'] == 150.0
+
+
+def test_kis_broker_get_portfolio_api_failure(kis_broker, mock_requests):
+    """잔고 조회 API 실패"""
+    fail_response = MagicMock()
+    fail_response.json.return_value = {
+        'rt_cd': '1',
+        'msg1': 'Session Expired'
+    }
+    mock_requests.get.return_value = fail_response
+
+    pf = kis_broker.get_portfolio()
+
+    assert pf.total_cash == 0
+    assert pf.holdings == {}
+
+
+def test_kis_broker_get_portfolio_exception(kis_broker, mock_requests):
+    """잔고 조회 중 예외 발생"""
+    mock_requests.get.side_effect = Exception("Connection Error")
+
+    pf = kis_broker.get_portfolio()
+
+    assert pf.total_cash == 0
+    kis_broker.logger.error.assert_called()
+
+
+def test_kis_broker_get_portfolio_real_mode(kis_broker_real, mock_requests):
+    """실전 모드에서 TR_ID 확인"""
+    portfolio_response = MagicMock()
+    portfolio_response.json.return_value = {
+        'rt_cd': '0',
+        'output1': [],
+        'output2': {'ovrs_ord_psbl_amt': '1000.0'}
+    }
+    mock_requests.get.return_value = portfolio_response
+
+    kis_broker_real.get_portfolio()
+
+    args, kwargs = mock_requests.get.call_args
+    assert kwargs['headers']['tr_id'] == 'TTTS3012R'
+
+
+# --- _send_order 테스트 ---
+
+def test_kis_broker_send_order_buy_success(kis_broker, mock_requests):
+    """매수 주문 전송 성공"""
+    order_response = MagicMock()
+    order_response.json.return_value = {'rt_cd': '0', 'msg1': 'OK'}
+    # hashkey도 mock
+    hash_response = MagicMock()
+    hash_response.json.return_value = {'HASH': 'hash123'}
+    mock_requests.post.side_effect = [hash_response, order_response]
+
+    order = Order('SPY', 'BUY', 10, 150.0)
+    result = kis_broker._send_order(order)
+
+    assert result is not None
+    assert result.ticker == 'SPY'
+    assert result.action == 'BUY'
+    assert result.quantity == 10
+    assert result.status == 'ORDERED'
+
+
+def test_kis_broker_send_order_sell_success(kis_broker, mock_requests):
+    """매도 주문 전송 성공"""
+    order_response = MagicMock()
+    order_response.json.return_value = {'rt_cd': '0', 'msg1': 'OK'}
+    hash_response = MagicMock()
+    hash_response.json.return_value = {'HASH': 'hash456'}
+    mock_requests.post.side_effect = [hash_response, order_response]
+
+    order = Order('SPY', 'SELL', 5, 150.0)
+    result = kis_broker._send_order(order)
+
+    assert result is not None
+    assert result.action == 'SELL'
+
+
+def test_kis_broker_send_order_failure(kis_broker, mock_requests):
+    """주문 전송 실패 (API 에러)"""
+    order_response = MagicMock()
+    order_response.json.return_value = {'rt_cd': '1', 'msg1': 'Insufficient balance'}
+    hash_response = MagicMock()
+    hash_response.json.return_value = {'HASH': 'hash'}
+    mock_requests.post.side_effect = [hash_response, order_response]
+
+    order = Order('SPY', 'BUY', 10, 150.0)
+    result = kis_broker._send_order(order)
+
+    assert result is None
+    kis_broker.logger.error.assert_called()
+
+
+def test_kis_broker_send_order_exception(kis_broker, mock_requests):
+    """주문 전송 중 예외"""
+    hash_response = MagicMock()
+    hash_response.json.return_value = {'HASH': 'hash'}
+    mock_requests.post.side_effect = [hash_response, Exception("Network Down")]
+
+    order = Order('SPY', 'BUY', 5, 100.0)
+    result = kis_broker._send_order(order)
+
+    assert result is None
+
+
+def test_kis_broker_send_order_real_mode_tr_ids(kis_broker_real, mock_requests):
+    """실전 모드 TR_ID 확인 (매수/매도)"""
+    order_response = MagicMock()
+    order_response.json.return_value = {'rt_cd': '0'}
+    hash_response = MagicMock()
+    hash_response.json.return_value = {'HASH': 'h'}
+
+    # 매수
+    mock_requests.post.side_effect = [hash_response, order_response]
+    buy_order = Order('SPY', 'BUY', 1, 100.0)
+    kis_broker_real._send_order(buy_order)
+    # 두 번째 post call의 headers에서 tr_id 확인
+    call_args = mock_requests.post.call_args_list[1]
+    assert call_args[1]['headers']['tr_id'] == 'TTTS1002U'
+
+    mock_requests.post.reset_mock()
+    mock_requests.post.side_effect = [hash_response, order_response]
+    # 매도
+    sell_order = Order('SPY', 'SELL', 1, 100.0)
+    kis_broker_real._send_order(sell_order)
+    call_args = mock_requests.post.call_args_list[1]
+    assert call_args[1]['headers']['tr_id'] == 'TTTS1006U'
+
+
+# --- execute_orders 테스트 ---
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_execute_sell_then_buy(mock_sleep, kis_broker, mock_requests):
+    """매도 후 매수 순서 실행"""
+    # _send_order와 _wait_for_completion, get_portfolio를 모킹
+    with patch.object(kis_broker, '_send_order') as mock_send, \
+         patch.object(kis_broker, '_wait_for_completion', return_value=True), \
+         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+
+        from src.core.models import TradeExecution
+        sell_exec = TradeExecution('SPY', 'SELL', 5, 150.0, 0.0, '2024-01-01', 'ORDERED')
+        buy_exec = TradeExecution('IEF', 'BUY', 10, 100.0, 0.0, '2024-01-01', 'ORDERED')
+        mock_send.side_effect = [sell_exec, buy_exec]
+
+        mock_get_pf.return_value = Portfolio(
+            total_cash=10000.0,
+            holdings={'SPY': 5},
+            current_prices={'SPY': 150.0}
+        )
+
+        orders = [
+            Order('SPY', 'SELL', 5, 150.0),
+            Order('IEF', 'BUY', 10, 100.0),
+        ]
+        executions = kis_broker.execute_orders(orders)
+
+        assert len(executions) == 2
+        assert mock_send.call_count == 2
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_execute_buy_only(mock_sleep, kis_broker, mock_requests):
+    """매수만 있는 경우"""
+    with patch.object(kis_broker, '_send_order') as mock_send, \
+         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+
+        from src.core.models import TradeExecution
+        buy_exec = TradeExecution('SPY', 'BUY', 5, 100.0, 0.0, '2024-01-01', 'ORDERED')
+        mock_send.return_value = buy_exec
+        mock_get_pf.return_value = Portfolio(
+            total_cash=50000.0, holdings={}, current_prices={}
+        )
+
+        orders = [Order('SPY', 'BUY', 5, 100.0)]
+        executions = kis_broker.execute_orders(orders)
+
+        assert len(executions) == 1
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_execute_buy_qty_adjusted(mock_sleep, kis_broker, mock_requests):
+    """매수 시 잔고 부족으로 수량 조정"""
+    with patch.object(kis_broker, '_send_order') as mock_send, \
+         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+
+        from src.core.models import TradeExecution
+        buy_exec = TradeExecution('SPY', 'BUY', 1, 100.0, 0.0, '2024-01-01', 'ORDERED')
+        mock_send.return_value = buy_exec
+        # 현금이 적어서 수량이 조정되어야 함
+        mock_get_pf.return_value = Portfolio(
+            total_cash=200.0, holdings={}, current_prices={}
+        )
+
+        orders = [Order('SPY', 'BUY', 100, 100.0)]  # 100주 요청하지만 돈이 부족
+        executions = kis_broker.execute_orders(orders)
+
+        # 수량이 조정되어 실행됨 (200*0.98/102 = 1주)
+        assert len(executions) == 1
+        kis_broker.logger.warning.assert_called()
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_execute_buy_zero_price(mock_sleep, kis_broker, mock_requests):
+    """매수 가격이 0인 경우 스킵"""
+    with patch.object(kis_broker, '_send_order') as mock_send, \
+         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+
+        mock_get_pf.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={}
+        )
+
+        orders = [Order('SPY', 'BUY', 10, 0.0)]  # 가격 0
+        executions = kis_broker.execute_orders(orders)
+
+        assert len(executions) == 0
+        mock_send.assert_not_called()
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_execute_buy_zero_qty_after_adjust(mock_sleep, kis_broker, mock_requests):
+    """수량 조정 후 0이 되면 주문 안 함"""
+    with patch.object(kis_broker, '_send_order') as mock_send, \
+         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+
+        mock_get_pf.return_value = Portfolio(
+            total_cash=10.0, holdings={}, current_prices={}
+        )
+
+        orders = [Order('SPY', 'BUY', 10, 500.0)]  # 수량 조정 후 0
+        executions = kis_broker.execute_orders(orders)
+
+        assert len(executions) == 0
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_execute_sell_timeout(mock_sleep, kis_broker, mock_requests):
+    """매도 체결 대기 타임아웃"""
+    with patch.object(kis_broker, '_send_order') as mock_send, \
+         patch.object(kis_broker, '_wait_for_completion', return_value=False):
+
+        from src.core.models import TradeExecution
+        sell_exec = TradeExecution('SPY', 'SELL', 5, 150.0, 0.0, '2024-01-01', 'ORDERED')
+        mock_send.return_value = sell_exec
+
+        orders = [Order('SPY', 'SELL', 5, 150.0)]
+        executions = kis_broker.execute_orders(orders)
+
+        # 타임아웃이어도 실행 결과는 반환
+        assert len(executions) == 1
+        kis_broker.logger.warning.assert_called()
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_execute_send_order_returns_none(mock_sleep, kis_broker, mock_requests):
+    """_send_order가 None을 반환하는 경우 (주문 실패)"""
+    with patch.object(kis_broker, '_send_order', return_value=None) as mock_send, \
+         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+
+        mock_get_pf.return_value = Portfolio(
+            total_cash=50000.0, holdings={}, current_prices={}
+        )
+
+        orders = [Order('SPY', 'BUY', 5, 100.0)]
+        executions = kis_broker.execute_orders(orders)
+
+        assert len(executions) == 0
+
+
+# --- _wait_for_completion 테스트 ---
+
+@patch('src.infra.broker.time.sleep')
+@patch('src.infra.broker.time.time')
+def test_kis_broker_wait_completion_success(mock_time, mock_sleep, kis_broker):
+    """체결 대기 성공 (미체결 0)"""
+    mock_time.side_effect = [0, 1]  # 시작, 루프 1회
+    with patch.object(kis_broker, '_get_pending_orders_count', return_value=0):
+        result = kis_broker._wait_for_completion(timeout=60)
+        assert result is True
+
+
+@patch('src.infra.broker.time.sleep')
+@patch('src.infra.broker.time.time')
+def test_kis_broker_wait_completion_timeout(mock_time, mock_sleep, kis_broker):
+    """체결 대기 타임아웃"""
+    # time.time()이 계속 증가하여 timeout 초과
+    mock_time.side_effect = [0, 10, 30, 61]
+    with patch.object(kis_broker, '_get_pending_orders_count', return_value=5):
+        result = kis_broker._wait_for_completion(timeout=60)
+        assert result is False
+
+
+# --- _get_pending_orders_count 테스트 ---
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_pending_orders_found(mock_sleep, kis_broker, mock_requests):
+    """미체결 내역 발견"""
+    pending_response = MagicMock()
+    pending_response.json.return_value = {
+        'rt_cd': '0',
+        'output': [{'order_id': '1'}, {'order_id': '2'}]
+    }
+    mock_requests.get.return_value = pending_response
+
+    count = kis_broker._get_pending_orders_count()
+
+    assert count == 2
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_pending_orders_none(mock_sleep, kis_broker, mock_requests):
+    """미체결 내역 없음 (모든 거래소 조회)"""
+    empty_response = MagicMock()
+    empty_response.json.return_value = {
+        'rt_cd': '0',
+        'output': []
+    }
+    mock_requests.get.return_value = empty_response
+
+    count = kis_broker._get_pending_orders_count()
+
+    assert count == 0
+    # NAS, NYS, AMS 3개 거래소 모두 조회
+    assert mock_requests.get.call_count == 3
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_pending_orders_api_error(mock_sleep, kis_broker, mock_requests):
+    """미체결 조회 API 에러"""
+    error_response = MagicMock()
+    error_response.json.return_value = {
+        'rt_cd': '1',
+        'msg1': 'Service unavailable'
+    }
+    mock_requests.get.return_value = error_response
+
+    count = kis_broker._get_pending_orders_count()
+
+    assert count == 0
+    kis_broker.logger.warning.assert_called()
+
+
+@patch('src.infra.broker.time.sleep')
+def test_kis_broker_pending_orders_exception(mock_sleep, kis_broker, mock_requests):
+    """미체결 조회 중 예외"""
+    mock_requests.get.side_effect = Exception("Connection Reset")
+
+    count = kis_broker._get_pending_orders_count()
+
+    assert count == 0
+    kis_broker.logger.error.assert_called()
+
+
+# --- _get_exchange_code 테스트 ---
+
+def test_kis_broker_exchange_code_mapping(kis_broker):
+    """거래소 코드 매핑 확인"""
+    assert kis_broker._get_exchange_code('SPY') == 'AMS'
+    assert kis_broker._get_exchange_code('QLD') == 'AMS'
+    assert kis_broker._get_exchange_code('SSO') == 'AMS'
+    assert kis_broker._get_exchange_code('IEF') == 'NAS'
+    assert kis_broker._get_exchange_code('GLD') == 'NYS'
+    assert kis_broker._get_exchange_code('PDBC') == 'NAS'
+    assert kis_broker._get_exchange_code('SHV') == 'NAS'
+
+
+def test_kis_broker_exchange_code_default(kis_broker):
+    """매핑에 없는 티커는 기본값 NAS"""
+    assert kis_broker._get_exchange_code('UNKNOWN') == 'NAS'
+    assert kis_broker._get_exchange_code('AAPL') == 'NAS'
+
+
+# --- MockBroker 추가 테스트 ---
+
+def test_mock_broker_fetch_current_prices():
+    """MockBroker.fetch_current_prices가 항상 100.0을 반환"""
+    broker = MockBroker(initial_cash=1000.0)
+    prices = broker.fetch_current_prices(['SPY', 'IEF', 'GLD'])
+
+    assert prices == {'SPY': 100.0, 'IEF': 100.0, 'GLD': 100.0}
+
+
+@patch('src.infra.broker.time.sleep')
+def test_mock_broker_wait_for_completion(mock_sleep):
+    """MockBroker._wait_for_completion은 항상 True (미체결 0)"""
+    broker = MockBroker(initial_cash=1000.0)
+    result = broker._wait_for_completion(timeout=5)
+    assert result is True
+
+
+def test_mock_broker_buy_price_zero():
+    """매수 가격이 0인 경우 스킵"""
+    broker = MockBroker(initial_cash=1000.0)
+    orders = [Order('SPY', 'BUY', 10, 0.0)]
+    executions = broker.execute_orders(orders)
+    assert len(executions) == 0

--- a/tests/test_infra_repo.py
+++ b/tests/test_infra_repo.py
@@ -283,25 +283,26 @@ def test_repo_recover_from_corruption(repo, dummy_market_data, dummy_portfolio):
         data = json.load(f)
         assert data['strategy']['trigger_reason'] == "Recover"
 
+@pytest.mark.skipif(os.getuid() == 0, reason="root 사용자는 읽기 전용 파일에도 쓰기 가능")
 def test_repo_read_only_file(repo, dummy_market_data, dummy_portfolio):
     """
     [OS] 파일이 읽기 전용(Read-only)이라 쓸 수 없을 때, 명확한 에러 발생 확인
     (Linux/Mac 환경 기준)
     """
     import stat
-    
+
     # 1. 파일 생성
     signal = TradeSignal(0.8, True, [], "Test")
     repo.save_daily_summary(dummy_market_data, signal, dummy_portfolio)
-    
+
     # 2. 읽기 전용으로 권한 변경 (Write 권한 제거)
     os.chmod(repo.summary_file, stat.S_IREAD)
-    
+
     try:
         # 3. 쓰기 시도 -> PermissionError 발생해야 함
         with pytest.raises(PermissionError):
             repo.save_daily_summary(dummy_market_data, signal, dummy_portfolio)
-            
+
     finally:
         # 테스트 종료 후 권한 복구 (Cleanup) - 안 하면 임시 폴더 삭제 시 에러 날 수 있음
         os.chmod(repo.summary_file, stat.S_IWRITE | stat.S_IREAD)


### PR DESCRIPTION
- KisBroker 전체 메서드 테스트 추가 (broker.py 32% → 98%)
  - 인증, 헤더 생성, 현재가 조회, 잔고 조회, 주문 실행, 미체결 조회
  - 실전/모의 모드 TR_ID 분기 검증
- BacktestFetcher 테스트 추가 (fetcher.py 40% → 100%)
- BacktestDataLoader 엣지 케이스 테스트 (components.py 86% → 100%)
  - 휴장일 처리, KeyError fallback, VIX 기본값
- Notifier 미커버 경로 테스트 (notifier.py 83% → 100%)
  - TelegramNotifier.send_alert, Slack webhook 없는 경우, 연결 에러
- YFinanceLoader VIX 예외 처리 테스트 (data.py 90% → 97%)
- TradingBot 실전 모드 초기화/실행 테스트 (main.py 94% → 98%)
- broker.py에 누락된 requests import 추가
- root 환경에서 실패하는 읽기 전용 테스트에 skipif 추가

https://claude.ai/code/session_01Xe8dyYco41aRmxb4sqK1Kf