### PR TITLE
Show backtest logs inline without downloading artifacts

### DIFF
--- a/.github/workflows/run-backtest.yml
+++ b/.github/workflows/run-backtest.yml
@@ -41,6 +41,17 @@ jobs:
         BACKTEST_CASH: ${{ inputs.initial_cash }}
       run: python scripts/run_backtest_ci.py
 
+    - name: Print backtest log
+      if: always()
+      run: |
+        LOG_FILE=$(ls logs/backtest/*.log 2>/dev/null | head -1)
+        if [ -n "$LOG_FILE" ]; then
+          echo "=== 백테스트 로그: $LOG_FILE ==="
+          cat "$LOG_FILE"
+        else
+          echo "로그 파일이 생성되지 않았습니다."
+        fi
+
     - name: Upload backtest artifacts
       if: always()
       uses: actions/upload-artifact@v4

--- a/scripts/run_backtest_ci.py
+++ b/scripts/run_backtest_ci.py
@@ -41,6 +41,19 @@ def main() -> None:
     if result.chart_path:
         lines.append(f"\n차트 저장 경로: `{result.chart_path}`")
 
+    # Step Summary에 로그 파일 내용 추가
+    log_dir = "logs/backtest"
+    if os.path.isdir(log_dir):
+        log_files = sorted(
+            [os.path.join(log_dir, f) for f in os.listdir(log_dir) if f.endswith(".log")]
+        )
+        if log_files:
+            log_path = log_files[-1]  # 가장 최신 로그 파일
+            lines += ["", "### 실행 로그", f"<details><summary>{os.path.basename(log_path)}</summary>", "", "```"]
+            with open(log_path, encoding="utf-8") as lf:
+                lines.append(lf.read().rstrip())
+            lines += ["```", "", "</details>"]
+
     summary = "\n".join(lines) + "\n"
 
     summary_file = os.environ.get("GITHUB_STEP_SUMMARY", "")


### PR DESCRIPTION
1. run-backtest.yml: 'Print backtest log' 스텝 추가 (if: always())
   - cat으로 로그 파일 전문을 Actions 실행 로그에 직접 출력

2. run_backtest_ci.py: Step Summary에 로그 내용 포함
   - <details> 토글로 접어서 표시, 기본은 접힌 상태로 렌더링

https://claude.ai/code/session_01FWmsAXb1n8VPT6mYcFkNuW