### PR TITLE
Fix DataFrame mutation issue in calculator by adding copy()

### DIFF
--- a/src/utils/calculator.py
+++ b/src/utils/calculator.py
@@ -11,7 +11,7 @@ class IndicatorCalculator:
         """
         # [수정] 결측치 전처리 (ffill -> bfill)
         # 중간에 빈 데이터가 있으면 직전 값으로 채워서 계산 연속성 보장
-        df = df.ffill().bfill()
+        df = df.copy().ffill().bfill()
         # 물리적으로 253개가 안 되면 12개월 모멘텀 계산 불가
         min_required = 253
         


### PR DESCRIPTION
## Summary
Added `.copy()` to the DataFrame preprocessing step to prevent unintended mutations of the input DataFrame during forward/backward fill operations.

## Key Changes
- Modified the `calculate()` method in `src/utils/calculator.py` to call `.copy()` before chaining `.ffill().bfill()`
- This ensures the original DataFrame passed to the function remains unchanged after preprocessing

## Implementation Details
The change prevents side effects where the input DataFrame would be modified in-place during the forward fill and backward fill operations. By creating a copy first, the original data structure is preserved while the calculation logic continues to work with the filled values as intended.

https://claude.ai/code/session_01JmRBvisyrokgrcvxr2iYh4