### PR TITLE
fix(#89): fetch_ohlcv KeyError 발생 시 ValueError 전파로 데이터 무결성 보호

### DIFF
--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -33,7 +33,11 @@ class BacktestDataLoader(IDataProvider):
              try:
                  return sliced.xs(tickers[0], axis=1, level=1)
              except KeyError:
-                 return sliced # 이미 처리된 경우
+                 available = list(sliced.columns.get_level_values(1).unique())
+                 raise ValueError(
+                     f"Ticker '{tickers[0]}' not found in DataFrame. "
+                     f"Available tickers: {available}"
+                 )
                  
         return sliced
 

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -288,3 +288,61 @@ def test_backtest_broker_set_date_updates_per_day():
 
     assert executions_day1[0].date == "2020-01-02"
     assert executions_day2[0].date == "2020-01-03"
+
+
+def test_fetch_ohlcv_raises_value_error_when_ticker_not_in_multiindex():
+    """
+    [이슈 #89] 단일 종목 요청 시 해당 티커가 MultiIndex에 없으면 ValueError를 발생시켜야 함.
+    전체 MultiIndex DataFrame을 그대로 반환하면 IDataProvider 계약 위반.
+    """
+    dates = pd.date_range(start="2024-01-01", periods=5)
+    # AAPL 데이터만 있는 MultiIndex DataFrame
+    columns = pd.MultiIndex.from_product([['Close'], ['AAPL']])
+    df = pd.DataFrame([[100.0]] * 5, index=dates, columns=columns)
+    vix_df = pd.DataFrame({'Close': [20.0] * 5}, index=dates)
+
+    loader = BacktestDataLoader(df, vix_df)
+    loader.set_date(pd.Timestamp("2024-01-05"))
+
+    # SPY는 데이터에 없으므로 ValueError가 발생해야 함
+    with pytest.raises(ValueError, match="SPY"):
+        loader.fetch_ohlcv(["SPY"], days=5)
+
+
+def test_fetch_ohlcv_error_message_contains_available_tickers():
+    """
+    [이슈 #89] ValueError 메시지에 사용 가능한 티커 목록이 포함되어야 함.
+    """
+    dates = pd.date_range(start="2024-01-01", periods=5)
+    columns = pd.MultiIndex.from_product([['Close'], ['QLD']])
+    df = pd.DataFrame([[50.0]] * 5, index=dates, columns=columns)
+    vix_df = pd.DataFrame({'Close': [20.0] * 5}, index=dates)
+
+    loader = BacktestDataLoader(df, vix_df)
+    loader.set_date(pd.Timestamp("2024-01-05"))
+
+    with pytest.raises(ValueError) as exc_info:
+        loader.fetch_ohlcv(["SSO"], days=5)
+
+    assert "QLD" in str(exc_info.value)  # 사용 가능한 티커가 메시지에 포함
+
+
+def test_fetch_ohlcv_single_ticker_returns_single_index_when_found():
+    """
+    [이슈 #89] 단일 종목 요청 시 해당 티커가 존재하면 SingleIndex DataFrame을 반환해야 함.
+    KeyError 수정이 정상 케이스에 영향을 주지 않는지 확인.
+    """
+    dates = pd.date_range(start="2024-01-01", periods=5)
+    columns = pd.MultiIndex.from_product([['Close', 'Open'], ['SPY']])
+    data = [[100.0, 99.0]] * 5
+    df = pd.DataFrame(data, index=dates, columns=columns)
+    vix_df = pd.DataFrame({'Close': [20.0] * 5}, index=dates)
+
+    loader = BacktestDataLoader(df, vix_df)
+    loader.set_date(pd.Timestamp("2024-01-05"))
+
+    result = loader.fetch_ohlcv(["SPY"], days=5)
+
+    # SingleIndex여야 함 (MultiIndex가 아닌)
+    assert not isinstance(result.columns, pd.MultiIndex)
+    assert "Close" in result.columns

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -39,16 +39,16 @@ class TestBacktestDataLoaderEdgeCases:
         assert len(df) == 5
 
     def test_loader_fetch_ohlcv_keyerror(self, loader_data):
-        """단일 종목 요청인데 해당 종목이 MultiIndex에 없는 경우"""
+        """단일 종목 요청인데 해당 종목이 MultiIndex에 없는 경우 ValueError 발생 (이슈 #89)"""
         from src.backtest.components import BacktestDataLoader
 
         full_df, full_vix = loader_data
         loader = BacktestDataLoader(full_df, full_vix)
         loader.set_date(pd.Timestamp("2024-01-05"))
 
-        # 'IEF'는 데이터에 없음 -> KeyError -> except 분기로 원본 반환
-        df = loader.fetch_ohlcv(["IEF"], days=3)
-        assert len(df) == 3  # 원본 슬라이스가 그대로 반환
+        # 'IEF'는 데이터에 없음 -> KeyError -> ValueError로 전파 (계약 준수)
+        with pytest.raises(ValueError, match="IEF"):
+            loader.fetch_ohlcv(["IEF"], days=3)
 
     def test_loader_fetch_vix_fallback(self, loader_data):
         """VIX 데이터가 비정상적일 때 기본값 20.0 반환"""


### PR DESCRIPTION
- BacktestDataLoader.fetch_ohlcv()에서 단일 티커 요청 시 xs()가 KeyError를
  발생시키면 전체 MultiIndex DataFrame을 그대로 반환하던 문제 수정
- IDataProvider 인터페이스 계약(Raises: ValueError)에 맞게 ValueError로 변환
- 에러 메시지에 요청한 티커명과 사용 가능한 티커 목록을 포함하여 디버깅 용이

Tests:
- test_fetch_ohlcv_raises_value_error_when_ticker_not_in_multiindex: 없는 티커 요청 시 ValueError 검증
- test_fetch_ohlcv_error_message_contains_available_tickers: 에러 메시지에 가능한 티커 포함 검증
- test_fetch_ohlcv_single_ticker_returns_single_index_when_found: 정상 케이스 회귀 검증
- test_coverage_gaps.py 기존 테스트를 새 동작(ValueError 전파)으로 업데이트

https://claude.ai/code/session_01Uiov3iyjnKqDTQdD8Ffyc7