### PR TITLE
fix: MockBroker/KisBroker Order 객체 직접 변경(mutation) 버그 수정 (#71)

### DIFF
--- a/src/infra/broker.py
+++ b/src/infra/broker.py
@@ -78,13 +78,16 @@ class MockBroker(IBrokerAdapter):
                 if estimated_price <= 0: continue
 
                 max_qty = int(budget / estimated_price)
-                
+                # 원본 Order 객체를 변경하지 않고 조정된 수량으로 로컬 변수 사용
+                actual_qty = min(order.quantity, max_qty)
+
                 if max_qty < order.quantity:
-                    print(f"⚠️ [Safety] Qty Adjusted: {order.ticker} {order.quantity} -> {max_qty} (Budget: ${budget:.2f})")
-                    order.quantity = max_qty
-                
-                if order.quantity > 0:
-                    res = self._process_order_internal(order)
+                    print(f"⚠️ [Safety] Qty Adjusted: {order.ticker} {order.quantity} -> {actual_qty} (Budget: ${budget:.2f})")
+
+                if actual_qty > 0:
+                    # 조정된 수량으로 새 Order 생성 (원본 불변 유지)
+                    adjusted_order = Order(ticker=order.ticker, action=order.action, quantity=actual_qty, price=order.price)
+                    res = self._process_order_internal(adjusted_order)
                     executions.append(res)
         
         return executions
@@ -350,13 +353,16 @@ class KisBroker(IBrokerAdapter):
                 
                 # 수량 재계산
                 max_qty = int(budget / estimated_price)
-                
+                # 원본 Order 객체를 변경하지 않고 조정된 수량으로 로컬 변수 사용
+                actual_qty = min(order.quantity, max_qty)
+
                 if max_qty < order.quantity:
-                    self.logger.warning(f"⚠️ Qty Adjusted: {order.ticker} {order.quantity} -> {max_qty}")
-                    order.quantity = max_qty
-                
-                if order.quantity > 0:
-                    res = self._send_order(order)
+                    self.logger.warning(f"⚠️ Qty Adjusted: {order.ticker} {order.quantity} -> {actual_qty}")
+
+                if actual_qty > 0:
+                    # 조정된 수량으로 새 Order 생성 (원본 불변 유지)
+                    adjusted_order = Order(ticker=order.ticker, action=order.action, quantity=actual_qty, price=order.price)
+                    res = self._send_order(adjusted_order)
                     if res:
                         executions.append(res)
                         # 메모리상 잔고 차감 (다음 주문을 위해)

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -136,6 +136,61 @@ def test_mock_broker_insufficient_funds():
 
 
 
+def test_mock_broker_order_not_mutated_on_qty_adjustment():
+    """
+    [버그 방지: #71] 잔고 부족으로 수량 조정 시 원본 Order 객체가 변경되지 않아야 함.
+    MockBroker가 order.quantity를 직접 수정하면 호출자가 보유한 동일 객체 참조도 오염된다.
+    """
+    broker = MockBroker(initial_cash=500.0)
+
+    # 500원으로 100원짜리 10주 매수 시도 -> 잔고 부족으로 수량 조정 필요
+    original_order = Order(ticker='SPY', action=OrderAction.BUY, quantity=10, price=100.0)
+    original_qty = original_order.quantity  # 수정 전 수량 저장
+
+    broker.execute_orders([original_order])
+
+    # 원본 Order 객체의 quantity는 변하지 않아야 함
+    assert original_order.quantity == original_qty, (
+        f"원본 Order.quantity가 변경됨: {original_qty} -> {original_order.quantity}"
+    )
+
+
+def test_mock_broker_order_not_mutated_when_sufficient_funds():
+    """
+    [버그 방지: #71] 잔고가 충분할 때도 원본 Order 객체가 변경되지 않아야 함.
+    """
+    broker = MockBroker(initial_cash=10000.0)
+
+    original_order = Order(ticker='SPY', action=OrderAction.BUY, quantity=5, price=100.0)
+    original_qty = original_order.quantity
+
+    broker.execute_orders([original_order])
+
+    # 정상 체결 후에도 원본 quantity 불변
+    assert original_order.quantity == original_qty
+
+
+def test_mock_broker_tradesignal_orders_integrity():
+    """
+    [버그 방지: #71] TradeSignal.orders 목록의 Order 객체들이
+    execute_orders 호출 후에도 원래 수량을 유지해야 함.
+    """
+    from src.core.models import TradeSignal
+
+    broker = MockBroker(initial_cash=150.0)
+
+    # 잔고: 150원, 주문: 100원짜리 10주 (총 1000원 필요) -> 수량 조정됨
+    order = Order(ticker='SPY', action=OrderAction.BUY, quantity=10, price=100.0)
+    signal = TradeSignal(target_exposure=0.8, orders=[order], reason="테스트")
+
+    original_qty_in_signal = signal.orders[0].quantity
+
+    broker.execute_orders(signal.orders)
+
+    # TradeSignal 내 Order 수량이 변하지 않아야 함
+    assert signal.orders[0].quantity == original_qty_in_signal
+
+
 def test_mock_broker_cash_recycling_logic():
     """
     [심화] 매도 대금이 즉시 매수 재원으로 활용되는지 검증


### PR DESCRIPTION
수량 조정 시 원본 Order 객체를 변경하지 않고 조정된 수량으로 새 Order를 생성하여
TradeSignal.orders 무결성과 로그 기록의 정확성을 보장합니다.

- MockBroker.execute_orders: order.quantity = max_qty → adjusted_order 생성
- KisBroker.execute_orders: 동일하게 원본 Order 불변 유지
- 테스트 3개 추가: Order mutation 방지 검증

https://claude.ai/code/session_014FtpU7jZLuUiurdcoKm4nG