### PR TITLE
refactor: Rebalancer 국면별 리밸런싱 임계치를 생성자 파라미터로 추출 (#16)

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -56,9 +56,21 @@ class VolatilityTargeter:
 
 class Rebalancer:
     """리밸런싱 및 주문 생성기"""
-    def __init__(self, asset_groups: Dict[str, List[str]], logger: Optional[ILogger] = None):
+
+    # 국면별 리밸런싱 임계치 기본값
+    DEFAULT_THRESHOLD_MAP: Dict[MarketRegime, float] = {
+        MarketRegime.BULL: 0.15,
+        MarketRegime.SIDEWAYS: 0.05,
+        MarketRegime.BEAR_WEAK: 0.10,
+        MarketRegime.BEAR_STRONG: 0.10,
+    }
+
+    def __init__(self, asset_groups: Dict[str, List[str]],
+                 logger: Optional[ILogger] = None,
+                 threshold_map: Optional[Dict[MarketRegime, float]] = None):
         self.groups = asset_groups
         self._logger = logger
+        self._threshold_map = threshold_map if threshold_map is not None else dict(self.DEFAULT_THRESHOLD_MAP)
 
     def generate_signal(self, 
                         portfolio: Portfolio, 
@@ -74,13 +86,7 @@ class Rebalancer:
             )
 
         # 1. 국면별 리밸런싱 임계치 설정
-        threshold_map = {
-            MarketRegime.BULL: 0.15,
-            MarketRegime.SIDEWAYS: 0.05,
-            MarketRegime.BEAR_WEAK: 0.10,
-            MarketRegime.BEAR_STRONG: 0.10,
-        }
-        threshold = threshold_map.get(regime, 0.10)
+        threshold = self._threshold_map.get(regime, 0.10)
         
         # 2. 가격 누락 종목 경고
         if self._logger:

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -482,3 +482,56 @@ def test_rebalancer_no_warning_when_all_prices_present(create_portfolio):
     # 가격 누락 관련 warning이 없어야 함
     warning_messages = [call.args[0] for call in mock_logger.warning.call_args_list]
     assert not any("누락" in msg for msg in warning_messages)
+
+
+# ==========================================
+# 7. Rebalancer 커스텀 임계치 주입 테스트
+# ==========================================
+
+def test_rebalancer_custom_threshold_map(create_portfolio):
+    """
+    [커스텀 임계치 테스트]
+    threshold_map을 외부에서 주입하면 해당 임계치가 적용되어야 한다.
+    기본 BULL 임계치 0.15에서는 리밸런싱이 발생하지 않는 10% 차이가,
+    커스텀 임계치 0.05로 변경하면 리밸런싱이 발생해야 한다.
+    """
+    groups = {'A': ['SPY'], 'B': ['IEF']}
+
+    # 차이 10%인 포트폴리오
+    pf = create_portfolio(
+        holdings={'SPY': 550, 'IEF': 450},
+        prices={'SPY': 1000, 'IEF': 1000}
+    )
+
+    # Case 1: 기본 임계치 (BULL=0.15) → 10% 차이이므로 리밸런싱 불필요
+    rebalancer_default = Rebalancer(groups)
+    signal_default = rebalancer_default.generate_signal(pf, target_exposure=1.0, regime=MarketRegime.BULL)
+    assert signal_default.has_orders is False
+
+    # Case 2: 커스텀 임계치 (BULL=0.05) → 10% 차이이므로 리밸런싱 필요
+    custom_thresholds = {
+        MarketRegime.BULL: 0.05,
+        MarketRegime.SIDEWAYS: 0.05,
+        MarketRegime.BEAR_WEAK: 0.10,
+        MarketRegime.BEAR_STRONG: 0.10,
+    }
+    rebalancer_custom = Rebalancer(groups, threshold_map=custom_thresholds)
+    signal_custom = rebalancer_custom.generate_signal(pf, target_exposure=1.0, regime=MarketRegime.BULL)
+    assert signal_custom.has_orders is True
+    assert "비율 재조정" in signal_custom.reason
+
+
+def test_rebalancer_default_threshold_map_unchanged(create_portfolio):
+    """
+    [기본 임계치 유지 테스트]
+    threshold_map을 지정하지 않으면 기존 기본값이 그대로 적용되어야 한다.
+    """
+    groups = {'A': ['SPY'], 'B': ['IEF']}
+
+    # 기본 임계치가 클래스 상수와 동일한지 확인
+    rebalancer = Rebalancer(groups)
+    assert rebalancer._threshold_map == Rebalancer.DEFAULT_THRESHOLD_MAP
+
+    # 인스턴스의 threshold_map 수정이 클래스 상수에 영향을 주지 않는지 확인
+    rebalancer._threshold_map[MarketRegime.BULL] = 0.99
+    assert Rebalancer.DEFAULT_THRESHOLD_MAP[MarketRegime.BULL] == 0.15


### PR DESCRIPTION
하드코딩된 threshold_map을 클래스 상수(DEFAULT_THRESHOLD_MAP)로 정의하고
생성자에서 외부 주입이 가능하도록 threshold_map 파라미터를 추가합니다.
기본값은 기존과 동일하여 하위 호환성을 유지하며, 백테스트 시 다양한
임계치 실험이 가능해집니다.

https://claude.ai/code/session_01Hign9QDq4oigKMbJ7Y3hbV