### PR TITLE
fix: MockBroker 보유량 초과 매도 시 현금 지급 버그 수정 (#70)

### DIFF
--- a/src/infra/broker.py
+++ b/src/infra/broker.py
@@ -101,21 +101,24 @@ class MockBroker(IBrokerAdapter):
         
         print(f" > [FILLED] {order.action} {order.ticker}: {order.quantity} @ ${exec_price:.2f} (Fee: ${fee:.2f})")
         
-        amount = exec_price * order.quantity
-        
         # 잔고 반영
         if order.action == OrderAction.BUY:
+            amount = exec_price * order.quantity
             self.cash -= (amount + fee)
             self.holdings[order.ticker] = self.holdings.get(order.ticker, 0) + order.quantity
+            actual_qty = order.quantity
         elif order.action == OrderAction.SELL:
-            self.cash += (amount - fee)
             current_qty = self.holdings.get(order.ticker, 0)
-            self.holdings[order.ticker] = max(0, current_qty - order.quantity)
-            
+            actual_qty = min(order.quantity, current_qty)  # 보유량 한도 제한
+            amount = exec_price * actual_qty
+            fee = amount * 0.001
+            self.cash += (amount - fee)
+            self.holdings[order.ticker] = current_qty - actual_qty
+
         return TradeExecution(
             ticker=order.ticker,
             action=order.action,
-            quantity=order.quantity,
+            quantity=actual_qty,
             price=round(exec_price, 2),
             fee=round(fee, 2),
             date=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -74,17 +74,42 @@ def test_mock_broker_mixed_orders():
 def test_mock_broker_sell_more_than_owned():
     """
     [예외 시나리오: 과매도]
-    보유 수량보다 더 많이 팔려고 하면 0에서 멈추는지 확인
+    보유 수량보다 더 많이 팔려고 하면 실제 보유량만 체결되어야 함.
+    현금은 실제 체결된 수량(5주)만큼만 지급되어야 한다 (10주분 지급 금지).
     """
     broker = MockBroker(initial_cash=0.0, holdings={'SPY': 5})
-    
-    # 10주 매도 시도
+
+    # 10주 매도 시도 (보유는 5주)
     orders = [Order('SPY', OrderAction.SELL, 10, 100.0)]
     broker.execute_orders(orders)
-    
+
     pf = broker.get_portfolio()
-    
+
+    # 보유량은 0으로 감소 (5주 전량 매도)
     assert pf.holdings['SPY'] == 0
+
+    # 현금은 실제 체결 수량(5주)만큼만 지급되어야 함
+    # 체결가: 100 * 0.99 = 99.0
+    # 금액: 99.0 * 5 = 495.0
+    # 수수료: 495.0 * 0.001 = 0.495
+    # 입금액: 495.0 - 0.495 = 494.505
+    assert pf.total_cash == pytest.approx(494.505)
+
+
+def test_mock_broker_sell_more_than_owned_execution_qty():
+    """
+    [예외 시나리오: 과매도 체결 수량]
+    보유 수량보다 더 많이 팔려고 할 때 TradeExecution의 quantity가
+    실제 체결된 수량(보유량)으로 기록되어야 함.
+    """
+    broker = MockBroker(initial_cash=0.0, holdings={'SPY': 5})
+
+    orders = [Order('SPY', OrderAction.SELL, 10, 100.0)]
+    executions = broker.execute_orders(orders)
+
+    assert len(executions) == 1
+    # 실제 체결 수량은 보유량인 5주여야 함 (주문 수량 10주가 아님)
+    assert executions[0].quantity == 5
 
 def test_mock_broker_insufficient_funds():
     """


### PR DESCRIPTION
보유량보다 많은 수량을 매도하려 할 때 실제 보유량만 체결되도록 수정.
기존에는 주문 수량 전체에 대해 현금을 지급하여 존재하지 않는 주식의
대금이 생성되는 버그가 있었음 (백테스트 결과 신뢰성 훼손).

- _process_order_internal SELL 분기: actual_qty = min(order.quantity, current_qty)
- amount, fee, holdings 모두 actual_qty 기준으로 계산
- TradeExecution.quantity도 실제 체결 수량(actual_qty)으로 반환
- 테스트 보강: 현금 검증 추가, 체결 수량 검증 테스트 신규 추가

https://claude.ai/code/session_01Y5UbNeuZRhDCwCur7Gybkg