### PR TITLE
fix: yfinance mock 오적용으로 인한 테스트 실패 수정

### DIFF
--- a/src/infra/data.py
+++ b/src/infra/data.py
@@ -17,8 +17,8 @@ class YFinanceLoader(IDataProvider):
         self.logger.info(f"[Data] Fetching {tickers} history for {days} days...")
         try:
             df = yf.download(tickers, period=f"{days}d", auto_adjust=True, progress=False)
-            
-            if df.empty:
+
+            if df is None or df.empty:
                 raise ValueError("No data fetched from Yahoo Finance.")
                 
             if len(tickers) == 1:
@@ -38,9 +38,9 @@ class YFinanceLoader(IDataProvider):
 
         try:
             vix_df = yf.download("^VIX", period="5d",auto_adjust=True,  progress=False)
-            
+
             # 1. 데이터가 비어있는 경우
-            if vix_df.empty:
+            if vix_df is None or vix_df.empty:
                 self.logger.warning("[Data] ⚠️ VIX DataFrame is empty! Returning safety default: 20.0")
                 return 20.0
             

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ import types
 import pytest
 
 # yfinance가 설치되지 않은 환경을 위한 mock 모듈 등록
-if 'yfinance' not in sys.modules:
+try:
+    import yfinance  # noqa: F401 - 설치 여부만 확인
+except ImportError:
     yf_mock = types.ModuleType('yfinance')
     yf_mock.download = lambda *a, **kw: None
     sys.modules['yfinance'] = yf_mock

--- a/tests/test_infra_data_live.py
+++ b/tests/test_infra_data_live.py
@@ -1,3 +1,4 @@
+import socket
 import pytest
 import pandas as pd
 from datetime import datetime, timedelta
@@ -6,6 +7,21 @@ from src.infra.data import YFinanceLoader
 
 # 이 테스트들은 실제 네트워크 호출을 하므로 속도가 느릴 수 있습니다.
 # CI/CD 환경이나 네트워크가 없는 곳에서는 실패할 수 있습니다.
+
+def _is_network_available() -> bool:
+    """Yahoo Finance 서버에 연결 가능한지 확인"""
+    try:
+        socket.create_connection(("query1.finance.yahoo.com", 443), timeout=3)
+        return True
+    except OSError:
+        return False
+
+NETWORK_AVAILABLE = _is_network_available()
+
+pytestmark = pytest.mark.skipif(
+    not NETWORK_AVAILABLE,
+    reason="네트워크 연결 불가 - Yahoo Finance에 접근할 수 없어 Live 테스트를 건너뜁니다."
+)
 
 @pytest.fixture
 def live_loader():


### PR DESCRIPTION
- tests/conftest.py: `if 'yfinance' not in sys.modules` 조건이 conftest 로드 시점에
  yfinance가 아직 import되지 않아 항상 True가 되는 버그 수정.
  `try/import` 방식으로 변경하여 yfinance가 실제로 설치된 경우에는 mock을 등록하지 않음.

- src/infra/data.py: yf.download()가 None을 반환하는 경우를 방어적으로 처리.
  `if df is None or df.empty:` 및 `if vix_df is None or vix_df.empty:` 조건 추가.

- tests/test_infra_data_live.py: 네트워크 미연결 환경에서 live 테스트를 자동으로
  skip하도록 pytestmark에 skipif 조건 추가 (Yahoo Finance 443 포트 연결 여부로 판단).

결과: 180 passed, 17 skipped (0 failed), coverage 98%

https://claude.ai/code/session_01G2SGdcz7wwjFFEeW87bfyX