### PR TITLE
fix(#66): BacktestBroker가 시뮬레이션 날짜를 TradeExecution.date에 기록하도록 수정

### DIFF
--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -48,12 +48,17 @@ class BacktestDataLoader(IDataProvider):
 
 class BacktestBroker(MockBroker):
     """
-    MockBroker를 상속받되, '현재가'를 API가 아닌 
+    MockBroker를 상속받되, '현재가'를 API가 아닌
     백테스터가 주입해준 가격(simulation_prices)으로 처리
     """
     def __init__(self, initial_cash: float):
         super().__init__(initial_cash=initial_cash)
         self.simulation_prices = {} # {ticker: price}
+        self.current_date = None    # 시뮬레이션 상의 '오늘'
+
+    def set_date(self, date):
+        """시뮬레이션 날짜를 설정한다. runner가 매 거래일마다 호출해야 한다."""
+        self.current_date = date
 
     def set_prices(self, prices: Dict[str, float]):
         self.simulation_prices = prices
@@ -79,6 +84,14 @@ class BacktestBroker(MockBroker):
             for order in orders
         ]
         return super().execute_orders(updated_orders)
+
+    def _process_order_internal(self, order: Order) -> TradeExecution:
+        """체결 날짜를 실제 현재 시각이 아닌 시뮬레이션 날짜로 기록한다."""
+        result = super()._process_order_internal(order)
+        if self.current_date is not None:
+            sim_date = self.current_date.strftime("%Y-%m-%d")
+            return replace(result, date=sim_date)
+        return result
 
     def _wait_for_completion(self, timeout: int = 60) -> bool:
         # 백테스트에서는 모든 주문이 즉시 체결됨 (폴링 불필요)

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -86,6 +86,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
     for today in sim_days:
         # [Time Setting] 오늘 날짜 설정
         loader.set_date(today)
+        broker.set_date(today)
 
         # [Price Injection] 오늘 종가를 브로커에 주입 (종가 매매 가정)
         current_prices = {}

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -230,3 +230,61 @@ def test_backtest_broker_wait_for_completion_returns_immediately():
     broker = BacktestBroker(initial_cash=5000.0)
     result = broker._wait_for_completion(timeout=60)
     assert result is True
+
+
+def test_backtest_broker_execution_date_uses_simulation_date():
+    """
+    [이슈 #66] BacktestBroker.set_date()로 설정한 시뮬레이션 날짜가
+    TradeExecution.date에 기록되는지 확인 (datetime.now() 사용 금지).
+    """
+    broker = BacktestBroker(initial_cash=10000.0)
+    broker.set_prices({'SPY': 100.0})
+
+    sim_date = pd.Timestamp("2018-03-15")
+    broker.set_date(sim_date)
+
+    order = Order('SPY', OrderAction.BUY, 5, 100.0)
+    executions = broker.execute_orders([order])
+
+    assert len(executions) == 1
+    assert executions[0].date == "2018-03-15"
+
+
+def test_backtest_broker_execution_date_fallback_without_set_date():
+    """
+    [이슈 #66] set_date()를 호출하지 않으면 current_date가 None이므로
+    기본 MockBroker 동작(datetime.now() 기반 날짜)이 그대로 사용되어야 함.
+    즉, date 필드는 빈 문자열이 아니어야 한다.
+    """
+    broker = BacktestBroker(initial_cash=10000.0)
+    broker.set_prices({'SPY': 100.0})
+    # set_date() 호출 없이 주문 실행
+
+    order = Order('SPY', OrderAction.BUY, 5, 100.0)
+    executions = broker.execute_orders([order])
+
+    assert len(executions) == 1
+    # current_date가 None이면 MockBroker의 datetime.now() 결과가 그대로 사용됨
+    assert executions[0].date != ""
+
+
+def test_backtest_broker_set_date_updates_per_day():
+    """
+    [이슈 #66] 날짜를 변경할 때마다 다음 체결의 date가 갱신되는지 확인.
+    """
+    broker = BacktestBroker(initial_cash=50000.0)
+    broker.set_prices({'SPY': 100.0})
+
+    # 첫 번째 거래일: 2020-01-02
+    broker.set_date(pd.Timestamp("2020-01-02"))
+    broker.holdings['SPY'] = 10
+    sell_order = Order('SPY', OrderAction.SELL, 5, 100.0)
+    executions_day1 = broker.execute_orders([sell_order])
+
+    # 두 번째 거래일: 2020-01-03
+    broker.set_date(pd.Timestamp("2020-01-03"))
+    buy_order = Order('SPY', OrderAction.BUY, 3, 100.0)
+    executions_day2 = broker.execute_orders([buy_order])
+
+    assert executions_day1[0].date == "2020-01-02"
+    assert executions_day2[0].date == "2020-01-03"


### PR DESCRIPTION
- BacktestBroker에 set_date() 메서드와 current_date 속성 추가
- _process_order_internal()을 오버라이드하여 datetime.now() 대신
  시뮬레이션 날짜(YYYY-MM-DD)를 TradeExecution.date에 기록
- runner.py의 루프에서 loader.set_date() 직후 broker.set_date()도 호출
- 신규 테스트 3개 추가: 시뮬레이션 날짜 사용, fallback 동작, 날짜 갱신 확인

https://claude.ai/code/session_01XcV14jRS2TH4PrEAgRNdw4