### PR TITLE
Add artifact upload to backtest CI workflow

### DIFF
--- a/.github/workflows/run-backtest.yml
+++ b/.github/workflows/run-backtest.yml
@@ -40,3 +40,13 @@ jobs:
         BACKTEST_END: ${{ inputs.end }}
         BACKTEST_CASH: ${{ inputs.initial_cash }}
       run: python scripts/run_backtest_ci.py
+
+    - name: Upload backtest artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: backtest-results-${{ inputs.start }}-${{ inputs.end }}
+        path: |
+          logs/backtest/
+          docs/backtest_*.png
+        retention-days: 30


### PR DESCRIPTION
## Summary
Added artifact upload step to the backtest CI workflow to persist backtest results and generated visualizations for later retrieval and analysis.

## Key Changes
- Added `upload-artifact` action to capture backtest outputs after each run
- Configured to upload backtest logs from `logs/backtest/` directory
- Configured to upload generated backtest charts (`docs/backtest_*.png`)
- Set artifact retention period to 30 days
- Configured step to run regardless of previous step success/failure using `if: always()`
- Artifact naming includes start and end dates for easy identification

## Implementation Details
- Uses GitHub Actions `upload-artifact@v4` for reliable artifact storage
- The `always()` condition ensures artifacts are captured even if the backtest script fails, which is valuable for debugging
- Artifact name is dynamically generated using workflow inputs to distinguish between different backtest runs

https://claude.ai/code/session_01FWmsAXb1n8VPT6mYcFkNuW