### PR TITLE
fix: 테스트 실행 시 backtest 데이터 삭제 문제 해결

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -50,7 +50,8 @@ def _validate_tickers(full_df: pd.DataFrame, required: List[str], logger: TradeL
 
 
 def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
-                  execution_interval: int = 1) -> Optional[BacktestResult]:
+                  execution_interval: int = 1,
+                  output_dir: str = "docs/data/backtest") -> Optional[BacktestResult]:
     # 0. 파라미터 검증
     if execution_interval < 1:
         raise ValueError(f"execution_interval은 1 이상이어야 합니다: {execution_interval}")
@@ -76,7 +77,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
     # 3. 컴포넌트 조립
     loader = BacktestDataLoader(full_df, full_vix)
     broker = BacktestBroker(initial_cash, logger=logger)
-    backtest_data_path = "docs/data/backtest"
+    backtest_data_path = output_dir
     shutil.rmtree(backtest_data_path, ignore_errors=True)
     backtest_repo = JsonRepository(backtest_data_path)
 
@@ -315,7 +316,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
 
     # 차트 저장 (plt.show() 대신 파일로 저장)
     Path("docs").mkdir(parents=True, exist_ok=True)
-    chart_path = f"docs/data/backtest/backtest_{start_date}_{end_date}.png"
+    chart_path = f"{output_dir}/backtest_{start_date}_{end_date}.png"
     plt.figure(figsize=(12, 6))
     plt.plot(res_df['total_value'], label='Portfolio Value')
     if spy_cagr is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import sys
 import types
 import pytest
+import os
 
 # yfinance가 설치되지 않은 환경을 위한 mock 모듈 등록
 try:
@@ -12,6 +13,34 @@ except ImportError:
     sys.modules['yfinance'] = yf_mock
 
 from src.core.models import MarketData, Portfolio
+
+
+@pytest.fixture(autouse=True)
+def isolate_backtest_filesystem(tmp_path, monkeypatch):
+    """테스트 시 backtest 파일 시스템 작업을 임시 경로로 자동 격리한다.
+
+    - shutil.rmtree: 실제 docs/data/backtest 삭제 방지
+    - JsonRepository: backtest 경로 요청 시 임시 경로(tmp_path)로 리다이렉트
+    """
+    try:
+        import src.backtest.runner as runner_mod
+        from src.infra.repo import JsonRepository
+    except ImportError:
+        return  # backtest 모듈이 없는 환경에서는 건너뜀
+
+    # 1. shutil.rmtree no-op → 실제 backtest 데이터 보호
+    monkeypatch.setattr(runner_mod.shutil, "rmtree", lambda *a, **kw: None)
+
+    # 2. JsonRepository가 backtest 경로 요청 시 임시 경로로 리다이렉트
+    backtest_tmp = str(tmp_path / "backtest")
+
+    class _TmpBacktestRepo(JsonRepository):
+        def __init__(self, root_path=None, **kwargs):
+            if root_path is None or root_path == "docs/data/backtest":
+                root_path = backtest_tmp
+            super().__init__(root_path, **kwargs)
+
+    monkeypatch.setattr(runner_mod, "JsonRepository", _TmpBacktestRepo)
 
 @pytest.fixture
 def mock_market_bear():


### PR DESCRIPTION
- run_backtest()에 output_dir 파라미터 추가 (기본값: docs/data/backtest)
- conftest.py에 autouse fixture로 테스트 격리 자동화:
  - shutil.rmtree no-op 처리 → 실제 backtest 데이터 보호
  - JsonRepository를 tmp_path로 리다이렉트 → 테스트/프로덕션 파일 분리

https://claude.ai/code/session_01AYemGCMXyXxKM6jyUrBN38