### PR TITLE
fix: KisPaperBroker PRICE_TR_ID를 해외주식용 HHDFS00000300으로 수정

### DIFF
--- a/src/infra/broker.py
+++ b/src/infra/broker.py
@@ -499,7 +499,7 @@ class KisBrokerBase(IBrokerAdapter):
 class KisPaperBroker(KisBrokerBase):
     """한국투자증권 모의투자 브로커 (가상거래 서버)"""
     BASE_URL = "https://openapivts.koreainvestment.com:29443"
-    PRICE_TR_ID = "FHKST01010100"
+    PRICE_TR_ID = "HHDFS00000300"  # 해외주식 현재가 조회 (실전/모의 동일 TR_ID)
     PORTFOLIO_TR_ID = "VTTS3012R"
     BUY_TR_ID = "VTTT1002U"
     SELL_TR_ID = "VTTT1006U"

--- a/tests/test_infra_broker_kis.py
+++ b/tests/test_infra_broker_kis.py
@@ -70,7 +70,7 @@ def test_kis_paper_broker_init(mock_requests, mock_logger):
     broker = KisPaperBroker('key', 'secret', '1234567890', mock_logger)
 
     assert broker.base_url == "https://openapivts.koreainvestment.com:29443"
-    assert broker.PRICE_TR_ID == "FHKST01010100"
+    assert broker.PRICE_TR_ID == "HHDFS00000300"
     assert broker.PORTFOLIO_TR_ID == "VTTS3012R"
     assert broker.cano == '12345678'
     assert broker.acnt_prdt_cd == '90'
@@ -115,10 +115,10 @@ def test_paper_broker_auth_network_error(mock_requests, mock_logger):
 
 def test_paper_broker_get_header_without_data(paper_broker, mock_requests):
     """데이터 없이 헤더 생성 (GET 요청용)"""
-    headers = paper_broker._get_header("FHKST01010100")
+    headers = paper_broker._get_header("HHDFS00000300")
 
     assert headers['authorization'] == 'Bearer test_token_123'
-    assert headers['tr_id'] == 'FHKST01010100'
+    assert headers['tr_id'] == 'HHDFS00000300'
     assert headers['appkey'] == 'test_key'
     assert 'hashkey' not in headers
 
@@ -205,6 +205,24 @@ def test_paper_broker_fetch_prices_real_mode(mock_sleep, live_broker, mock_reque
 
     args, kwargs = mock_requests.get.call_args
     # 실전 TR_ID: HHDFS00000300
+    assert kwargs['headers']['tr_id'] == 'HHDFS00000300'
+
+
+@patch('src.infra.broker.time.sleep')
+def test_paper_broker_fetch_prices_uses_overseas_tr_id(mock_sleep, paper_broker, mock_requests):
+    """모의투자 모드에서 해외주식 TR_ID(HHDFS00000300)를 사용하는지 확인.
+    FHKST01010100(국내주식)이 아닌 HHDFS00000300(해외주식)이어야 한다."""
+    price_response = MagicMock()
+    price_response.json.return_value = {
+        'rt_cd': '0',
+        'output': {'last': '150.00'}
+    }
+    mock_requests.get.return_value = price_response
+
+    paper_broker.fetch_current_prices(['SPY'])
+
+    args, kwargs = mock_requests.get.call_args
+    # 모의투자도 해외주식 현재가 TR_ID는 실전과 동일: HHDFS00000300
     assert kwargs['headers']['tr_id'] == 'HHDFS00000300'
 
 


### PR DESCRIPTION
모의투자 브로커의 PRICE_TR_ID가 국내주식 현재가 조회용 TR_ID(FHKST01010100)로
잘못 설정되어 있었음. KIS API 문서에 따르면 해외주식 현재가 조회(HHDFS00000300)는
실전/모의투자 구분 없이 동일한 TR_ID를 사용해야 함.

- src/infra/broker.py: KisPaperBroker.PRICE_TR_ID FHKST01010100 → HHDFS00000300
- tests/test_infra_broker_kis.py: 관련 assertion 수정 및 모의투자 TR_ID 검증 테스트 추가

Fixes #104

https://claude.ai/code/session_01UuNyg5Dc7RzbzyaXvMSwak