### PR TITLE
fix(runner): NaN과 CRASH 국면을 히스토리에서 구분하여 기록 (이슈 #68)

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -111,14 +111,17 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
 
             # 2. 전략 판단 (main.py와 동일한 NaN 체크 + CRASH 처리)
             nan_fields = market_data.nan_fields()
-            if nan_fields:
+            nan_triggered = bool(nan_fields)  # NaN 여부를 별도로 추적
+            if nan_triggered:
+                # main.py와 동일: NaN → 데이터 품질 이상으로 CRASH 처리
                 regime = MarketRegime.CRASH
                 exposure = 0.0
             else:
                 regime = analyzer.analyze(market_data)
                 exposure = targeter.calculate_exposure(regime, market_data.spy_volatility)
 
-            # CRASH: 리밸런싱 없이 현재 상태 기록 후 스킵
+            # CRASH 또는 NaN: 리밸런싱 없이 현재 상태 기록 후 스킵
+            # main.py와 달리 알림/대기 대신 기록으로 대체하되, NaN과 CRASH를 구분하여 저장
             if regime == MarketRegime.CRASH:
                 final_pf = broker.get_portfolio()
                 history.append({
@@ -128,6 +131,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
                     "exposure": 0.0,
                     "regime": regime.value,
                     "trade_count": 0,
+                    "nan_triggered": nan_triggered,  # NaN 원인 여부 구분
                 })
                 continue
 
@@ -151,6 +155,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0) 
                 "exposure": exposure,
                 "regime": regime.value,
                 "trade_count": len(day_executions),
+                "nan_triggered": False,  # 정상 처리 (NaN 없음)
             })
 
         except Exception as e:

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -409,6 +409,46 @@ def test_docs_directory_created_if_missing(mock_path_cls, mock_savefig, mock_dow
 
 @patch("src.backtest.runner.download_historical_data")
 @patch("src.backtest.runner.plt.savefig")
+def test_nan_triggered_flag_true_when_nan_occurs(mock_savefig, mock_download, mock_fetcher_return):
+    """
+    [Issue #68] NaN 데이터 발생 시 history에 nan_triggered=True가 기록되어야 한다.
+    이를 통해 실제 CRASH와 데이터 품질 오류(NaN)를 사후 분석에서 구분할 수 있다.
+    """
+    mock_download.return_value = mock_fetcher_return
+
+    nan_market_data = MagicMock()
+    nan_market_data.nan_fields.return_value = ['spy_volatility']
+    nan_market_data.spy_volatility = math.nan
+
+    with patch("src.backtest.runner.IndicatorCalculator.calculate", return_value=nan_market_data):
+        result = run_backtest(start_date="2023-01-02", end_date="2023-01-03", initial_cash=10000.0)
+
+    assert result is not None
+    assert "nan_triggered" in result.history.columns, "history에 nan_triggered 컬럼이 있어야 함"
+    # NaN 발생일은 nan_triggered=True
+    assert result.history["nan_triggered"].any(), "NaN 발생 시 nan_triggered=True인 행이 있어야 함"
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_nan_triggered_flag_false_for_real_crash(mock_savefig, mock_download, mock_fetcher_return):
+    """
+    [Issue #68] 실제 CRASH 국면(NaN 없음)에서는 nan_triggered=False로 기록되어야 한다.
+    NaN 원인 없는 CRASH와 NaN으로 인한 CRASH를 구분할 수 있어야 한다.
+    """
+    mock_download.return_value = mock_fetcher_return
+
+    with patch("src.backtest.runner.RegimeAnalyzer.analyze", return_value=MarketRegime.CRASH):
+        result = run_backtest(start_date="2023-01-02", end_date="2023-01-03", initial_cash=10000.0)
+
+    assert result is not None
+    assert "nan_triggered" in result.history.columns, "history에 nan_triggered 컬럼이 있어야 함"
+    # 실제 CRASH(NaN 없음)는 nan_triggered=False
+    assert not result.history["nan_triggered"].any(), "NaN 없는 CRASH에서 nan_triggered=False이어야 함"
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
 def test_execute_orders_return_value_collected(mock_savefig, mock_download, mock_fetcher_return):
     """
     [Issue #45] execute_orders 반환값(TradeExecution 리스트)이 누락 없이 수집되어야 한다.


### PR DESCRIPTION
- runner.py: NaN 발생 시 nan_triggered=True, 실제 CRASH 시 False로 구분 기록
- nan_triggered 플래그를 history DataFrame 모든 행에 추가
- main.py와의 NaN/CRASH 처리 흐름 일치도 향상 (알림/대기 대신 기록으로 대체)
- 테스트 2개 추가: NaN 발생 시 nan_triggered=True, 실제 CRASH 시 False 검증

https://claude.ai/code/session_01WhE9rWLD2CQGQTuuvekP63