### PR TITLE
fix(runner): docs/ 디렉토리 미존재 시 차트 저장 실패 방지 (#52)

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -2,7 +2,9 @@
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from collections import Counter
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Optional
 from src.config import Config
 from src.core.models import MarketRegime, TradeExecution
@@ -210,7 +212,6 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
     # 거래 통계 출력
     print(f"Total Executions: {len(all_executions)}")
     if all_executions:
-        from collections import Counter
         ticker_counts = Counter(e.ticker for e in all_executions)
         action_counts = Counter(f"{e.ticker}/{e.action}" for e in all_executions)
         print("Trade Frequency by Ticker:", dict(ticker_counts))
@@ -218,6 +219,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
 
     # 차트 저장 (plt.show() 대신 파일로 저장)
     chart_path = f"docs/backtest_{start_date}_{end_date}.png"
+    Path("docs").mkdir(parents=True, exist_ok=True)
     plt.figure(figsize=(12, 6))
     plt.plot(res_df['total_value'], label='Portfolio Value')
     if spy_cagr is not None:

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -390,6 +390,25 @@ def test_trade_count_in_history(mock_savefig, mock_download, mock_fetcher_return
 
 @patch("src.backtest.runner.download_historical_data")
 @patch("src.backtest.runner.plt.savefig")
+@patch("src.backtest.runner.Path")
+def test_docs_directory_created_if_missing(mock_path_cls, mock_savefig, mock_download, mock_fetcher_return):
+    """
+    [Issue #52] run_backtest가 차트 저장 전에 docs/ 디렉토리를 자동 생성해야 한다.
+    docs/ 가 없어도 FileNotFoundError 없이 plt.savefig가 호출되어야 한다.
+    """
+    mock_download.return_value = mock_fetcher_return
+    mock_path_instance = MagicMock()
+    mock_path_cls.return_value = mock_path_instance
+
+    run_backtest(start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0)
+
+    mock_path_cls.assert_called_with("docs")
+    mock_path_instance.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_savefig.assert_called_once()
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
 def test_execute_orders_return_value_collected(mock_savefig, mock_download, mock_fetcher_return):
     """
     [Issue #45] execute_orders 반환값(TradeExecution 리스트)이 누락 없이 수집되어야 한다.


### PR DESCRIPTION
- Path("docs").mkdir(parents=True, exist_ok=True)를 plt.savefig 전에 추가하여
  docs/ 디렉토리가 없어도 FileNotFoundError 없이 차트를 저장할 수 있도록 수정
- from collections import Counter를 함수 내부에서 파일 상단 import 영역으로 이동 (#56)
- test_docs_directory_created_if_missing 테스트 추가: Path.mkdir가 올바른
  인자(parents=True, exist_ok=True)로 호출되는지 검증

https://claude.ai/code/session_01SFMtBrTDmudujPQm6HhPYg