### PR TITLE
fix: IDataProvider.fetch_ohlcv 반환 타입을 Any에서 pd.DataFrame으로 변경 (#19)

### DIFF
--- a/src/backtest/data.py
+++ b/src/backtest/data.py
@@ -12,7 +12,7 @@ class HistoricalDataLoader(IDataProvider):
     def set_date(self, date):
         self.current_date = date
 
-    def fetch_ohlcv(self, tickers: List[str], days: int = 400):
+    def fetch_ohlcv(self, tickers: List[str], days: int = 400) -> pd.DataFrame:
         # [핵심] 전체 데이터에서 current_date 이전 days 만큼만 잘라서 리턴
         end_idx = self.full_data.index.get_loc(self.current_date)
         start_idx = max(0, end_idx - days)
@@ -28,6 +28,6 @@ class HistoricalDataLoader(IDataProvider):
 
         return sliced_df
 
-    def fetch_vix(self):
+    def fetch_vix(self) -> float:
         # current_date 시점의 VIX 값 리턴
         return self.full_vix.loc[self.current_date]['Close']

--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -1,10 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, Dict
+from typing import List, Dict
+import pandas as pd
 from src.core.models import Portfolio, Order, MarketData, TradeSignal, MarketRegime, TradeExecution
 
 class IDataProvider(ABC):
     @abstractmethod
-    def fetch_ohlcv(self, tickers: List[str], days: int = 365) -> Any:
+    def fetch_ohlcv(self, tickers: List[str], days: int = 365) -> pd.DataFrame:
         """OHLCV 데이터를 반환한다.
 
         Args:


### PR DESCRIPTION
인터페이스의 타입 계약을 강화하여 타입 체커(mypy, pyright)가
구현체와 호출부 사이의 타입 안전성을 검증할 수 있도록 개선.
HistoricalDataLoader의 누락된 반환 타입 어노테이션도 추가.

https://claude.ai/code/session_01NXpt23tmRCj64Hr8nqb6hx