### PR TITLE
fix: BacktestBroker에서 time.sleep() 제거하여 백테스트 성능 저하 해결 (#67)

### DIFF
--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -79,3 +79,11 @@ class BacktestBroker(MockBroker):
             for order in orders
         ]
         return super().execute_orders(updated_orders)
+
+    def _wait_for_completion(self, timeout: int = 60) -> bool:
+        # 백테스트에서는 모든 주문이 즉시 체결됨 (폴링 불필요)
+        return True
+
+    def _refresh_balance_from_api(self):
+        # 백테스트에서는 API 갱신 및 딜레이 불필요
+        pass

--- a/src/infra/broker.py
+++ b/src/infra/broker.py
@@ -57,8 +57,7 @@ class MockBroker(IBrokerAdapter):
         if sell_orders:
             # 매도가 있었으면 예수금이 변했을 테니, API로 정확한 현재 잔고를 다시 가져옴
             print("[Broker] Refreshing Cash Balance...")
-            time.sleep(1) # API 반영 딜레이 고려
-            self._refresh_balance_from_api() 
+            self._refresh_balance_from_api()
         
         # ==========================================
         # Phase 3: 매수 집행 (Buy Execution)
@@ -149,8 +148,9 @@ class MockBroker(IBrokerAdapter):
         return 0 
 
     def _refresh_balance_from_api(self):
+        # 실전 브로커에서 오버라이드: API로 정확한 잔고를 가져오기 전 반영 대기
+        time.sleep(1) # API 반영 딜레이 고려
         # 실제 구현 시: KIS API 잔고 조회 후 self.cash 업데이트
-        pass
 
 
 # 실전용 (뼈대 코드)

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -201,3 +201,32 @@ def test_broker_get_portfolio_total_value_without_prices():
     assert pf.total_cash == pytest.approx(5000.0)
     assert pf.total_value == pytest.approx(5000.0)
     assert pf.current_prices == {}
+
+
+def test_backtest_broker_no_sleep_on_sell_orders():
+    """
+    [이슈 #67] BacktestBroker는 매도 주문 실행 시 time.sleep을 호출하지 않아야 함.
+    MockBroker는 _refresh_balance_from_api()에서 time.sleep(1)을 사용하지만,
+    BacktestBroker는 이 메서드를 오버라이드하여 딜레이가 없어야 한다.
+    """
+    from unittest.mock import patch
+
+    broker = BacktestBroker(initial_cash=5000.0)
+    broker.set_prices({'SPY': 100.0})
+    broker.holdings['SPY'] = 10  # 매도 가능 수량 설정
+
+    sell_order = Order('SPY', OrderAction.SELL, 5, 100.0)
+
+    with patch('time.sleep') as mock_sleep:
+        broker.execute_orders([sell_order])
+        # BacktestBroker에서는 time.sleep이 호출되지 않아야 함
+        mock_sleep.assert_not_called()
+
+
+def test_backtest_broker_wait_for_completion_returns_immediately():
+    """
+    [이슈 #67] BacktestBroker._wait_for_completion()이 즉시 True를 반환하는지 확인.
+    """
+    broker = BacktestBroker(initial_cash=5000.0)
+    result = broker._wait_for_completion(timeout=60)
+    assert result is True


### PR DESCRIPTION
MockBroker.execute_orders()의 time.sleep(1)이 BacktestBroker에서도 실행되어
10년 백테스트 시 수십 분 대기가 발생하는 문제를 수정함.

- broker.py: time.sleep(1)을 execute_orders() 본문에서 _refresh_balance_from_api()로 이동
  (서브클래스에서 오버라이드 가능하도록 캡슐화)
- components.py: BacktestBroker에 _wait_for_completion() 및 _refresh_balance_from_api()
  오버라이드 추가 (딜레이 없이 즉시 반환)
- tests: BacktestBroker 매도 주문 시 time.sleep 미호출 검증 테스트 2개 추가

https://claude.ai/code/session_01Sr9pwahFMom3K6mG6yFmAh