### PR TITLE
fix: execute_orders에서 Order 객체 직접 수정 제거 (이슈 #54)

### DIFF
--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -1,5 +1,6 @@
 # src/backtest/components.py
 import pandas as pd
+from dataclasses import replace
 from typing import List, Dict
 from src.core.interfaces import IDataProvider, IBrokerAdapter
 from src.core.models import Portfolio, Order, TradeExecution
@@ -65,11 +66,8 @@ class BacktestBroker(MockBroker):
         # 주문 객체의 price는 '예상가'일 뿐이므로, 
         # 체결은 'simulation_prices'(실제 종가)로 이루어져야 함.
         
-        updated_orders = []
-        for order in orders:
-            real_price = self.simulation_prices.get(order.ticker, order.price)
-            # 주문 객체의 가격을 그 날의 실제 종가로 강제 수정 (시장가 체결 시뮬레이션)
-            order.price = real_price 
-            updated_orders.append(order)
-            
+        updated_orders = [
+            replace(order, price=self.simulation_prices.get(order.ticker, order.price))
+            for order in orders
+        ]
         return super().execute_orders(updated_orders)

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -112,3 +112,20 @@ def test_broker_price_injection():
     
     # 잔고 차감 확인: 10000 - (202 * 10 + 수수료)
     assert broker.get_portfolio().total_cash < 8000.0
+
+
+def test_broker_execute_orders_does_not_mutate_original_order():
+    """
+    [Broker] execute_orders 호출 후 원본 Order 객체의 price가 변경되지 않는지 확인
+    (이슈 #54: Order 직접 수정 부작용 방지)
+    """
+    broker = BacktestBroker(initial_cash=10000.0)
+    broker.set_prices({'SPY': 200.0})
+
+    original_price = 150.0
+    order = Order('SPY', OrderAction.BUY, 5, original_price)
+
+    broker.execute_orders([order])
+
+    # 원본 객체 price가 변경되지 않아야 함
+    assert order.price == original_price


### PR DESCRIPTION
BacktestBroker.execute_orders에서 order.price를 직접 수정하던 방식을
dataclasses.replace()를 사용한 새 객체 생성 방식으로 변경하여
원본 Order 객체의 부작용(mutation) 위험을 제거합니다.

- src/backtest/components.py: replace() 사용으로 Order 불변성 보장
- tests/test_backtest_components.py: 원본 Order 불변성 확인 테스트 추가

https://claude.ai/code/session_017iaQbzLCjcDMcXgJJxvK8H