### PR TITLE
refactor: VolatilityTargeter 최소 exposure 하한선 및 국면별 상한선을 생성자 파라미터로 추출 (#17)

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -37,25 +37,25 @@ class VolatilityTargeter:
     MIN_VOLATILITY_FLOOR = 0.001
 
     # 국면별 exposure 상한선 기본값
-    DEFAULT_REGIME_CAPS: Dict[MarketRegime, float] = {
+    DEFAULT_REGIME_MAX_EXPOSURES: Dict[MarketRegime, float] = {
         MarketRegime.BEAR_STRONG: 0.4,
         MarketRegime.BEAR_WEAK: 0.6,
     }
 
-    # 최소 exposure 하한선 기본값
+    # exposure 하한선 기본값
     DEFAULT_MIN_EXPOSURE = 0.2
 
-    # 기본 상한선 (regime_caps에 없는 국면에 적용)
-    DEFAULT_MAX_CAP = 1.0
+    # exposure 상한선 기본값 (regime_max_exposures에 없는 국면에 적용)
+    DEFAULT_MAX_EXPOSURE = 1.0
 
     def __init__(self, target_vol: float = 0.15,
                  min_exposure: float = DEFAULT_MIN_EXPOSURE,
-                 regime_caps: Optional[Dict[MarketRegime, float]] = None,
-                 default_cap: float = DEFAULT_MAX_CAP):
+                 regime_max_exposures: Optional[Dict[MarketRegime, float]] = None,
+                 max_exposure: float = DEFAULT_MAX_EXPOSURE):
         self.target_vol = target_vol
         self.min_exposure = min_exposure
-        self._regime_caps = dict(regime_caps) if regime_caps is not None else dict(self.DEFAULT_REGIME_CAPS)
-        self.default_cap = default_cap
+        self._regime_max_exposures = dict(regime_max_exposures) if regime_max_exposures is not None else dict(self.DEFAULT_REGIME_MAX_EXPOSURES)
+        self.max_exposure = max_exposure
 
     def calculate_exposure(self, regime: MarketRegime, current_vol: float) -> float:
         if regime == MarketRegime.CRASH:
@@ -67,11 +67,11 @@ class VolatilityTargeter:
         # 기본 비율 (Target Vol / Current Vol)
         base_ratio = self.target_vol / vol
 
-        # 국면별 상한선(Cap)
-        max_cap = self._regime_caps.get(regime, self.default_cap)
+        # 국면별 exposure 상한선
+        upper = self._regime_max_exposures.get(regime, self.max_exposure)
 
-        # Cap 적용 및 하한선(Floor) 적용
-        exposure = min(base_ratio, max_cap)
+        # 상한선·하한선 적용
+        exposure = min(base_ratio, upper)
         return max(exposure, self.min_exposure)
 
 class Rebalancer:

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -136,27 +136,27 @@ def test_vol_targeter_min_volatility_floor_boundary():
     assert VolatilityTargeter.MIN_VOLATILITY_FLOOR == 0.001
 
 
-def test_vol_targeter_custom_regime_caps():
+def test_vol_targeter_custom_regime_max_exposures():
     """
-    [커스텀 국면별 상한선 테스트]
-    regime_caps를 외부에서 주입하면 해당 상한선이 적용되어야 한다.
+    [커스텀 국면별 exposure 상한선 테스트]
+    regime_max_exposures를 외부에서 주입하면 해당 상한선이 적용되어야 한다.
     """
-    custom_caps = {
+    custom_max_exposures = {
         MarketRegime.BEAR_STRONG: 0.3,
         MarketRegime.BEAR_WEAK: 0.5,
     }
-    targeter = VolatilityTargeter(target_vol=0.15, regime_caps=custom_caps)
+    targeter = VolatilityTargeter(target_vol=0.15, regime_max_exposures=custom_max_exposures)
 
-    # BEAR_STRONG: 0.15/0.10 = 1.5 → cap 0.3
+    # BEAR_STRONG: 0.15/0.10 = 1.5 → 상한 0.3
     assert targeter.calculate_exposure(MarketRegime.BEAR_STRONG, 0.10) == 0.3
 
-    # BEAR_WEAK: 0.15/0.10 = 1.5 → cap 0.5
+    # BEAR_WEAK: 0.15/0.10 = 1.5 → 상한 0.5
     assert targeter.calculate_exposure(MarketRegime.BEAR_WEAK, 0.10) == 0.5
 
 
 def test_vol_targeter_custom_min_exposure():
     """
-    [커스텀 최소 exposure 하한선 테스트]
+    [커스텀 exposure 하한선 테스트]
     min_exposure를 외부에서 주입하면 해당 하한선이 적용되어야 한다.
     """
     targeter = VolatilityTargeter(target_vol=0.15, min_exposure=0.1)
@@ -168,14 +168,14 @@ def test_vol_targeter_custom_min_exposure():
     assert targeter.calculate_exposure(MarketRegime.BULL, 2.0) == 0.1
 
 
-def test_vol_targeter_custom_default_cap():
+def test_vol_targeter_custom_max_exposure():
     """
-    [커스텀 기본 상한선 테스트]
-    default_cap을 변경하면 regime_caps에 없는 국면에 해당 값이 적용되어야 한다.
+    [커스텀 exposure 상한선 테스트]
+    max_exposure를 변경하면 regime_max_exposures에 없는 국면에 해당 값이 적용되어야 한다.
     """
-    targeter = VolatilityTargeter(target_vol=0.15, default_cap=0.8)
+    targeter = VolatilityTargeter(target_vol=0.15, max_exposure=0.8)
 
-    # BULL: 0.15/0.01 = 15.0 → 기본 cap 1.0이 아닌 0.8로 제한
+    # BULL: 0.15/0.01 = 15.0 → 기본 상한 1.0이 아닌 0.8로 제한
     assert targeter.calculate_exposure(MarketRegime.BULL, 0.01) == 0.8
 
 
@@ -186,20 +186,20 @@ def test_vol_targeter_default_values_unchanged():
     """
     targeter = VolatilityTargeter()
 
-    # 기본 min_exposure
+    # 기본 min_exposure (하한선)
     assert targeter.min_exposure == 0.2
     assert targeter.min_exposure == VolatilityTargeter.DEFAULT_MIN_EXPOSURE
 
-    # 기본 regime_caps
-    assert targeter._regime_caps == VolatilityTargeter.DEFAULT_REGIME_CAPS
+    # 기본 max_exposure (상한선)
+    assert targeter.max_exposure == 1.0
+    assert targeter.max_exposure == VolatilityTargeter.DEFAULT_MAX_EXPOSURE
 
-    # 기본 default_cap
-    assert targeter.default_cap == 1.0
-    assert targeter.default_cap == VolatilityTargeter.DEFAULT_MAX_CAP
+    # 기본 regime_max_exposures (국면별 상한선)
+    assert targeter._regime_max_exposures == VolatilityTargeter.DEFAULT_REGIME_MAX_EXPOSURES
 
-    # 인스턴스의 regime_caps 수정이 클래스 상수에 영향을 주지 않는지 확인
-    targeter._regime_caps[MarketRegime.BEAR_STRONG] = 0.99
-    assert VolatilityTargeter.DEFAULT_REGIME_CAPS[MarketRegime.BEAR_STRONG] == 0.4
+    # 인스턴스의 regime_max_exposures 수정이 클래스 상수에 영향을 주지 않는지 확인
+    targeter._regime_max_exposures[MarketRegime.BEAR_STRONG] = 0.99
+    assert VolatilityTargeter.DEFAULT_REGIME_MAX_EXPOSURES[MarketRegime.BEAR_STRONG] == 0.4
 
 
 # ==========================================


### PR DESCRIPTION
하드코딩된 min_exposure(0.2), regime_caps(BEAR_STRONG:0.4, BEAR_WEAK:0.6),
default_cap(1.0) 값을 생성자 파라미터로 추출하여 외부 설정 가능하게 개선.
기본값은 기존과 동일하게 유지하여 하위 호환성 보장.

https://claude.ai/code/session_01YRcct438dMPFrVRT4hVg9M