### PR TITLE
refactor: RegimeAnalyzer BULL 판정 모멘텀 임계치를 생성자 파라미터로 추출 (#15)

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -4,26 +4,32 @@ from src.core.models import MarketRegime, MarketData, Portfolio, TradeSignal, Or
 from src.core.interfaces import ILogger
 
 class RegimeAnalyzer:
+    # BULL/SIDEWAYS 판정 기본 모멘텀 임계치 (SPY 6개월 수익률 기준)
+    DEFAULT_BULL_MOMENTUM_THRESHOLD = 0.05
+
+    def __init__(self, bull_momentum_threshold: float = 0.05):
+        self.bull_momentum_threshold = bull_momentum_threshold
+
     def analyze(self, data: MarketData) -> MarketRegime:
         # 1. Crash Check
         if data.is_risk_condition():
             return MarketRegime.CRASH
-            
+
         is_bear_momentum = data.spy_momentum < 0
         is_below_ma = data.spy_price < data.spy_ma180
-        
+
         # 2. Bear Check
         if is_bear_momentum and is_below_ma:
             return MarketRegime.BEAR_STRONG
         elif is_bear_momentum or is_below_ma:
             return MarketRegime.BEAR_WEAK
-            
+
         # 3. Bull / Sideways Check
         # 이 시점: momentum >= 0 AND price >= MA
-        if data.spy_momentum >= 0.05:
+        if data.spy_momentum >= self.bull_momentum_threshold:
             return MarketRegime.BULL
         else:
-            # momentum이 0 이상 0.05 미만 → 횡보장
+            # momentum이 0 이상 임계치 미만 → 횡보장
             return MarketRegime.SIDEWAYS
 
 class VolatilityTargeter:

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -54,6 +54,37 @@ def test_regime_bull_vs_sideways(create_market_data):
     assert analyzer.analyze(data_zero_mom) == MarketRegime.SIDEWAYS
 
 
+def test_regime_custom_bull_threshold(create_market_data):
+    """
+    [커스텀 BULL 임계치 테스트]
+    bull_momentum_threshold를 외부에서 주입하면 해당 임계치가 적용되어야 한다.
+    기본 임계치 0.05에서는 BULL인 모멘텀 0.08이,
+    커스텀 임계치 0.10에서는 SIDEWAYS가 되어야 한다.
+    """
+    # Case 1: 기본 임계치 (0.05) → 모멘텀 0.08은 BULL
+    analyzer_default = RegimeAnalyzer()
+    data = create_market_data(price=110, ma=100, mom=0.08)
+    assert analyzer_default.analyze(data) == MarketRegime.BULL
+
+    # Case 2: 커스텀 임계치 (0.10) → 모멘텀 0.08은 SIDEWAYS
+    analyzer_custom = RegimeAnalyzer(bull_momentum_threshold=0.10)
+    assert analyzer_custom.analyze(data) == MarketRegime.SIDEWAYS
+
+    # Case 3: 커스텀 임계치 (0.10) → 모멘텀 0.10은 BULL (경계값)
+    data_boundary = create_market_data(price=110, ma=100, mom=0.10)
+    assert analyzer_custom.analyze(data_boundary) == MarketRegime.BULL
+
+
+def test_regime_default_bull_threshold_unchanged():
+    """
+    [기본 BULL 임계치 유지 테스트]
+    bull_momentum_threshold를 지정하지 않으면 기본값 0.05가 적용되어야 한다.
+    """
+    analyzer = RegimeAnalyzer()
+    assert analyzer.bull_momentum_threshold == 0.05
+    assert analyzer.bull_momentum_threshold == RegimeAnalyzer.DEFAULT_BULL_MOMENTUM_THRESHOLD
+
+
 # ==========================================
 # 2. VolatilityTargeter 테스트 (비중 계산의 한계점)
 # ==========================================


### PR DESCRIPTION
하드코딩된 매직 넘버 0.05를 bull_momentum_threshold 생성자 파라미터로 추출하여
외부에서 설정 가능하게 개선. 기본값 0.05로 하위 호환성 유지.

https://claude.ai/code/session_013vEYt2ae3ibsFfqa59mSew