### PR TITLE
fix: repo.py bare except를 구체적 예외 타입으로 교체 (#30)

### DIFF
--- a/src/infra/repo.py
+++ b/src/infra/repo.py
@@ -124,7 +124,7 @@ class JsonRepository:
         try:
             with open(path, 'r', encoding='utf-8') as f:
                 return json.load(f)
-        except:
+        except (json.JSONDecodeError, IOError, OSError):
             return default
 
     def _save_json(self, path: str, data):

--- a/tests/test_infra_repo.py
+++ b/tests/test_infra_repo.py
@@ -351,6 +351,46 @@ def test_repo_status_overwrite_clean(repo, dummy_portfolio, dummy_market_data):
     assert "extra_field" not in data
     assert data['strategy']['trigger_reason'] == "Overwrite"
 
+def test_load_json_propagates_keyboard_interrupt(repo, monkeypatch):
+    """
+    [안전] bare except가 제거된 후 KeyboardInterrupt가 _load_json에서 전파되는지 확인
+    실거래 봇에서 Ctrl+C 신호가 무시되지 않아야 함
+    """
+    import json
+
+    # 파일 생성 (os.path.exists 체크를 통과하도록)
+    with open(repo.status_file, 'w') as f:
+        f.write("{}")
+
+    # json.load가 KeyboardInterrupt를 발생시키도록 패치
+    def raise_keyboard_interrupt(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(json, "load", raise_keyboard_interrupt)
+
+    # KeyboardInterrupt가 삼켜지지 않고 전파되어야 함
+    with pytest.raises(KeyboardInterrupt):
+        repo._load_json(repo.status_file, default={})
+
+
+def test_load_json_propagates_system_exit(repo, monkeypatch):
+    """
+    [안전] bare except가 제거된 후 SystemExit이 _load_json에서 전파되는지 확인
+    """
+    import json
+
+    with open(repo.status_file, 'w') as f:
+        f.write("{}")
+
+    def raise_system_exit(*args, **kwargs):
+        raise SystemExit(0)
+
+    monkeypatch.setattr(json, "load", raise_system_exit)
+
+    with pytest.raises(SystemExit):
+        repo._load_json(repo.status_file, default={})
+
+
 def test_repo_simulation_week_trading(repo, dummy_portfolio, dummy_market_data):
     """
     [시나리오] 일주일(7일) 동안 봇이 매일 실행되어 데이터를 쌓는 상황 시뮬레이션


### PR DESCRIPTION
_load_json()의 bare except:를 except (json.JSONDecodeError, IOError, OSError):로
변경하여 KeyboardInterrupt와 SystemExit이 정상적으로 전파되도록 수정.
실거래 봇에서 Ctrl+C 신호가 무시되는 안전 문제 해결.

테스트: KeyboardInterrupt/SystemExit 전파 확인 테스트 2개 추가

https://claude.ai/code/session_01UFb4RBVQiYDhBLkC2RDMJx