### PR TITLE
refactor: KisBroker를 KisPaperBroker/KisLiveBroker로 분리

### DIFF
--- a/src/infra/broker.py
+++ b/src/infra/broker.py
@@ -157,27 +157,29 @@ class MockBroker(IBrokerAdapter):
         # 실제 구현 시: KIS API 잔고 조회 후 self.cash 업데이트
 
 
-# 실전용 (뼈대 코드)
-class KisBroker(IBrokerAdapter):
-    """한국투자증권 REST API 구현체"""
-    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger, is_real: bool = False):
+class KisBrokerBase(IBrokerAdapter):
+    """한국투자증권 REST API 공통 베이스 클래스.
+    서브클래스에서 BASE_URL 및 TR_* 상수를 반드시 정의해야 한다.
+    """
+    BASE_URL: str = ""
+    PRICE_TR_ID: str = ""
+    PORTFOLIO_TR_ID: str = ""
+    BUY_TR_ID: str = ""
+    SELL_TR_ID: str = ""
+    PENDING_TR_ID: str = ""
+
+    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger):
         self.app_key = app_key
         self.app_secret = app_secret
         self.acc_no = acc_no
         self.logger = logger
-        self.is_real = is_real
-        
+
         # 계좌번호 분리 (앞 8자리, 뒤 2자리)
         self.cano = acc_no[:8]
         self.acnt_prdt_cd = acc_no[8:]
 
-        # URL 설정
-        if is_real:
-            self.base_url = "https://openapi.koreainvestment.com:9443"
-            self.logger.info("[KisBroker] Mode: REAL TRADING")
-        else:
-            self.base_url = "https://openapivts.koreainvestment.com:29443"
-            self.logger.info("[KisBroker] Mode: PAPER TRADING (Virtual)")
+        # URL은 서브클래스 클래스 상수에서 설정
+        self.base_url = self.BASE_URL
         self.access_token = self._auth()
 
     def _auth(self) -> str:
@@ -230,8 +232,7 @@ class KisBroker(IBrokerAdapter):
         해외주식 현재가 조회 (반복 호출)
         """
         prices = {}
-        # 실전 TR_ID: HHDFS00000300, 모의: FHKST01010100
-        tr_id = "HHDFS00000300" if self.is_real else "FHKST01010100"
+        tr_id = self.PRICE_TR_ID
         url = f"{self.base_url}/uapi/overseas-price/v1/quotations/price" 
         for ticker in tickers:
             exch = self._get_exchange_code(ticker)
@@ -265,8 +266,7 @@ class KisBroker(IBrokerAdapter):
         """
         해외주식 잔고 및 예수금 조회
         """
-        # 해외주식 잔고지원 TR_ID (실전: TTTS3012R, 모의: VTTS3012R)
-        tr_id = "TTTS3012R" if self.is_real else "VTTS3012R"
+        tr_id = self.PORTFOLIO_TR_ID
         url = f"{self.base_url}/uapi/overseas-stock/v1/trading/inquire-balance"
         # 환율구분: 000(전체), 국가: US(미국), 시장: NYSE
         params = {
@@ -374,14 +374,7 @@ class KisBroker(IBrokerAdapter):
 
     def _send_order(self, order: Order) -> Optional[TradeExecution]:
         """실제 주문 API 호출"""
-        # 실전: TTTS1002U(매수), TTTS1006U(매도)
-        # 모의: VTTT1002U(매수), VTTT1006U(매도)
-        
-        tr_id = ""
-        if self.is_real:
-            tr_id = "TTTS1002U" if order.action == OrderAction.BUY else "TTTS1006U"
-        else:
-            tr_id = "VTTT1002U" if order.action == OrderAction.BUY else "VTTT1006U"
+        tr_id = self.BUY_TR_ID if order.action == OrderAction.BUY else self.SELL_TR_ID
 
         url = f"{self.base_url}/uapi/overseas-stock/v1/trading/order"
         exch = self._get_exchange_code(order.ticker)
@@ -449,7 +442,7 @@ class KisBroker(IBrokerAdapter):
         NAS -> NYS -> AMS 순으로 조회하며, 미체결이 하나라도 발견되면 즉시 반환합니다.
         (전체 개수 합산보다 존재 여부가 중요함)
         """
-        tr_id = "TTTS3018R" if self.is_real else "VTTT3018R"
+        tr_id = self.PENDING_TR_ID
         url = f"{self.base_url}/uapi/overseas-stock/v1/trading/inquire-nccs"
         
         target_exchanges = ["NAS", "NYS", "AMS"]
@@ -501,3 +494,31 @@ class KisBroker(IBrokerAdapter):
             'SHV': 'NAS'
         }
         return mapping.get(ticker, 'NAS') # 기본값
+
+
+class KisPaperBroker(KisBrokerBase):
+    """한국투자증권 모의투자 브로커 (가상거래 서버)"""
+    BASE_URL = "https://openapivts.koreainvestment.com:29443"
+    PRICE_TR_ID = "FHKST01010100"
+    PORTFOLIO_TR_ID = "VTTS3012R"
+    BUY_TR_ID = "VTTT1002U"
+    SELL_TR_ID = "VTTT1006U"
+    PENDING_TR_ID = "VTTT3018R"
+
+    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger):
+        super().__init__(app_key, app_secret, acc_no, logger)
+        self.logger.info("[KisPaperBroker] Mode: PAPER TRADING (Virtual)")
+
+
+class KisLiveBroker(KisBrokerBase):
+    """한국투자증권 실전투자 브로커 (실거래 서버)"""
+    BASE_URL = "https://openapi.koreainvestment.com:9443"
+    PRICE_TR_ID = "HHDFS00000300"
+    PORTFOLIO_TR_ID = "TTTS3012R"
+    BUY_TR_ID = "TTTS1002U"
+    SELL_TR_ID = "TTTS1006U"
+    PENDING_TR_ID = "TTTS3018R"
+
+    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger):
+        super().__init__(app_key, app_secret, acc_no, logger)
+        self.logger.info("[KisLiveBroker] Mode: LIVE TRADING")

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
 from src.utils.calculator import IndicatorCalculator
 from src.utils.logger import TradeLogger
 from src.infra.data import YFinanceLoader
-from src.infra.broker import MockBroker, KisBroker
+from src.infra.broker import MockBroker, KisPaperBroker, KisLiveBroker
 from src.infra.notifier import TelegramNotifier
 from src.infra.notifier import SlackNotifier
 from src.infra.repo import JsonRepository
@@ -35,12 +35,12 @@ class TradingBot:
         
         # 브로커 선택 (실전 vs 모의)
         if self.config.IS_LIVE_TRADING:
-            self.logger.info("Mode: LIVE TRADING (KisBroker)")
-            # 주의: 실제 계좌 연동 시에는 acc_no 포맷 확인 필요
-            self.broker = KisBroker(
-                self.config.KIS_APP_KEY, 
-                self.config.KIS_APP_SECRET, 
-                self.config.KIS_ACC_NO
+            self.logger.info("Mode: LIVE TRADING (KisLiveBroker)")
+            self.broker = KisLiveBroker(
+                self.config.KIS_APP_KEY,
+                self.config.KIS_APP_SECRET,
+                self.config.KIS_ACC_NO,
+                self.logger
             )
         else:
             self.logger.info("Mode: PAPER TRADING (MockBroker)")

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -242,7 +242,7 @@ class TestTradingBotEdgeCases:
         with patch('src.main.YFinanceLoader') as MockLoader, \
              patch('src.main.JsonRepository') as MockRepo, \
              patch('src.main.SlackNotifier') as MockNotifier, \
-             patch('src.main.KisBroker') as MockKisBroker, \
+             patch('src.main.KisLiveBroker') as MockKisBroker, \
              patch('src.main.IndicatorCalculator') as MockCalc, \
              patch('src.main.RegimeAnalyzer') as MockAnalyzer, \
              patch('src.main.VolatilityTargeter') as MockTargeter, \
@@ -277,7 +277,7 @@ class TestTradingBotEdgeCases:
 
     @patch('src.main.time.sleep')
     def test_bot_live_trading_mode_init(self, mock_sleep, mock_deps_live):
-        """실전 모드에서 KisBroker가 초기화되는지 확인 (lines 38-40)"""
+        """실전 모드에서 KisLiveBroker가 초기화되는지 확인 (lines 38-40)"""
         from src.main import TradingBot
 
         mock_deps_live['calc'].calculate.return_value = MarketData(
@@ -292,7 +292,7 @@ class TestTradingBotEdgeCases:
         bot = TradingBot()
         bot.run()
 
-        # KisBroker가 사용되었는지 확인
+        # KisLiveBroker가 사용되었는지 확인
         mock_deps_live['repo'].save_daily_summary.assert_called()
 
     @patch('src.main.time.sleep')

--- a/tests/test_infra_broker_kis.py
+++ b/tests/test_infra_broker_kis.py
@@ -2,12 +2,12 @@
 import pytest
 import logging
 from unittest.mock import patch, MagicMock
-from src.infra.broker import KisBroker, MockBroker
+from src.infra.broker import KisPaperBroker, KisLiveBroker, MockBroker
 from src.core.models import Order, Portfolio, OrderAction, ExecutionStatus, TradeExecution
 
 
 # ==========================================
-# KisBroker 테스트 (외부 API는 모두 Mock)
+# KisPaperBroker / KisLiveBroker 테스트 (외부 API는 모두 Mock)
 # ==========================================
 
 @pytest.fixture
@@ -23,19 +23,17 @@ def mock_logger():
 
 
 @pytest.fixture
-def kis_broker(mock_requests, mock_logger):
-    """KisBroker 인스턴스 (인증 Mock 포함)"""
-    # _auth가 호출될 때 성공적으로 토큰을 반환하도록 설정
+def paper_broker(mock_requests, mock_logger):
+    """KisPaperBroker 인스턴스 (인증 Mock 포함)"""
     auth_response = MagicMock()
     auth_response.json.return_value = {'access_token': 'test_token_123'}
     mock_requests.post.return_value = auth_response
 
-    broker = KisBroker(
+    broker = KisPaperBroker(
         app_key='test_key',
         app_secret='test_secret',
         acc_no='1234567890',
-        logger=mock_logger,
-        is_real=False
+        logger=mock_logger
     )
     # post mock 초기화 (auth 호출 후)
     mock_requests.post.reset_mock()
@@ -44,18 +42,17 @@ def kis_broker(mock_requests, mock_logger):
 
 
 @pytest.fixture
-def kis_broker_real(mock_requests, mock_logger):
-    """실전 모드 KisBroker"""
+def live_broker(mock_requests, mock_logger):
+    """KisLiveBroker 인스턴스 (인증 Mock 포함)"""
     auth_response = MagicMock()
     auth_response.json.return_value = {'access_token': 'real_token_456'}
     mock_requests.post.return_value = auth_response
 
-    broker = KisBroker(
+    broker = KisLiveBroker(
         app_key='real_key',
         app_secret='real_secret',
         acc_no='9876543210',
-        logger=mock_logger,
-        is_real=True
+        logger=mock_logger
     )
     mock_requests.post.reset_mock()
     mock_requests.get.reset_mock()
@@ -64,57 +61,61 @@ def kis_broker_real(mock_requests, mock_logger):
 
 # --- __init__ 테스트 ---
 
-def test_kis_broker_init_paper(mock_requests, mock_logger):
-    """모의투자 모드 초기화"""
+def test_kis_paper_broker_init(mock_requests, mock_logger):
+    """모의투자 브로커 초기화"""
     auth_response = MagicMock()
     auth_response.json.return_value = {'access_token': 'token123'}
     mock_requests.post.return_value = auth_response
 
-    broker = KisBroker('key', 'secret', '1234567890', mock_logger, is_real=False)
+    broker = KisPaperBroker('key', 'secret', '1234567890', mock_logger)
 
     assert broker.base_url == "https://openapivts.koreainvestment.com:29443"
+    assert broker.PRICE_TR_ID == "FHKST01010100"
+    assert broker.PORTFOLIO_TR_ID == "VTTS3012R"
     assert broker.cano == '12345678'
     assert broker.acnt_prdt_cd == '90'
     assert broker.access_token == 'token123'
 
 
-def test_kis_broker_init_real(mock_requests, mock_logger):
-    """실전 모드 초기화"""
+def test_kis_live_broker_init(mock_requests, mock_logger):
+    """실전투자 브로커 초기화"""
     auth_response = MagicMock()
     auth_response.json.return_value = {'access_token': 'real_token'}
     mock_requests.post.return_value = auth_response
 
-    broker = KisBroker('key', 'secret', '1234567890', mock_logger, is_real=True)
+    broker = KisLiveBroker('key', 'secret', '1234567890', mock_logger)
 
     assert broker.base_url == "https://openapi.koreainvestment.com:9443"
+    assert broker.PRICE_TR_ID == "HHDFS00000300"
+    assert broker.PORTFOLIO_TR_ID == "TTTS3012R"
     assert broker.access_token == 'real_token'
 
 
 # --- _auth 테스트 ---
 
-def test_kis_broker_auth_failure(mock_requests, mock_logger):
+def test_paper_broker_auth_failure(mock_requests, mock_logger):
     """인증 실패 시 예외 발생"""
     auth_response = MagicMock()
     auth_response.json.return_value = {'error': 'invalid credentials'}
     mock_requests.post.return_value = auth_response
 
     with pytest.raises(Exception, match="Auth Failed"):
-        KisBroker('bad_key', 'bad_secret', '1234567890', mock_logger)
+        KisPaperBroker('bad_key', 'bad_secret', '1234567890', mock_logger)
 
 
-def test_kis_broker_auth_network_error(mock_requests, mock_logger):
+def test_paper_broker_auth_network_error(mock_requests, mock_logger):
     """인증 중 네트워크 에러"""
     mock_requests.post.side_effect = Exception("Network Error")
 
     with pytest.raises(Exception, match="Network Error"):
-        KisBroker('key', 'secret', '1234567890', mock_logger)
+        KisPaperBroker('key', 'secret', '1234567890', mock_logger)
 
 
 # --- _get_header / _get_hashkey 테스트 ---
 
-def test_kis_broker_get_header_without_data(kis_broker, mock_requests):
+def test_paper_broker_get_header_without_data(paper_broker, mock_requests):
     """데이터 없이 헤더 생성 (GET 요청용)"""
-    headers = kis_broker._get_header("FHKST01010100")
+    headers = paper_broker._get_header("FHKST01010100")
 
     assert headers['authorization'] == 'Bearer test_token_123'
     assert headers['tr_id'] == 'FHKST01010100'
@@ -122,31 +123,31 @@ def test_kis_broker_get_header_without_data(kis_broker, mock_requests):
     assert 'hashkey' not in headers
 
 
-def test_kis_broker_get_header_with_data(kis_broker, mock_requests):
+def test_paper_broker_get_header_with_data(paper_broker, mock_requests):
     """데이터 포함 헤더 생성 (POST 요청용, HashKey 포함)"""
     hash_response = MagicMock()
     hash_response.json.return_value = {'HASH': 'abc123hash'}
     mock_requests.post.return_value = hash_response
 
     data = {"CANO": "12345678", "PDNO": "SPY"}
-    headers = kis_broker._get_header("VTTT1002U", data)
+    headers = paper_broker._get_header("VTTT1002U", data)
 
     assert headers['hashkey'] == 'abc123hash'
     assert headers['tr_id'] == 'VTTT1002U'
 
 
-def test_kis_broker_get_hashkey_failure(kis_broker, mock_requests):
+def test_paper_broker_get_hashkey_failure(paper_broker, mock_requests):
     """HashKey 조회 실패 시 빈 문자열 반환"""
     mock_requests.post.side_effect = Exception("Hash Error")
 
-    result = kis_broker._get_hashkey({"test": "data"})
+    result = paper_broker._get_hashkey({"test": "data"})
     assert result == ""
 
 
 # --- fetch_current_prices 테스트 ---
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_fetch_prices_success(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_fetch_prices_success(mock_sleep, paper_broker, mock_requests):
     """현재가 조회 성공"""
     price_response = MagicMock()
     price_response.json.return_value = {
@@ -155,7 +156,7 @@ def test_kis_broker_fetch_prices_success(mock_sleep, kis_broker, mock_requests):
     }
     mock_requests.get.return_value = price_response
 
-    prices = kis_broker.fetch_current_prices(['SPY', 'IEF'])
+    prices = paper_broker.fetch_current_prices(['SPY', 'IEF'])
 
     assert prices['SPY'] == 150.50
     assert prices['IEF'] == 150.50
@@ -163,7 +164,7 @@ def test_kis_broker_fetch_prices_success(mock_sleep, kis_broker, mock_requests):
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_fetch_prices_api_error(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_fetch_prices_api_error(mock_sleep, paper_broker, mock_requests):
     """현재가 조회 API 에러 (rt_cd != 0)"""
     price_response = MagicMock()
     price_response.json.return_value = {
@@ -172,26 +173,26 @@ def test_kis_broker_fetch_prices_api_error(mock_sleep, kis_broker, mock_requests
     }
     mock_requests.get.return_value = price_response
 
-    prices = kis_broker.fetch_current_prices(['INVALID'])
+    prices = paper_broker.fetch_current_prices(['INVALID'])
 
     assert prices['INVALID'] == 0.0
-    mock_logger = kis_broker.logger
+    mock_logger = paper_broker.logger
     mock_logger.warning.assert_called()
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_fetch_prices_exception(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_fetch_prices_exception(mock_sleep, paper_broker, mock_requests):
     """현재가 조회 중 예외 발생"""
     mock_requests.get.side_effect = Exception("Timeout")
 
-    prices = kis_broker.fetch_current_prices(['SPY'])
+    prices = paper_broker.fetch_current_prices(['SPY'])
 
     assert prices['SPY'] == 0.0
-    kis_broker.logger.error.assert_called()
+    paper_broker.logger.error.assert_called()
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_fetch_prices_real_mode(mock_sleep, kis_broker_real, mock_requests):
+def test_paper_broker_fetch_prices_real_mode(mock_sleep, live_broker, mock_requests):
     """실전 모드에서 TR_ID가 올바른지 확인"""
     price_response = MagicMock()
     price_response.json.return_value = {
@@ -200,7 +201,7 @@ def test_kis_broker_fetch_prices_real_mode(mock_sleep, kis_broker_real, mock_req
     }
     mock_requests.get.return_value = price_response
 
-    kis_broker_real.fetch_current_prices(['SPY'])
+    live_broker.fetch_current_prices(['SPY'])
 
     args, kwargs = mock_requests.get.call_args
     # 실전 TR_ID: HHDFS00000300
@@ -209,7 +210,7 @@ def test_kis_broker_fetch_prices_real_mode(mock_sleep, kis_broker_real, mock_req
 
 # --- get_portfolio 테스트 ---
 
-def test_kis_broker_get_portfolio_success(kis_broker, mock_requests):
+def test_paper_broker_get_portfolio_success(paper_broker, mock_requests):
     """잔고 조회 성공"""
     portfolio_response = MagicMock()
     portfolio_response.json.return_value = {
@@ -223,7 +224,7 @@ def test_kis_broker_get_portfolio_success(kis_broker, mock_requests):
     }
     mock_requests.get.return_value = portfolio_response
 
-    pf = kis_broker.get_portfolio()
+    pf = paper_broker.get_portfolio()
 
     assert pf.total_cash == 5000.50
     assert pf.holdings['SPY'] == 10
@@ -232,7 +233,7 @@ def test_kis_broker_get_portfolio_success(kis_broker, mock_requests):
     assert pf.current_prices['SPY'] == 150.0
 
 
-def test_kis_broker_get_portfolio_api_failure(kis_broker, mock_requests):
+def test_paper_broker_get_portfolio_api_failure(paper_broker, mock_requests):
     """잔고 조회 API 실패"""
     fail_response = MagicMock()
     fail_response.json.return_value = {
@@ -241,23 +242,23 @@ def test_kis_broker_get_portfolio_api_failure(kis_broker, mock_requests):
     }
     mock_requests.get.return_value = fail_response
 
-    pf = kis_broker.get_portfolio()
+    pf = paper_broker.get_portfolio()
 
     assert pf.total_cash == 0
     assert pf.holdings == {}
 
 
-def test_kis_broker_get_portfolio_exception(kis_broker, mock_requests):
+def test_paper_broker_get_portfolio_exception(paper_broker, mock_requests):
     """잔고 조회 중 예외 발생"""
     mock_requests.get.side_effect = Exception("Connection Error")
 
-    pf = kis_broker.get_portfolio()
+    pf = paper_broker.get_portfolio()
 
     assert pf.total_cash == 0
-    kis_broker.logger.error.assert_called()
+    paper_broker.logger.error.assert_called()
 
 
-def test_kis_broker_get_portfolio_real_mode(kis_broker_real, mock_requests):
+def test_paper_broker_get_portfolio_real_mode(live_broker, mock_requests):
     """실전 모드에서 TR_ID 확인"""
     portfolio_response = MagicMock()
     portfolio_response.json.return_value = {
@@ -267,7 +268,7 @@ def test_kis_broker_get_portfolio_real_mode(kis_broker_real, mock_requests):
     }
     mock_requests.get.return_value = portfolio_response
 
-    kis_broker_real.get_portfolio()
+    live_broker.get_portfolio()
 
     args, kwargs = mock_requests.get.call_args
     assert kwargs['headers']['tr_id'] == 'TTTS3012R'
@@ -275,7 +276,7 @@ def test_kis_broker_get_portfolio_real_mode(kis_broker_real, mock_requests):
 
 # --- _send_order 테스트 ---
 
-def test_kis_broker_send_order_buy_success(kis_broker, mock_requests):
+def test_paper_broker_send_order_buy_success(paper_broker, mock_requests):
     """매수 주문 전송 성공"""
     order_response = MagicMock()
     order_response.json.return_value = {'rt_cd': '0', 'msg1': 'OK'}
@@ -285,7 +286,7 @@ def test_kis_broker_send_order_buy_success(kis_broker, mock_requests):
     mock_requests.post.side_effect = [hash_response, order_response]
 
     order = Order('SPY', OrderAction.BUY, 10, 150.0)
-    result = kis_broker._send_order(order)
+    result = paper_broker._send_order(order)
 
     assert result is not None
     assert result.ticker == 'SPY'
@@ -294,7 +295,7 @@ def test_kis_broker_send_order_buy_success(kis_broker, mock_requests):
     assert result.status == ExecutionStatus.ORDERED
 
 
-def test_kis_broker_send_order_sell_success(kis_broker, mock_requests):
+def test_paper_broker_send_order_sell_success(paper_broker, mock_requests):
     """매도 주문 전송 성공"""
     order_response = MagicMock()
     order_response.json.return_value = {'rt_cd': '0', 'msg1': 'OK'}
@@ -303,13 +304,13 @@ def test_kis_broker_send_order_sell_success(kis_broker, mock_requests):
     mock_requests.post.side_effect = [hash_response, order_response]
 
     order = Order('SPY', OrderAction.SELL, 5, 150.0)
-    result = kis_broker._send_order(order)
+    result = paper_broker._send_order(order)
 
     assert result is not None
     assert result.action == OrderAction.SELL
 
 
-def test_kis_broker_send_order_failure(kis_broker, mock_requests):
+def test_paper_broker_send_order_failure(paper_broker, mock_requests):
     """주문 전송 실패 (API 에러)"""
     order_response = MagicMock()
     order_response.json.return_value = {'rt_cd': '1', 'msg1': 'Insufficient balance'}
@@ -318,25 +319,25 @@ def test_kis_broker_send_order_failure(kis_broker, mock_requests):
     mock_requests.post.side_effect = [hash_response, order_response]
 
     order = Order('SPY', OrderAction.BUY, 10, 150.0)
-    result = kis_broker._send_order(order)
+    result = paper_broker._send_order(order)
 
     assert result is None
-    kis_broker.logger.error.assert_called()
+    paper_broker.logger.error.assert_called()
 
 
-def test_kis_broker_send_order_exception(kis_broker, mock_requests):
+def test_paper_broker_send_order_exception(paper_broker, mock_requests):
     """주문 전송 중 예외"""
     hash_response = MagicMock()
     hash_response.json.return_value = {'HASH': 'hash'}
     mock_requests.post.side_effect = [hash_response, Exception("Network Down")]
 
     order = Order('SPY', OrderAction.BUY, 5, 100.0)
-    result = kis_broker._send_order(order)
+    result = paper_broker._send_order(order)
 
     assert result is None
 
 
-def test_kis_broker_send_order_real_mode_tr_ids(kis_broker_real, mock_requests):
+def test_paper_broker_send_order_real_mode_tr_ids(live_broker, mock_requests):
     """실전 모드 TR_ID 확인 (매수/매도)"""
     order_response = MagicMock()
     order_response.json.return_value = {'rt_cd': '0'}
@@ -346,7 +347,7 @@ def test_kis_broker_send_order_real_mode_tr_ids(kis_broker_real, mock_requests):
     # 매수
     mock_requests.post.side_effect = [hash_response, order_response]
     buy_order = Order('SPY', OrderAction.BUY, 1, 100.0)
-    kis_broker_real._send_order(buy_order)
+    live_broker._send_order(buy_order)
     # 두 번째 post call의 headers에서 tr_id 확인
     call_args = mock_requests.post.call_args_list[1]
     assert call_args[1]['headers']['tr_id'] == 'TTTS1002U'
@@ -355,7 +356,7 @@ def test_kis_broker_send_order_real_mode_tr_ids(kis_broker_real, mock_requests):
     mock_requests.post.side_effect = [hash_response, order_response]
     # 매도
     sell_order = Order('SPY', OrderAction.SELL, 1, 100.0)
-    kis_broker_real._send_order(sell_order)
+    live_broker._send_order(sell_order)
     call_args = mock_requests.post.call_args_list[1]
     assert call_args[1]['headers']['tr_id'] == 'TTTS1006U'
 
@@ -363,12 +364,12 @@ def test_kis_broker_send_order_real_mode_tr_ids(kis_broker_real, mock_requests):
 # --- execute_orders 테스트 ---
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_execute_sell_then_buy(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_execute_sell_then_buy(mock_sleep, paper_broker, mock_requests):
     """매도 후 매수 순서 실행"""
     # _send_order와 _wait_for_completion, get_portfolio를 모킹
-    with patch.object(kis_broker, '_send_order') as mock_send, \
-         patch.object(kis_broker, '_wait_for_completion', return_value=True), \
-         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+    with patch.object(paper_broker, '_send_order') as mock_send, \
+         patch.object(paper_broker, '_wait_for_completion', return_value=True), \
+         patch.object(paper_broker, 'get_portfolio') as mock_get_pf:
 
         from src.core.models import TradeExecution
         sell_exec = TradeExecution('SPY', OrderAction.SELL, 5, 150.0, 0.0, '2024-01-01', ExecutionStatus.ORDERED)
@@ -385,17 +386,17 @@ def test_kis_broker_execute_sell_then_buy(mock_sleep, kis_broker, mock_requests)
             Order('SPY', OrderAction.SELL, 5, 150.0),
             Order('IEF', OrderAction.BUY, 10, 100.0),
         ]
-        executions = kis_broker.execute_orders(orders)
+        executions = paper_broker.execute_orders(orders)
 
         assert len(executions) == 2
         assert mock_send.call_count == 2
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_execute_buy_only(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_execute_buy_only(mock_sleep, paper_broker, mock_requests):
     """매수만 있는 경우"""
-    with patch.object(kis_broker, '_send_order') as mock_send, \
-         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+    with patch.object(paper_broker, '_send_order') as mock_send, \
+         patch.object(paper_broker, 'get_portfolio') as mock_get_pf:
 
         from src.core.models import TradeExecution
         buy_exec = TradeExecution('SPY', OrderAction.BUY, 5, 100.0, 0.0, '2024-01-01', ExecutionStatus.ORDERED)
@@ -405,16 +406,16 @@ def test_kis_broker_execute_buy_only(mock_sleep, kis_broker, mock_requests):
         )
 
         orders = [Order('SPY', OrderAction.BUY, 5, 100.0)]
-        executions = kis_broker.execute_orders(orders)
+        executions = paper_broker.execute_orders(orders)
 
         assert len(executions) == 1
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_execute_buy_qty_adjusted(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_execute_buy_qty_adjusted(mock_sleep, paper_broker, mock_requests):
     """매수 시 잔고 부족으로 수량 조정"""
-    with patch.object(kis_broker, '_send_order') as mock_send, \
-         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+    with patch.object(paper_broker, '_send_order') as mock_send, \
+         patch.object(paper_broker, 'get_portfolio') as mock_get_pf:
 
         from src.core.models import TradeExecution
         buy_exec = TradeExecution('SPY', OrderAction.BUY, 1, 100.0, 0.0, '2024-01-01', ExecutionStatus.ORDERED)
@@ -425,76 +426,76 @@ def test_kis_broker_execute_buy_qty_adjusted(mock_sleep, kis_broker, mock_reques
         )
 
         orders = [Order('SPY', OrderAction.BUY, 100, 100.0)]  # 100주 요청하지만 돈이 부족
-        executions = kis_broker.execute_orders(orders)
+        executions = paper_broker.execute_orders(orders)
 
         # 수량이 조정되어 실행됨 (200*0.98/102 = 1주)
         assert len(executions) == 1
-        kis_broker.logger.warning.assert_called()
+        paper_broker.logger.warning.assert_called()
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_execute_buy_zero_price(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_execute_buy_zero_price(mock_sleep, paper_broker, mock_requests):
     """매수 가격이 0인 경우 스킵"""
-    with patch.object(kis_broker, '_send_order') as mock_send, \
-         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+    with patch.object(paper_broker, '_send_order') as mock_send, \
+         patch.object(paper_broker, 'get_portfolio') as mock_get_pf:
 
         mock_get_pf.return_value = Portfolio(
             total_cash=10000.0, holdings={}, current_prices={}
         )
 
         orders = [Order('SPY', OrderAction.BUY, 10, 0.0)]  # 가격 0
-        executions = kis_broker.execute_orders(orders)
+        executions = paper_broker.execute_orders(orders)
 
         assert len(executions) == 0
         mock_send.assert_not_called()
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_execute_buy_zero_qty_after_adjust(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_execute_buy_zero_qty_after_adjust(mock_sleep, paper_broker, mock_requests):
     """수량 조정 후 0이 되면 주문 안 함"""
-    with patch.object(kis_broker, '_send_order') as mock_send, \
-         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+    with patch.object(paper_broker, '_send_order') as mock_send, \
+         patch.object(paper_broker, 'get_portfolio') as mock_get_pf:
 
         mock_get_pf.return_value = Portfolio(
             total_cash=10.0, holdings={}, current_prices={}
         )
 
         orders = [Order('SPY', OrderAction.BUY, 10, 500.0)]  # 수량 조정 후 0
-        executions = kis_broker.execute_orders(orders)
+        executions = paper_broker.execute_orders(orders)
 
         assert len(executions) == 0
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_execute_sell_timeout(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_execute_sell_timeout(mock_sleep, paper_broker, mock_requests):
     """매도 체결 대기 타임아웃"""
-    with patch.object(kis_broker, '_send_order') as mock_send, \
-         patch.object(kis_broker, '_wait_for_completion', return_value=False):
+    with patch.object(paper_broker, '_send_order') as mock_send, \
+         patch.object(paper_broker, '_wait_for_completion', return_value=False):
 
         from src.core.models import TradeExecution
         sell_exec = TradeExecution('SPY', OrderAction.SELL, 5, 150.0, 0.0, '2024-01-01', ExecutionStatus.ORDERED)
         mock_send.return_value = sell_exec
 
         orders = [Order('SPY', OrderAction.SELL, 5, 150.0)]
-        executions = kis_broker.execute_orders(orders)
+        executions = paper_broker.execute_orders(orders)
 
         # 타임아웃이어도 실행 결과는 반환
         assert len(executions) == 1
-        kis_broker.logger.warning.assert_called()
+        paper_broker.logger.warning.assert_called()
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_execute_send_order_returns_none(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_execute_send_order_returns_none(mock_sleep, paper_broker, mock_requests):
     """_send_order가 None을 반환하는 경우 (주문 실패)"""
-    with patch.object(kis_broker, '_send_order', return_value=None) as mock_send, \
-         patch.object(kis_broker, 'get_portfolio') as mock_get_pf:
+    with patch.object(paper_broker, '_send_order', return_value=None) as mock_send, \
+         patch.object(paper_broker, 'get_portfolio') as mock_get_pf:
 
         mock_get_pf.return_value = Portfolio(
             total_cash=50000.0, holdings={}, current_prices={}
         )
 
         orders = [Order('SPY', OrderAction.BUY, 5, 100.0)]
-        executions = kis_broker.execute_orders(orders)
+        executions = paper_broker.execute_orders(orders)
 
         assert len(executions) == 0
 
@@ -503,29 +504,29 @@ def test_kis_broker_execute_send_order_returns_none(mock_sleep, kis_broker, mock
 
 @patch('src.infra.broker.time.sleep')
 @patch('src.infra.broker.time.time')
-def test_kis_broker_wait_completion_success(mock_time, mock_sleep, kis_broker):
+def test_paper_broker_wait_completion_success(mock_time, mock_sleep, paper_broker):
     """체결 대기 성공 (미체결 0)"""
     mock_time.side_effect = [0, 1]  # 시작, 루프 1회
-    with patch.object(kis_broker, '_get_pending_orders_count', return_value=0):
-        result = kis_broker._wait_for_completion(timeout=60)
+    with patch.object(paper_broker, '_get_pending_orders_count', return_value=0):
+        result = paper_broker._wait_for_completion(timeout=60)
         assert result is True
 
 
 @patch('src.infra.broker.time.sleep')
 @patch('src.infra.broker.time.time')
-def test_kis_broker_wait_completion_timeout(mock_time, mock_sleep, kis_broker):
+def test_paper_broker_wait_completion_timeout(mock_time, mock_sleep, paper_broker):
     """체결 대기 타임아웃"""
     # time.time()이 계속 증가하여 timeout 초과
     mock_time.side_effect = [0, 10, 30, 61]
-    with patch.object(kis_broker, '_get_pending_orders_count', return_value=5):
-        result = kis_broker._wait_for_completion(timeout=60)
+    with patch.object(paper_broker, '_get_pending_orders_count', return_value=5):
+        result = paper_broker._wait_for_completion(timeout=60)
         assert result is False
 
 
 # --- _get_pending_orders_count 테스트 ---
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_pending_orders_found(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_pending_orders_found(mock_sleep, paper_broker, mock_requests):
     """미체결 내역 발견"""
     pending_response = MagicMock()
     pending_response.json.return_value = {
@@ -534,13 +535,13 @@ def test_kis_broker_pending_orders_found(mock_sleep, kis_broker, mock_requests):
     }
     mock_requests.get.return_value = pending_response
 
-    count = kis_broker._get_pending_orders_count()
+    count = paper_broker._get_pending_orders_count()
 
     assert count == 2
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_pending_orders_none(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_pending_orders_none(mock_sleep, paper_broker, mock_requests):
     """미체결 내역 없음 (모든 거래소 조회)"""
     empty_response = MagicMock()
     empty_response.json.return_value = {
@@ -549,7 +550,7 @@ def test_kis_broker_pending_orders_none(mock_sleep, kis_broker, mock_requests):
     }
     mock_requests.get.return_value = empty_response
 
-    count = kis_broker._get_pending_orders_count()
+    count = paper_broker._get_pending_orders_count()
 
     assert count == 0
     # NAS, NYS, AMS 3개 거래소 모두 조회
@@ -557,7 +558,7 @@ def test_kis_broker_pending_orders_none(mock_sleep, kis_broker, mock_requests):
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_pending_orders_api_error(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_pending_orders_api_error(mock_sleep, paper_broker, mock_requests):
     """미체결 조회 API 에러"""
     error_response = MagicMock()
     error_response.json.return_value = {
@@ -566,40 +567,40 @@ def test_kis_broker_pending_orders_api_error(mock_sleep, kis_broker, mock_reques
     }
     mock_requests.get.return_value = error_response
 
-    count = kis_broker._get_pending_orders_count()
+    count = paper_broker._get_pending_orders_count()
 
     assert count == 0
-    kis_broker.logger.warning.assert_called()
+    paper_broker.logger.warning.assert_called()
 
 
 @patch('src.infra.broker.time.sleep')
-def test_kis_broker_pending_orders_exception(mock_sleep, kis_broker, mock_requests):
+def test_paper_broker_pending_orders_exception(mock_sleep, paper_broker, mock_requests):
     """미체결 조회 중 예외"""
     mock_requests.get.side_effect = Exception("Connection Reset")
 
-    count = kis_broker._get_pending_orders_count()
+    count = paper_broker._get_pending_orders_count()
 
     assert count == 0
-    kis_broker.logger.error.assert_called()
+    paper_broker.logger.error.assert_called()
 
 
 # --- _get_exchange_code 테스트 ---
 
-def test_kis_broker_exchange_code_mapping(kis_broker):
+def test_paper_broker_exchange_code_mapping(paper_broker):
     """거래소 코드 매핑 확인"""
-    assert kis_broker._get_exchange_code('SPY') == 'AMS'
-    assert kis_broker._get_exchange_code('QLD') == 'AMS'
-    assert kis_broker._get_exchange_code('SSO') == 'AMS'
-    assert kis_broker._get_exchange_code('IEF') == 'NAS'
-    assert kis_broker._get_exchange_code('GLD') == 'NYS'
-    assert kis_broker._get_exchange_code('PDBC') == 'NAS'
-    assert kis_broker._get_exchange_code('SHV') == 'NAS'
+    assert paper_broker._get_exchange_code('SPY') == 'AMS'
+    assert paper_broker._get_exchange_code('QLD') == 'AMS'
+    assert paper_broker._get_exchange_code('SSO') == 'AMS'
+    assert paper_broker._get_exchange_code('IEF') == 'NAS'
+    assert paper_broker._get_exchange_code('GLD') == 'NYS'
+    assert paper_broker._get_exchange_code('PDBC') == 'NAS'
+    assert paper_broker._get_exchange_code('SHV') == 'NAS'
 
 
-def test_kis_broker_exchange_code_default(kis_broker):
+def test_paper_broker_exchange_code_default(paper_broker):
     """매핑에 없는 티커는 기본값 NAS"""
-    assert kis_broker._get_exchange_code('UNKNOWN') == 'NAS'
-    assert kis_broker._get_exchange_code('AAPL') == 'NAS'
+    assert paper_broker._get_exchange_code('UNKNOWN') == 'NAS'
+    assert paper_broker._get_exchange_code('AAPL') == 'NAS'
 
 
 # --- MockBroker 추가 테스트 ---


### PR DESCRIPTION
is_real 파라미터로 모의/실전을 구분하던 KisBroker 클래스를 역할별로 분리.
각 클래스가 URL과 TR_ID를 클래스 상수로 갖게 되어 if self.is_real 분기 5곳 제거.

- KisBrokerBase: 공통 REST API 로직 (인증, 주문, 잔고 조회 등)
- KisPaperBroker: 한국투자증권 가상거래 서버 전용 (VTTT/VTTS TR_ID)
- KisLiveBroker: 한국투자증권 실거래 서버 전용 (TTTS TR_ID)
- main.py: KisLiveBroker 사용으로 변경 및 logger 누락 버그 수정

https://claude.ai/code/session_017VE632xeoFJCvC838wnD5v