### PR TITLE
fix: fetch_vix bare except를 명시적 예외로 교체 (이슈 #53)

### DIFF
--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -43,7 +43,7 @@ class BacktestDataLoader(IDataProvider):
             # asof: 인덱스에 딱 맞는 값이 없으면 직전 값을 가져옴
             idx = self.full_vix.index.get_indexer([self.current_date], method='pad')[0]
             return float(self.full_vix.iloc[idx]['Close'])
-        except:
+        except (IndexError, KeyError, TypeError, ValueError):
             return 20.0
 
 class BacktestBroker(MockBroker):

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -114,6 +114,37 @@ def test_broker_price_injection():
     assert broker.get_portfolio().total_cash < 8000.0
 
 
+def test_fetch_vix_returns_correct_value(mock_full_data):
+    """
+    [Loader] fetch_vix가 current_date에 해당하는 VIX 값을 올바르게 반환하는지 확인
+    """
+    full_df, full_vix = mock_full_data
+    loader = BacktestDataLoader(full_df, full_vix)
+
+    target_date = pd.Timestamp("2024-01-03")
+    loader.set_date(target_date)
+
+    vix = loader.fetch_vix()
+    assert vix == pytest.approx(20.0)
+
+
+def test_fetch_vix_returns_default_on_empty_dataframe():
+    """
+    [Loader] VIX 데이터가 비어 있을 때 기본값 20.0을 반환하는지 확인
+    (이슈 #53: bare except 수정 후 명시적 예외로 기본값 반환 동작 유지 검증)
+    """
+    dates = pd.date_range(start="2024-01-01", periods=5)
+    columns = pd.MultiIndex.from_product([['Close'], ['SPY']])
+    full_df = pd.DataFrame([[100.0]] * 5, index=dates, columns=columns)
+
+    empty_vix = pd.DataFrame({'Close': []})
+    loader = BacktestDataLoader(full_df, empty_vix)
+    loader.set_date(pd.Timestamp("2024-01-03"))
+
+    vix = loader.fetch_vix()
+    assert vix == pytest.approx(20.0)
+
+
 def test_broker_execute_orders_does_not_mutate_original_order():
     """
     [Broker] execute_orders 호출 후 원본 Order 객체의 price가 변경되지 않는지 확인


### PR DESCRIPTION
- bare except → except (IndexError, KeyError, TypeError, ValueError)
- KeyboardInterrupt, SystemExit 등 시스템 예외가 삼켜지지 않도록 수정
- fetch_vix 정상 동작 및 빈 DataFrame 기본값 반환 테스트 2개 추가

https://claude.ai/code/session_015BQXQ3LRU3bFWpYkG6okPr