### PR TITLE
fix: fetch_ohlcv dead code 제거 및 휴장일 처리 테스트 추가 (#50)

### DIFF
--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -17,14 +17,11 @@ class BacktestDataLoader(IDataProvider):
     def fetch_ohlcv(self, tickers: List[str], days: int = 365) -> pd.DataFrame:
         # [Time Travel] current_date 기준 과거 days 만큼 Slicing
         # full_df의 인덱스는 DatetimeIndex여야 함
-        
-        # 데이터가 없는 날짜(휴장일 등) 처리
-        if self.current_date not in self.full_df.index:
-            # 해당 날짜가 없으면 가장 가까운 과거 데이터 사용 (ffill 개념)
-            # 여기서는 로직 단순화를 위해 해당 날짜까지의 데이터를 자름
-            cutoff_df = self.full_df.loc[:self.current_date]
-        else:
-            cutoff_df = self.full_df.loc[:self.current_date]
+
+        # current_date 이하의 행 전체 선택
+        # loc[:date] 슬라이싱은 날짜가 인덱스에 없는 경우(휴장일 등)에도
+        # 해당 날짜 이전의 마지막 데이터까지 올바르게 반환 (ffill 효과)
+        cutoff_df = self.full_df.loc[:self.current_date]
             
         # 최근 days 만큼 자르기
         sliced = cutoff_df.tail(days)

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -41,6 +41,53 @@ def test_loader_time_travel_slicing(mock_full_data):
     assert df.index[-1] == target_date
     assert df.iloc[-1].item() == 140.0 # 5번째 값 (100, 110, 120, 130, 140)
 
+def test_loader_fetch_ohlcv_date_not_in_index(mock_full_data):
+    """
+    [Loader] current_date가 인덱스에 없는 날짜(휴장일 등)일 때도
+    이전 날짜까지의 데이터를 올바르게 반환하는지 확인
+    """
+    full_df, full_vix = mock_full_data
+    loader = BacktestDataLoader(full_df, full_vix)
+
+    # full_df 인덱스: 2024-01-01 ~ 2024-01-10 (영업일 기준)
+    # 2024-01-06은 토요일로 인덱스에 없을 수 있지만, 테스트용으로 임의 날짜 사용
+    # full_df의 마지막 날짜는 2024-01-10이므로 2024-01-07(존재)과 2024-01-11(미존재) 테스트
+    non_existent_date = pd.Timestamp("2024-01-11")  # 인덱스에 없는 날짜
+    loader.set_date(non_existent_date)
+
+    # 인덱스에 없는 날짜임을 확인
+    assert non_existent_date not in full_df.index
+
+    # 해당 날짜 이전 데이터가 반환되어야 함 (인덱스에 없어도 에러 없이 동작)
+    df = loader.fetch_ohlcv(["SPY"], days=5)
+
+    # full_df는 2024-01-01 ~ 2024-01-10 (10개), 그 중 마지막 5개
+    assert len(df) == 5
+    # 마지막 날짜는 full_df의 마지막 날짜인 2024-01-10이어야 함
+    assert df.index[-1] == pd.Timestamp("2024-01-10")
+
+
+def test_loader_fetch_ohlcv_no_future_data_leak(mock_full_data):
+    """
+    [Loader] fetch_ohlcv가 current_date 이후 데이터를 포함하지 않는지 확인 (미래 데이터 누출 방지)
+    """
+    full_df, full_vix = mock_full_data
+    loader = BacktestDataLoader(full_df, full_vix)
+
+    # 중간 날짜로 설정 (2024-01-05, 5번째)
+    target_date = pd.Timestamp("2024-01-05")
+    loader.set_date(target_date)
+
+    # 충분히 많은 days 요청 (전체 데이터보다 많음)
+    df = loader.fetch_ohlcv(["SPY"], days=100)
+
+    # target_date 이후 데이터가 포함되면 안 됨
+    assert df.index[-1] <= target_date
+    # 2024-01-06 ~ 2024-01-10 데이터가 없어야 함
+    future_dates = [d for d in df.index if d > target_date]
+    assert len(future_dates) == 0
+
+
 def test_broker_price_injection():
     """
     [Broker] 외부에서 주입한 가격이 체결에 반영되는지 확인


### PR DESCRIPTION
- BacktestDataLoader.fetch_ohlcv의 if/else 두 브랜치가 동일한 코드 실행 (dead code) 제거
- loc[:date] 슬라이싱은 날짜가 인덱스에 없는 경우(휴장일)에도 올바르게 동작하므로 단일 라인으로 통일
- 인덱스에 없는 날짜 처리 및 미래 데이터 누출 방지 테스트 케이스 2개 추가

https://claude.ai/code/session_01MRwTz4wUnpLNAV1Nwi4Erh