### PR TITLE
Add configurable size limits for JSON repository files

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -30,3 +30,7 @@ class Config:
         # 3. 데이터 경로
         self.DATA_PATH = "docs/data"
         self.LOG_PATH = "logs"
+
+        # 4. 저장소 크기 제한
+        self.MAX_SUMMARY_RECORDS = 2000  # summary.json 최대 레코드 수
+        self.MAX_HISTORY_RECORDS = 100   # history.json 최대 레코드 수

--- a/src/infra/repo.py
+++ b/src/infra/repo.py
@@ -7,8 +7,10 @@ from datetime import datetime
 from src.core.models import MarketData, Portfolio, TradeSignal, MarketRegime, TradeExecution
 
 class JsonRepository:
-    def __init__(self, root_path: str = "docs/data"):
+    def __init__(self, root_path: str = "docs/data", max_summary_records: int = 2000, max_history_records: int = 100):
         self.root = root_path
+        self.max_summary_records = max_summary_records
+        self.max_history_records = max_history_records
         os.makedirs(self.root, exist_ok=True)
         
         self.status_file = os.path.join(self.root, "status.json")
@@ -39,10 +41,10 @@ class JsonRepository:
         
         data = self._load_json(self.summary_file, default=[])
         data.append(record)
-        
-        # 파일이 너무 커지는 것을 방지하려면 여기서 최근 N개(예: 2000개)만 유지하는 로직 추가 가능
-        # data = data[-2000:] 
-        
+
+        if self.max_summary_records > 0:
+            data = data[-self.max_summary_records:]
+
         self._save_json(self.summary_file, data)
     def save_trade_history(self, executions: List[TradeExecution], pf: Portfolio, reason: str):
         """매매 내역 저장 - Append"""
@@ -66,13 +68,13 @@ class JsonRepository:
         }
         
         data = self._load_json(self.history_file, default=[])
-        
+
         # 최신 내역이 위로 오게 할지, 아래로 가게 할지 결정 (여기선 Append -> 아래)
         data.append(record)
-        
-        # 히스토리가 무한정 길어지는 것 방지 (예: 최근 100건만 유지) - 선택사항
-        # if len(data) > 100: data = data[-100:]
-        
+
+        if self.max_history_records > 0:
+            data = data[-self.max_history_records:]
+
         self._save_json(self.history_file, data)
     def update_status(self, 
                       regime: MarketRegime, 

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,11 @@ class TradingBot:
         
         # 2. 인프라 객체 생성 (DI)
         self.data_loader = YFinanceLoader(self.logger)
-        self.repo = JsonRepository(self.config.DATA_PATH)
+        self.repo = JsonRepository(
+            self.config.DATA_PATH,
+            max_summary_records=self.config.MAX_SUMMARY_RECORDS,
+            max_history_records=self.config.MAX_HISTORY_RECORDS,
+        )
         #self.notifier = TelegramNotifier(self.config.TELEGRAM_TOKEN, self.config.TELEGRAM_CHAT_ID)
         self.notifier = SlackNotifier(self.config.SLACK_WEBHOOK_URL, self.logger)
         

--- a/tests/test_infra_repo.py
+++ b/tests/test_infra_repo.py
@@ -134,43 +134,89 @@ def test_repo_resilience_malformed_json(repo):
 
 
 
-def test_save_summary_large_file_performance(repo, dummy_market_data, dummy_portfolio):
+def test_save_summary_large_file_performance(tmp_path, dummy_market_data, dummy_portfolio):
     """
     [성능] summary.json에 데이터가 10,000개 쌓여있어도 정상적으로 Append 되는지 확인
+    (크기 제한을 11000으로 설정하여 10001건 전체가 유지되는 것을 검증)
     """
+    # max_summary_records를 충분히 크게 설정
+    large_repo = JsonRepository(root_path=str(tmp_path), max_summary_records=11000)
+
     # 1. 가짜 대용량 데이터 생성 (10,000일치)
     large_data = [
         {
-            "date": f"2020-01-{i%30+1:02d}", 
+            "date": f"2020-01-{i%30+1:02d}",
             "total_value": 10000 + i,
             "spy_price": 100 + i
-        } 
+        }
         for i in range(10000)
     ]
-    
+
     # 파일에 강제 쓰기
-    repo._save_json(repo.summary_file, large_data)
-    
+    large_repo._save_json(large_repo.summary_file, large_data)
+
     # 2. 새로운 데이터 저장 시도 (Append)
     signal = TradeSignal(0.8, [], "Performance Test")
-    
+
     # 시간 측정 가능 (선택사항)
     import time
     start = time.time()
-    
-    repo.save_daily_summary(dummy_market_data, signal, dummy_portfolio)
-    
+
+    large_repo.save_daily_summary(dummy_market_data, signal, dummy_portfolio)
+
     end = time.time()
-    
+
     # 3. 검증
     # 에러 없이 저장되었는지
-    with open(repo.summary_file, 'r') as f:
+    with open(large_repo.summary_file, 'r') as f:
         data = json.load(f)
         assert len(data) == 10001
-        
+
     # 속도 체크 (JSON 파싱 및 쓰기가 1초 이내여야 함)
     # 로컬 디스크 I/O에 따라 다르지만, 10000건 정도는 순식간이어야 함
     assert (end - start) < 1.0
+
+
+def test_summary_size_limit_applied(tmp_path, dummy_market_data, dummy_portfolio):
+    """
+    [크기 제한] summary.json이 max_summary_records를 초과하면 오래된 레코드를 잘라내는지 확인
+    """
+    limit = 5
+    repo = JsonRepository(root_path=str(tmp_path), max_summary_records=limit)
+
+    # limit + 2건 저장 → limit건만 남아야 함
+    for i in range(limit + 2):
+        market = MarketData(f"2024-01-{i+1:02d}", 100 + i, 90, 0.1, 0.1, -0.05, 15)
+        signal = TradeSignal(0.8, [], f"Day {i+1}")
+        repo.save_daily_summary(market, signal, dummy_portfolio)
+
+    with open(repo.summary_file, 'r') as f:
+        data = json.load(f)
+
+    assert len(data) == limit
+    # 최신 데이터가 유지되어야 함
+    assert data[-1]['date'] == f"2024-01-{limit+2:02d}"
+
+
+def test_history_size_limit_applied(tmp_path, dummy_portfolio):
+    """
+    [크기 제한] history.json이 max_history_records를 초과하면 오래된 레코드를 잘라내는지 확인
+    """
+    limit = 3
+    repo = JsonRepository(root_path=str(tmp_path), max_history_records=limit)
+
+    execution = TradeExecution("SPY", OrderAction.BUY, 1, 100.0, 0.1, "2024-01-01", ExecutionStatus.FILLED)
+
+    # limit + 1건 저장 → limit건만 남아야 함
+    for i in range(limit + 1):
+        repo.save_trade_history([execution], dummy_portfolio, f"Trade {i+1}")
+
+    with open(repo.history_file, 'r') as f:
+        data = json.load(f)
+
+    assert len(data) == limit
+    # 최신 레코드가 유지되어야 함
+    assert data[-1]['reason'] == f"Trade {limit+1}"
 
 # ... (기존 임포트 및 Fixture 생략) ...
 


### PR DESCRIPTION
## Summary
This PR implements configurable size limits for the JSON repository to prevent unbounded growth of `summary.json` and `history.json` files. When these limits are exceeded, the oldest records are automatically trimmed, keeping only the most recent entries.

## Key Changes

- **JsonRepository class** (`src/infra/repo.py`):
  - Added `max_summary_records` and `max_history_records` constructor parameters (defaults: 2000 and 100 respectively)
  - Implemented automatic record trimming in `save_daily_summary()` and `save_trade_history()` methods
  - Records are kept using Python's list slicing (`data[-max_records:]`) to retain only the most recent entries

- **Configuration** (`src/config.py`):
  - Added `MAX_SUMMARY_RECORDS` and `MAX_HISTORY_RECORDS` configuration constants
  - Allows centralized management of repository size limits

- **Application initialization** (`src/main.py`):
  - Updated `JsonRepository` instantiation to pass size limit parameters from config
  - Enables configuration-driven behavior without hardcoding limits

- **Test coverage** (`tests/test_infra_repo.py`):
  - Enhanced `test_save_summary_large_file_performance()` to use isolated `tmp_path` and verify 10,001 records are maintained with appropriate limit
  - Added `test_summary_size_limit_applied()` to verify summary.json trimming behavior
  - Added `test_history_size_limit_applied()` to verify history.json trimming behavior

## Implementation Details

- Size limits are applied **after** appending new records, ensuring the new record is always included
- Setting `max_*_records` to 0 or negative disables trimming for that file type
- The trimming logic preserves the most recent records while discarding older ones
- All changes are backward compatible; existing code continues to work with default limits

https://claude.ai/code/session_01YHEyLCcibm9VPeh6AsaHjJ