### PR TITLE
fix(notifier): TelegramNotifier에 ILogger 주입하여 print() 제거 (#108)

### DIFF
--- a/src/infra/notifier.py
+++ b/src/infra/notifier.py
@@ -3,9 +3,10 @@ import requests
 from src.core.interfaces import INotifier
 
 class TelegramNotifier(INotifier):
-    def __init__(self, token: str, chat_id: str):
+    def __init__(self, token: str, chat_id: str, logger):
         self.token = token
         self.chat_id = chat_id
+        self.logger = logger
         self.base_url = f"https://api.telegram.org/bot{token}/sendMessage"
 
     def send_message(self, message: str) -> None:
@@ -16,14 +17,14 @@ class TelegramNotifier(INotifier):
 
     def _send(self, text: str):
         if not self.token or not self.chat_id:
-            print(f"[Telegram Mock] {text}") # 설정 없으면 콘솔 출력
+            self.logger.info(f"[Telegram Mock] {text}") # 설정 없으면 로거 출력
             return
 
         try:
             payload = {"chat_id": self.chat_id, "text": text}
             requests.post(self.base_url, json=payload, timeout=5)
         except Exception as e:
-            print(f"[Telegram Error] Failed to send: {e}")
+            self.logger.error(f"[Telegram Error] Failed to send: {e}")
 
 class SlackNotifier(INotifier):
     def __init__(self, webhook_url: str, logger):

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -140,7 +140,7 @@ class TestNotifierEdgeCases:
         from src.infra.notifier import TelegramNotifier
 
         with patch('src.infra.notifier.requests.post') as mock_post:
-            notifier = TelegramNotifier(token="123:ABC", chat_id="999")
+            notifier = TelegramNotifier(token="123:ABC", chat_id="999", logger=MagicMock())
             notifier.send_alert("Danger!")
 
             mock_post.assert_called_once()

--- a/tests/test_infra_notifier.py
+++ b/tests/test_infra_notifier.py
@@ -12,9 +12,9 @@ def mock_requests_post():
 def mock_logger():
     """가짜 로거 생성"""
     return MagicMock()
-def test_telegram_send_success(mock_requests_post):
+def test_telegram_send_success(mock_requests_post, mock_logger):
     # 1. 정상 전송 테스트
-    notifier = TelegramNotifier(token="1234:ABC", chat_id="999")
+    notifier = TelegramNotifier(token="1234:ABC", chat_id="999", logger=mock_logger)
     notifier.send_message("Hello Test")
     
     # requests.post가 호출되었는지 확인
@@ -26,26 +26,31 @@ def test_telegram_send_success(mock_requests_post):
     assert kwargs['json']['chat_id'] == "999"
     assert "Hello Test" in kwargs['json']['text']
 
-def test_telegram_send_without_token(mock_requests_post):
+def test_telegram_send_without_token(mock_requests_post, mock_logger):
     # 2. 토큰이 없는 경우 (설정 미비)
-    notifier = TelegramNotifier(token="", chat_id="")
+    notifier = TelegramNotifier(token="", chat_id="", logger=mock_logger)
     notifier.send_message("Should not send")
-    
+
     # 전송 시도조차 하지 않아야 함
     mock_requests_post.assert_not_called()
+    # logger.info로 mock 출력되었는지 확인
+    mock_logger.info.assert_called_once()
+    args, _ = mock_logger.info.call_args
+    assert "[Telegram Mock]" in args[0]
 
-def test_telegram_network_error(mock_requests_post, capsys):
+def test_telegram_network_error(mock_requests_post, mock_logger):
     # 3. 네트워크 에러 발생 시 프로그램이 죽지 않고 예외 처리하는지
     mock_requests_post.side_effect = Exception("Connection Refused")
-    
-    notifier = TelegramNotifier(token="123:ABC", chat_id="111")
-    
+
+    notifier = TelegramNotifier(token="123:ABC", chat_id="111", logger=mock_logger)
+
     # 에러가 발생하더라도 catch 되어야 함 (여기서 raise되면 테스트 실패)
     notifier.send_message("Error Test")
-    
-    # 콘솔에 에러 로그가 찍혔는지 확인
-    captured = capsys.readouterr()
-    assert "[Telegram Error]" in captured.out
+
+    # logger.error로 에러 로그가 기록되었는지 확인
+    mock_logger.error.assert_called_once()
+    args, _ = mock_logger.error.call_args
+    assert "[Telegram Error]" in args[0]
 
 
 def test_slack_send_success(mock_requests_post,mock_logger):


### PR DESCRIPTION
- TelegramNotifier 생성자에 logger 파라미터 추가
- 설정 미비 시 print() → self.logger.info()로 교체
- 에러 발생 시 print() → self.logger.error()로 교체
- SlackNotifier와 일관된 패턴 적용
- 관련 테스트를 logger 검증 방식으로 업데이트

https://claude.ai/code/session_01D7PMZyPvPm9ppexHdfFJVZ