### PR TITLE
fix: KisBroker._get_hashkey 실패 시 에러 로깅 및 안전한 실패 처리 (#106)

### DIFF
--- a/src/infra/broker.py
+++ b/src/infra/broker.py
@@ -212,10 +212,13 @@ class KisBrokerBase(IBrokerAdapter):
         }
         # 주문 등 POST 요청 시 HashKey 필요
         if data:
-            headers["hashkey"] = self._get_hashkey(data)
+            hashkey = self._get_hashkey(data)
+            if hashkey is None:
+                raise ValueError("[KisBroker] HashKey 생성 실패로 주문 헤더를 생성할 수 없습니다.")
+            headers["hashkey"] = hashkey
         return headers
 
-    def _get_hashkey(self, data: dict) -> str:
+    def _get_hashkey(self, data: dict) -> Optional[str]:
         url = f"{self.base_url}/uapi/hashkey"
         try:
             res = requests.post(url, headers={
@@ -224,8 +227,9 @@ class KisBrokerBase(IBrokerAdapter):
                 "appsecret": self.app_secret
             }, json=data)
             return res.json()["HASH"]
-        except Exception:
-            return ""
+        except Exception as e:
+            self.logger.error(f"[KisBroker] HashKey 생성 실패: {e}")
+            return None
     
     def fetch_current_prices(self, tickers: List[str]) -> Dict[str, float]:
         """
@@ -405,9 +409,8 @@ class KisBrokerBase(IBrokerAdapter):
             "ORD_DVSN": "00" # 00: 지정가 (미국은 보통 지정가 사용)
         }
         
-        headers = self._get_header(tr_id, data)
-        
         try:
+            headers = self._get_header(tr_id, data)
             res = requests.post(url, headers=headers, json=data)
             resp_data = res.json()
             

--- a/tests/test_infra_broker_kis.py
+++ b/tests/test_infra_broker_kis.py
@@ -137,11 +137,44 @@ def test_paper_broker_get_header_with_data(paper_broker, mock_requests):
 
 
 def test_paper_broker_get_hashkey_failure(paper_broker, mock_requests):
-    """HashKey 조회 실패 시 빈 문자열 반환"""
+    """HashKey 조회 실패 시 None 반환 및 에러 로깅"""
     mock_requests.post.side_effect = Exception("Hash Error")
 
     result = paper_broker._get_hashkey({"test": "data"})
-    assert result == ""
+    assert result is None
+    paper_broker.logger.error.assert_called_once()
+    call_args = paper_broker.logger.error.call_args[0][0]
+    assert "HashKey 생성 실패" in call_args
+
+
+def test_paper_broker_get_hashkey_failure_logs_error_message(paper_broker, mock_requests):
+    """HashKey 조회 실패 시 원인 예외 메시지가 로그에 포함됨"""
+    mock_requests.post.side_effect = Exception("Connection timeout")
+
+    paper_broker._get_hashkey({"test": "data"})
+
+    call_args = paper_broker.logger.error.call_args[0][0]
+    assert "Connection timeout" in call_args
+
+
+def test_paper_broker_get_header_raises_on_hashkey_failure(paper_broker, mock_requests):
+    """_get_header: hashkey 생성 실패 시 ValueError 발생"""
+    mock_requests.post.side_effect = Exception("Hash Error")
+
+    with pytest.raises(ValueError, match="HashKey 생성 실패"):
+        paper_broker._get_header("VTTT1002U", {"CANO": "12345678"})
+
+
+def test_paper_broker_send_order_fails_gracefully_on_hashkey_error(paper_broker, mock_requests):
+    """_send_order: hashkey 실패 시 None 반환 (예외 전파 없음)"""
+    # 첫 번째 post(hashkey 요청)에서 예외 발생
+    mock_requests.post.side_effect = Exception("Hash service down")
+
+    order = Order('SPY', OrderAction.BUY, 10, 150.0)
+    result = paper_broker._send_order(order)
+
+    assert result is None
+    paper_broker.logger.error.assert_called()
 
 
 # --- fetch_current_prices 테스트 ---


### PR DESCRIPTION
- _get_hashkey: 예외 발생 시 self.logger.error()로 원인 기록 후 None 반환
  (기존: 예외 무시 + 빈 문자열 반환 → 디버깅 불가)
- _get_header: hashkey가 None이면 ValueError 발생으로 호출자에 실패 전파
- _send_order: _get_header 호출을 try 블록 안으로 이동하여 ValueError를 포착,
  Order Error로 로깅하고 None 반환 (기존 에러 처리 일관성 유지)

https://claude.ai/code/session_01Nnrbh9xPEeumghGgdAGGKB