### PR TITLE
refactor: Rebalancer 첫 투자 로직을 일반 리밸런싱과 분리 (#20)

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -119,19 +119,22 @@ class Rebalancer:
         val_b = portfolio.get_group_value(self.groups.get('B', []))
         val_risky = val_a + val_b
 
+        # 첫 투자 여부 판별 (위험자산 보유액이 0이면 첫 투자)
+        is_first_investment = (val_risky == 0)
+
         # A, B 상대 비중
-        if val_risky == 0:
+        if is_first_investment:
             ratio_a = 0.5
             ratio_b = 0.5
-            needs_rebalance = True # 첫 투자
+            needs_rebalance = True
             current_diff = 0.0
         else:
             ratio_a = val_a / val_risky
             ratio_b = val_b / val_risky
-            
+
             # 부동소수점 오차 해결
             current_diff = round(abs(ratio_a - ratio_b), 6)
-            
+
             needs_rebalance = current_diff > threshold
             
         # 3. 목표 금액 계산
@@ -165,7 +168,11 @@ class Rebalancer:
         sorted_orders = sell_orders + buy_orders
 
         # 5. reason 결정 (주문 생성 결과를 반영)
-        if needs_rebalance and sorted_orders:
+        if is_first_investment and sorted_orders:
+            reason = "첫 투자: 50:50 비율로 진입"
+        elif is_first_investment and not sorted_orders:
+            reason = "첫 투자: 주문 단위 미달로 진입 불가"
+        elif needs_rebalance and sorted_orders:
             reason = f"비율 재조정: Threshold {threshold:.0%} 초과 (Diff: {current_diff:.1%})"
         elif needs_rebalance and not sorted_orders:
             reason = f"비율 재조정 필요하나 주문 단위 미달 (Diff: {current_diff:.1%})"

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -485,14 +485,14 @@ def test_rebalancer_order_sequence(create_portfolio):
 
 def test_rebalancer_reason_rebalance_but_no_orders(create_portfolio):
     """
-    [케이스 4: 비율 재조정 필요하지만 주문 단위 미달]
-    첫 투자(val_risky=0 → needs_rebalance=True)인데,
+    [케이스 4: 첫 투자이지만 주문 단위 미달]
+    첫 투자(val_risky=0 → is_first_investment=True)인데,
     주당 가격이 비싸서 매수 수량이 전부 floor → 0주.
     """
     groups = {'A': ['SPY'], 'B': ['IEF']}
     rebalancer = Rebalancer(groups)
 
-    # 현금 50만, 보유 종목 없음 (첫 투자 → needs_rebalance=True)
+    # 현금 50만, 보유 종목 없음 (첫 투자 → is_first_investment=True)
     # 주당 가격 100만 → target 25만/종목 → floor(0.25) = 0주
     pf = create_portfolio(
         cash=500000,
@@ -503,7 +503,30 @@ def test_rebalancer_reason_rebalance_but_no_orders(create_portfolio):
     signal = rebalancer.generate_signal(pf, target_exposure=1.0, regime=MarketRegime.SIDEWAYS)
 
     assert signal.has_orders is False
+    assert "첫 투자" in signal.reason
     assert "단위 미달" in signal.reason
+
+
+def test_rebalancer_first_investment_reason(create_portfolio):
+    """
+    [첫 투자 reason 메시지 테스트]
+    위험자산(A+B) 보유액이 0인 경우 첫 투자 전용 reason이 설정되어야 한다.
+    """
+    groups = {'A': ['SPY'], 'B': ['IEF']}
+    rebalancer = Rebalancer(groups)
+
+    # 현금 100만, 보유 종목 없음 (첫 투자)
+    pf = create_portfolio(
+        cash=1000000,
+        holdings={},
+        prices={'SPY': 100000, 'IEF': 100000}
+    )
+
+    signal = rebalancer.generate_signal(pf, target_exposure=1.0, regime=MarketRegime.BULL)
+
+    assert signal.has_orders is True
+    assert "첫 투자" in signal.reason
+    assert "50:50" in signal.reason
 
 
 def test_rebalancer_c_group_target_not_negative(create_portfolio):


### PR DESCRIPTION
is_first_investment 플래그를 도입하여 첫 투자 여부를 명시적으로 표현하고,
첫 투자 전용 reason 메시지를 추가하여 일반 리밸런싱과 구분되도록 개선.

https://claude.ai/code/session_01Gt9s9mF9LVh7Pn4N78w7L5