### PR TITLE
feat: 백테스트 매매 체결 기록 누락 수정 (#45)

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -3,9 +3,9 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from src.config import Config
-from src.core.models import MarketRegime
+from src.core.models import MarketRegime, TradeExecution
 from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
 from src.utils.calculator import IndicatorCalculator
 from src.backtest.fetcher import download_historical_data
@@ -24,6 +24,7 @@ class BacktestResult:
     spy_cagr: Optional[float]          # SPY Buy&Hold 연환산 수익률 (None = 데이터 없음)
     regime_returns: Dict[str, float]   # 국면별 연환산 평균 수익률
     chart_path: Optional[str]          # 저장된 차트 파일 경로
+    trade_executions: Optional[List[TradeExecution]] = None  # 전체 매매 체결 기록
 
 
 def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) -> Optional[BacktestResult]:
@@ -55,6 +56,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
     sim_days = [d for d in trading_days if start_date <= d.strftime("%Y-%m-%d") <= end_date]
 
     history = []
+    all_executions: List[TradeExecution] = []
     print(f"--- Starting Backtest ({len(sim_days)} trading days) ---")
 
     for today in sim_days:
@@ -99,7 +101,8 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
                     "total_value": final_pf.total_value,
                     "cash": final_pf.total_cash,
                     "exposure": 0.0,
-                    "regime": regime.value
+                    "regime": regime.value,
+                    "trade_count": 0,
                 })
                 continue
 
@@ -109,8 +112,10 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
 
             signal = rebalancer.generate_signal(current_pf, exposure, regime)
 
+            day_executions: List[TradeExecution] = []
             if signal.has_orders:
-                broker.execute_orders(signal.orders)
+                day_executions = broker.execute_orders(signal.orders)
+                all_executions.extend(day_executions)
 
             # 4. 결과 기록
             final_pf = broker.get_portfolio()
@@ -119,7 +124,8 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
                 "total_value": final_pf.total_value,
                 "cash": final_pf.total_cash,
                 "exposure": exposure,
-                "regime": regime.value
+                "regime": regime.value,
+                "trade_count": len(day_executions),
             })
 
         except Exception as e:
@@ -179,6 +185,15 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
         for regime_name, regime_ret in regime_returns.items():
             print(f"  {regime_name}: {regime_ret:.2%}")
 
+    # 거래 통계 출력
+    print(f"Total Executions: {len(all_executions)}")
+    if all_executions:
+        from collections import Counter
+        ticker_counts = Counter(e.ticker for e in all_executions)
+        action_counts = Counter(f"{e.ticker}/{e.action}" for e in all_executions)
+        print("Trade Frequency by Ticker:", dict(ticker_counts))
+        print("Trade Frequency by Ticker/Action:", dict(action_counts))
+
     # 차트 저장 (plt.show() 대신 파일로 저장)
     chart_path = f"docs/backtest_{start_date}_{end_date}.png"
     plt.figure(figsize=(12, 6))
@@ -207,6 +222,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
         spy_cagr=spy_cagr,
         regime_returns=regime_returns,
         chart_path=chart_path,
+        trade_executions=all_executions,
     )
 
 

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -5,7 +5,7 @@ import numpy as np
 import math
 from unittest.mock import patch, MagicMock
 from src.backtest.runner import run_backtest, BacktestResult
-from src.core.models import MarketRegime
+from src.core.models import MarketRegime, TradeExecution, OrderAction, ExecutionStatus
 
 
 @pytest.fixture
@@ -257,3 +257,71 @@ def test_chart_saved_not_shown(mock_savefig, mock_download, mock_fetcher_return)
 
     mock_savefig.assert_called_once()
     mock_show.assert_not_called()
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_trade_executions_in_result(mock_savefig, mock_download, mock_fetcher_return):
+    """
+    [Issue #45] BacktestResult에 trade_executions 필드가 존재하고 리스트 타입이어야 한다.
+    """
+    mock_download.return_value = mock_fetcher_return
+
+    result = run_backtest(start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0)
+
+    assert result is not None
+    assert hasattr(result, "trade_executions"), "BacktestResult에 trade_executions 필드가 있어야 함"
+    assert isinstance(result.trade_executions, list), "trade_executions는 리스트여야 함"
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_trade_count_in_history(mock_savefig, mock_download, mock_fetcher_return):
+    """
+    [Issue #45] history DataFrame에 trade_count 컬럼이 존재하고 0 이상의 정수여야 한다.
+    """
+    mock_download.return_value = mock_fetcher_return
+
+    result = run_backtest(start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0)
+
+    assert result is not None
+    assert "trade_count" in result.history.columns, "history에 trade_count 컬럼이 있어야 함"
+    assert (result.history["trade_count"] >= 0).all(), "trade_count는 0 이상이어야 함"
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_execute_orders_return_value_collected(mock_savefig, mock_download, mock_fetcher_return):
+    """
+    [Issue #45] execute_orders 반환값(TradeExecution 리스트)이 누락 없이 수집되어야 한다.
+    신호가 발생하면 result.trade_executions에 해당 체결 기록이 포함되어야 한다.
+    """
+    mock_download.return_value = mock_fetcher_return
+
+    fake_execution = TradeExecution(
+        ticker="SSO",
+        action=OrderAction.BUY,
+        quantity=5,
+        price=100.0,
+        fee=0.1,
+        date="2023-01-02",
+        status=ExecutionStatus.FILLED,
+    )
+
+    with patch("src.backtest.components.BacktestBroker.execute_orders",
+               return_value=[fake_execution]) as mock_exec, \
+         patch("src.backtest.runner.Rebalancer.generate_signal") as mock_signal:
+
+        mock_signal_obj = MagicMock()
+        mock_signal_obj.has_orders = True
+        mock_signal_obj.orders = [MagicMock()]
+        mock_signal_obj.reason = "test"
+        mock_signal.return_value = mock_signal_obj
+
+        result = run_backtest(start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0)
+
+    assert result is not None
+    # execute_orders가 최소 1회 호출되어야 함
+    assert mock_exec.call_count >= 1, "execute_orders가 최소 1회 호출되어야 함"
+    # 반환된 실행 기록이 누적되어야 함
+    assert len(result.trade_executions) >= 1, "trade_executions에 체결 기록이 누적되어야 함"


### PR DESCRIPTION
- BacktestResult에 trade_executions 필드 추가 (List[TradeExecution])
- run_backtest 루프에서 broker.execute_orders() 반환값 누적 수집
- history 각 행에 trade_count 필드 추가 (CRASH=0, 정상=체결 건수)
- 백테스트 종료 후 거래 통계 출력 (종목별/액션별 빈도)
- 관련 테스트 3개 추가:
  - test_trade_executions_in_result
  - test_trade_count_in_history
  - test_execute_orders_return_value_collected

https://claude.ai/code/session_01A4DPp5yZjpZhPsRa1XACAB