### PR TITLE
ci: add manual market data download workflow

### DIFF
--- a/.github/workflows/download-data.yml
+++ b/.github/workflows/download-data.yml
@@ -1,0 +1,68 @@
+name: Download Market Data
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: '시작 날짜 (예: 2014-01-01)'
+        required: true
+        type: string
+      end_date:
+        description: '종료 날짜 (예: 2025-12-31)'
+        required: true
+        type: string
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Download market data
+      run: |
+        python -c "
+        from src.backtest.cache import BacktestDataCache
+        from datetime import datetime, timedelta
+
+        start_date = '${{ inputs.start_date }}'
+        end_date = '${{ inputs.end_date }}'
+
+        # 지표 계산용 500일 여유분 포함
+        real_start = datetime.strptime(start_date, '%Y-%m-%d') - timedelta(days=500)
+        real_start_str = real_start.strftime('%Y-%m-%d')
+
+        tickers = ['SSO', 'QLD', 'IEF', 'GLD', 'PDBC', 'SHV']
+
+        cache = BacktestDataCache()
+        ohlcv, vix = cache.get_data(tickers, real_start_str, end_date)
+
+        print(f'OHLCV shape: {ohlcv.shape}')
+        print(f'OHLCV range: {ohlcv.index.min()} ~ {ohlcv.index.max()}')
+        print(f'VIX shape: {vix.shape}')
+        print(f'VIX range: {vix.index.min()} ~ {vix.index.max()}')
+        "
+
+    - name: Commit and push data
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add src/backtest/cache/
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "data: download market data (${{ inputs.start_date }} ~ ${{ inputs.end_date }})"
+          git push
+        fi


### PR DESCRIPTION
GitHub Actions에서 수동으로 yfinance 데이터를 다운로드하는 워크플로우 추가.
workflow_dispatch로 시작/종료 날짜를 입력하면 OHLCV + VIX 데이터를
parquet 캐시로 저장하고 저장소에 자동 커밋/푸시한다.

https://claude.ai/code/session_01BKHawuEQj1UqWr5cxwDxXc