### PR TITLE
fix: 백테스트 runner.py에 NaN 체크 및 CRASH 매매 중단 로직 추가 (#34)

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -2,6 +2,7 @@
 import pandas as pd
 import matplotlib.pyplot as plt
 from src.config import Config
+from src.core.models import MarketRegime
 from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
 from src.utils.calculator import IndicatorCalculator
 from src.backtest.fetcher import download_historical_data
@@ -73,19 +74,36 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0):
             vix_val = loader.fetch_vix()
             market_data = calculator.calculate(df_slice, vix_val)
             
-            # 2. 전략 판단
-            regime = analyzer.analyze(market_data)
-            exposure = targeter.calculate_exposure(regime, market_data.spy_volatility)
-            
+            # 2. 전략 판단 (main.py와 동일한 NaN 체크 + CRASH 처리)
+            nan_fields = market_data.nan_fields()
+            if nan_fields:
+                regime = MarketRegime.CRASH
+                exposure = 0.0
+            else:
+                regime = analyzer.analyze(market_data)
+                exposure = targeter.calculate_exposure(regime, market_data.spy_volatility)
+
+            # CRASH: 리밸런싱 없이 현재 상태 기록 후 스킵
+            if regime == MarketRegime.CRASH:
+                final_pf = broker.get_portfolio()
+                history.append({
+                    "date": today,
+                    "total_value": final_pf.total_value,
+                    "cash": final_pf.total_cash,
+                    "exposure": 0.0,
+                    "regime": regime.value
+                })
+                continue
+
             # 3. 리밸런싱
             current_pf = broker.get_portfolio()
             current_pf.current_prices = current_prices # 가격 동기화
-            
+
             signal = rebalancer.generate_signal(current_pf, exposure, regime)
-            
+
             if signal.has_orders:
                 broker.execute_orders(signal.orders)
-            
+
             # 4. 결과 기록
             final_pf = broker.get_portfolio()
             history.append({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,14 @@
 # tests/conftest.py
+import sys
+import types
 import pytest
+
+# yfinance가 설치되지 않은 환경을 위한 mock 모듈 등록
+if 'yfinance' not in sys.modules:
+    yf_mock = types.ModuleType('yfinance')
+    yf_mock.download = lambda *a, **kw: None
+    sys.modules['yfinance'] = yf_mock
+
 from src.core.models import MarketData, Portfolio
 
 @pytest.fixture

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -2,8 +2,10 @@
 import pytest
 import pandas as pd
 import numpy as np
+import math
 from unittest.mock import patch, MagicMock
 from src.backtest.runner import run_backtest
+from src.core.models import MarketRegime
 
 
 @pytest.fixture
@@ -46,3 +48,37 @@ def test_run_backtest_flow(mock_show, mock_download, mock_fetcher_return):
     
     # 로그 등을 통해 루프가 돌았는지 간접 확인할 수 있지만,
     # 에러 없이 여기까지 왔다면 로직 흐름은 정상임.
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.show")
+def test_nan_data_skips_rebalancing(mock_show, mock_download, mock_fetcher_return):
+    """
+    [Runner] NaN 데이터가 감지되면 regime을 CRASH로 강제하고 리밸런싱을 실행하지 않아야 한다.
+    """
+    mock_download.return_value = mock_fetcher_return
+
+    nan_market_data = MagicMock()
+    nan_market_data.nan_fields.return_value = ['spy_volatility']
+    nan_market_data.spy_volatility = math.nan
+
+    with patch("src.backtest.runner.IndicatorCalculator.calculate", return_value=nan_market_data), \
+         patch("src.backtest.runner.Rebalancer.generate_signal") as mock_signal:
+        run_backtest(start_date="2023-01-02", end_date="2023-01-03", initial_cash=10000.0)
+        # NaN으로 인해 CRASH 처리 → generate_signal이 호출되지 않아야 함
+        mock_signal.assert_not_called()
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.show")
+def test_crash_regime_skips_rebalancing(mock_show, mock_download, mock_fetcher_return):
+    """
+    [Runner] analyzer가 CRASH를 반환하면 리밸런싱을 실행하지 않고 history에 exposure=0으로 기록해야 한다.
+    """
+    mock_download.return_value = mock_fetcher_return
+
+    with patch("src.backtest.runner.RegimeAnalyzer.analyze", return_value=MarketRegime.CRASH), \
+         patch("src.backtest.runner.Rebalancer.generate_signal") as mock_signal:
+        run_backtest(start_date="2023-01-02", end_date="2023-01-03", initial_cash=10000.0)
+        # CRASH regime → generate_signal이 호출되지 않아야 함
+        mock_signal.assert_not_called()


### PR DESCRIPTION
- runner.py 메인 루프에 main.py와 동일한 NaN 체크 로직 추가
  - nan_fields() 감지 시 regime을 CRASH로 강제, exposure=0으로 설정
- CRASH regime 시 리밸런싱 없이 현재 포트폴리오 상태 기록 후 continue
- 아키텍처 규칙 준수: "백테스트는 프로덕션 로직을 100% 재사용"
- MarketRegime import 추가 (runner.py)
- conftest.py에 yfinance 미설치 환경을 위한 mock 모듈 등록
- 테스트 2개 추가: NaN 감지 시 리밸런싱 스킵, CRASH regime 시 리밸런싱 스킵

https://claude.ai/code/session_01W2GmUWwW4JVR9Tkqtnrgxz