### PR TITLE
Add SessionStart hook for automatic dependency installation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# 원격 환경(Claude Code on the web)에서만 실행
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+echo "SessionStart: 의존성 설치 시작..." >&2
+
+# gh CLI 설치 (없는 경우)
+if ! command -v gh &>/dev/null; then
+  echo "gh CLI 설치 중..." >&2
+  if command -v apt-get &>/dev/null; then
+    apt-get update -qq && apt-get install -y -qq gh 2>/dev/null || {
+      # apt에 없으면 GitHub releases에서 직접 설치
+      GH_VERSION=$(curl -sL https://api.github.com/repos/cli/cli/releases/latest \
+        | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/') || GH_VERSION="2.45.0"
+      curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+        | tar -xz -C /tmp
+      install -m 755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+    }
+  fi
+  if command -v gh &>/dev/null; then
+    echo "gh CLI 설치 완료 ($(gh --version | head -1))" >&2
+  else
+    echo "WARNING: gh CLI 설치 실패 - 일부 기능 제한될 수 있음" >&2
+  fi
+fi
+
+# Python 의존성 설치
+if [ -f "${CLAUDE_PROJECT_DIR}/requirements.txt" ]; then
+  echo "Python 패키지 설치 중..." >&2
+  python3 -m pip install -q --prefer-binary -r "${CLAUDE_PROJECT_DIR}/requirements.txt"
+  echo "Python 패키지 설치 완료" >&2
+fi
+
+echo "SessionStart: 의존성 설치 완료" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,15 +15,34 @@
     ]
   },
   "hooks": {
-		"UserPromptSubmit": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": ".claude/hooks/skill-forced-eval-hook.sh"
-					}
-				]
-			}
-		]
-	}
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/run-hook.cmd session-start"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/skill-forced-eval-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
This PR adds a new SessionStart hook that automatically installs project dependencies when a Claude session begins, improving the setup experience for remote environments.

## Key Changes
- **Updated `.claude/settings.json`**: 
  - Added new `SessionStart` hook configuration with platform-specific commands (Windows `.cmd` and Unix `.sh`)
  - Reformatted hooks section with consistent indentation (spaces instead of tabs)
  - Preserved existing `UserPromptSubmit` hook configuration

- **Added `.claude/hooks/session-start.sh`**:
  - New bash script that runs automatically on session start in remote Claude Code environments
  - Installs GitHub CLI (`gh`) if not present, with fallback to direct download from GitHub releases
  - Installs Python dependencies from `requirements.txt` if the file exists
  - Includes proper error handling and user feedback via stderr logging
  - Only executes in remote environments (checks `CLAUDE_CODE_REMOTE` flag)

## Implementation Details
- The SessionStart hook includes two configurations: one for Windows (`.cmd`) and one for Unix (`.sh`)
- The bash script uses `set -euo pipefail` for strict error handling
- GitHub CLI installation includes a fallback mechanism: attempts `apt-get` first, then downloads directly from GitHub releases if unavailable
- All output is directed to stderr to avoid interfering with hook return values
- The script gracefully exits if not in a remote environment, preventing unnecessary execution in local setups

https://claude.ai/code/session_01NU9ESeiwLCqC2WWwwkQ7G7