### PR TITLE
fix: 백테스트 JSON 출력에 시뮬레이션 날짜 사용

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -223,10 +223,11 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
                 "nan_triggered": False,  # 정상 처리 (NaN 없음)
                 "signal_reason": signal.reason,
             })
+            sim_date_str = today.strftime("%Y-%m-%d")
             backtest_repo.save_daily_summary(market_data, signal, final_pf)
             if day_executions:
-                backtest_repo.save_trade_history(day_executions, final_pf, signal.reason)
-            backtest_repo.update_status(regime, exposure, final_pf, market_data, signal.reason)
+                backtest_repo.save_trade_history(day_executions, final_pf, signal.reason, sim_date=sim_date_str)
+            backtest_repo.update_status(regime, exposure, final_pf, market_data, signal.reason, sim_date=sim_date_str)
 
         except Exception as e:
             logger.error(f"Error on {today.date()}: {e}")

--- a/src/infra/repo.py
+++ b/src/infra/repo.py
@@ -58,21 +58,25 @@ class JsonRepository:
             data = data[-self.max_summary_records:]
 
         self._save_json(self.summary_file, data)
-    def save_trade_history(self, executions: List[TradeExecution], pf: Portfolio, reason: str):
+    def save_trade_history(self, executions: List[TradeExecution], pf: Portfolio, reason: str, sim_date: str = None):
         """매매 내역 저장 - Append"""
         if not executions:
             return
 
         # 거래 규모 계산
         trade_amt = sum(e.price * e.quantity for e in executions)
-        
-        # ID 생성 (타임스탬프 기반)
-        now_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        tx_id = f"tx_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+        # ID/날짜 생성: 시뮬레이션 날짜가 주어지면 그것을, 아니면 현재 시각 사용
+        if sim_date:
+            date_str = sim_date
+            tx_id = f"tx_{sim_date.replace('-', '')}"
+        else:
+            date_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            tx_id = f"tx_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
         record = {
             "id": tx_id,                    # [추가]
-            "date": now_str,
+            "date": date_str,
             "portfolio_value": pf.total_value, # [추가]
             "total_trade_amount": trade_amt,   # [추가]
             "reason": reason,
@@ -88,15 +92,17 @@ class JsonRepository:
             data = data[-self.max_history_records:]
 
         self._save_json(self.history_file, data)
-    def update_status(self, 
-                      regime: MarketRegime, 
-                      exposure: float, 
-                      pf: Portfolio, 
+    def update_status(self,
+                      regime: MarketRegime,
+                      exposure: float,
+                      pf: Portfolio,
                       market_data: MarketData, # [필수] 데이터 매핑을 위해 필요
-                      reason: str):            # [필수] 사유 기록
-        
+                      reason: str,
+                      sim_date: str = None):   # [백테스트] 시뮬레이션 날짜 (없으면 현재 시각)
+
+        last_updated = sim_date if sim_date else datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         status = {
-            "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "last_updated": last_updated,
             
             "strategy": {
                 "regime": regime.value,


### PR DESCRIPTION
history.json의 date/tx_id, status.json의 last_updated가
백테스트 수행 시각(datetime.now())으로 기록되던 버그를 수정.

- save_trade_history에 sim_date 파라미터 추가
  - 시뮬레이션 날짜 전달 시 date·tx_id에 해당 날짜 사용
  - 미전달 시(라이브 트레이딩) 기존 동작(datetime.now) 유지
- update_status에 sim_date 파라미터 추가
  - last_updated에 시뮬레이션 날짜 기록
- runner.py에서 두 메서드 호출 시 today 날짜를 sim_date로 전달

https://claude.ai/code/session_013Knp7Hr64TSokA7U7k7ht5