### PR TITLE
refactor: 대시보드 레이아웃을 3탭 구조로 재편성

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -15,16 +15,16 @@ body {
 
 /* 국면별 뱃지/텍스트 색상 */
 .regime-bull {
-    color: #198754; /* Success Green */
+    color: #198754;
 }
 .regime-bear {
-    color: #dc3545; /* Danger Red */
+    color: #dc3545;
 }
 .regime-sideways {
-    color: #ffc107; /* Warning Yellow */
+    color: #ffc107;
 }
 .regime-crash {
-    color: #212529; /* Dark */
+    color: #212529;
     background-color: #ffcccc;
 }
 
@@ -35,18 +35,17 @@ body {
 }
 .order-badge {
     font-size: 0.85em;
-    margin-right: 4px;
 }
 
 /* 내비게이션 활성화 버튼 스타일 */
 .btn-group .btn.active-live {
-    background-color: #198754 !important; /* 초록색 (Live) */
+    background-color: #198754 !important;
     color: white !important;
     border-color: #198754 !important;
 }
 
 .btn-group .btn.active-backtest {
-    background-color: #0dcaf0 !important; /* 하늘색 (Backtest) */
+    background-color: #0dcaf0 !important;
     color: #000 !important;
     border-color: #0dcaf0 !important;
 }
@@ -55,4 +54,119 @@ body {
 #mode-badge {
     font-size: 0.9rem;
     padding: 0.5em 0.8em;
+}
+
+/* ====== Tab Navigation ====== */
+#dashboardTabs {
+    border-bottom: none;
+}
+
+#dashboardTabs .nav-link {
+    color: #6c757d;
+    border: none;
+    border-bottom: 3px solid transparent;
+    padding: 0.75rem 1.25rem;
+    font-weight: 500;
+    transition: color 0.2s, border-color 0.2s;
+}
+
+#dashboardTabs .nav-link:hover {
+    color: #0d6efd;
+    border-bottom-color: #dee2e6;
+}
+
+#dashboardTabs .nav-link.active {
+    color: #0d6efd;
+    background-color: transparent;
+    border-bottom-color: #0d6efd;
+}
+
+/* ====== Status Banner ====== */
+.status-banner {
+    padding: 0.75rem 1.25rem;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+}
+
+.status-banner-bull {
+    background: linear-gradient(135deg, #d1e7dd, #badbcc);
+    color: #0f5132;
+}
+
+.status-banner-bear {
+    background: linear-gradient(135deg, #f8d7da, #f1aeb5);
+    color: #842029;
+}
+
+.status-banner-sideways {
+    background: linear-gradient(135deg, #fff3cd, #ffe69c);
+    color: #664d03;
+}
+
+.status-banner-crash {
+    background: linear-gradient(135deg, #dc3545, #b02a37);
+    color: #ffffff;
+}
+
+.status-banner-default {
+    background: linear-gradient(135deg, #e2e3e5, #d3d6d8);
+    color: #41464b;
+}
+
+/* ====== Time Range Selector ====== */
+#time-range-selector .btn.active {
+    background-color: #0d6efd;
+    border-color: #0d6efd;
+    color: white;
+}
+
+/* ====== Responsive ====== */
+@media (max-width: 768px) {
+    /* 탭 수평 스크롤 */
+    #dashboardTabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    #dashboardTabs .nav-link {
+        white-space: nowrap;
+        padding: 0.6rem 1rem;
+        font-size: 0.9rem;
+    }
+
+    /* 카드 높이 자동 조절 */
+    .card {
+        margin-bottom: 0.5rem;
+    }
+
+    /* 상태 배너 텍스트 축소 */
+    .status-banner {
+        font-size: 0.85rem;
+        padding: 0.6rem 1rem;
+    }
+
+    /* 차트 높이 축소 */
+    #performanceChart,
+    #strategyChart,
+    #groupAllocationChart {
+        max-height: 200px;
+    }
+}
+
+@media (max-width: 576px) {
+    .navbar-brand {
+        font-size: 1rem;
+    }
+
+    #last-updated {
+        display: none;
+    }
+
+    /* 기간 선택 버튼 축소 */
+    #time-range-selector .btn {
+        padding: 0.2rem 0.5rem;
+        font-size: 0.75rem;
+    }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,14 +13,14 @@
 </head>
 <body class="bg-light">
 
-    <!-- Navbar -->    
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <!-- Navbar -->
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <div class="d-flex align-items-center">
                 <a class="navbar-brand" href="index.html">
                     <i class="fas fa-robot me-2"></i>SolidQuant Bot
                 </a>
-                <!-- 모드 전환 버튼 그룹 추가 -->
+                <!-- 모드 전환 버튼 그룹 -->
                 <div class="btn-group btn-group-sm ms-3" role="group" aria-label="Mode Switcher">
                     <a href="index.html" id="link-live" class="btn btn-outline-light">Live</a>
                     <a href="index.html?mode=backtest" id="link-backtest" class="btn btn-outline-light">Backtest</a>
@@ -34,136 +34,295 @@
         </div>
     </nav>
 
-    <div class="container">
-        <!-- 1. 핵심 지표 (Key Metrics) -->
-        <div class="row g-4 mb-4">
-            <!-- Total Value & Return -->
-            <div class="col-md-3">
-                <div class="card h-100 border-0 shadow-sm">
-                    <div class="card-body">
-                        <h6 class="text-muted">Total Assets</h6>
-                        <h2 class="fw-bold mb-0" id="total-value">$-</h2>
-                        <div class="mt-2">
-                            <span id="daily-return" class="badge rounded-pill bg-secondary">0.00%</span>
-                            <span class="text-muted small ms-1">vs Yesterday</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Current Regime -->
-            <div class="col-md-3">
-                <div class="card h-100 border-0 shadow-sm">
-                    <div class="card-body">
-                        <h6 class="text-muted">Market Regime</h6>
-                        <h3 class="fw-bold mb-0" id="regime-text">-</h3>
-                        <div class="mt-2 text-muted small">
-                            Momentum: <span id="momentum-score">-</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Target Exposure -->
-            <div class="col-md-3">
-                <div class="card h-100 border-0 shadow-sm">
-                    <div class="card-body">
-                        <h6 class="text-muted">Target Exposure</h6>
-                        <h3 class="fw-bold mb-0" id="target-exposure">-</h3>
-                        <div class="progress mt-2" style="height: 6px;">
-                            <div id="exposure-bar" class="progress-bar bg-info" role="progressbar" style="width: 0%"></div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Risk Indicators -->
-            <div class="col-md-3">
-                <div class="card h-100 border-0 shadow-sm">
-                    <div class="card-body">
-                        <h6 class="text-muted">Risk Indicators</h6>
-                        <div class="d-flex justify-content-between align-items-center mb-1">
-                            <span>VIX</span>
-                            <span id="vix-value" class="fw-bold">-</span>
-                        </div>
-                        <div class="d-flex justify-content-between align-items-center">
-                            <span>SPY MDD</span>
-                            <span id="mdd-value" class="fw-bold text-danger">-</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
+    <!-- Tab Navigation -->
+    <div class="bg-white border-bottom shadow-sm">
+        <div class="container">
+            <ul class="nav nav-tabs border-0" id="dashboardTabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link active" id="overview-tab" data-bs-toggle="tab" data-bs-target="#overview" type="button" role="tab" aria-controls="overview" aria-selected="true">
+                        <i class="fas fa-tachometer-alt me-1"></i>Overview
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="performance-tab" data-bs-toggle="tab" data-bs-target="#performance" type="button" role="tab" aria-controls="performance" aria-selected="false">
+                        <i class="fas fa-chart-line me-1"></i>Performance
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link" id="trades-tab" data-bs-toggle="tab" data-bs-target="#trades" type="button" role="tab" aria-controls="trades" aria-selected="false">
+                        <i class="fas fa-exchange-alt me-1"></i>Trades
+                    </button>
+                </li>
+            </ul>
         </div>
+    </div>
 
-        <!-- 2. 차트 영역 (Charts) -->
-        <div class="row mb-4">
-            <!-- 메인 차트: 자산 추이 vs SPY -->
-            <div class="col-lg-8">
-                <div class="card border-0 shadow-sm h-100">
-                    <div class="card-header bg-white py-3">
-                        <h5 class="mb-0"><i class="fas fa-chart-line me-2"></i>Performance History</h5>
-                    </div>
-                    <div class="card-body">
-                        <canvas id="performanceChart" height="250"></canvas>
+    <div class="container mt-4">
+        <div class="tab-content" id="dashboardTabContent">
+
+            <!-- ==================== TAB 1: OVERVIEW ==================== -->
+            <div class="tab-pane fade show active" id="overview" role="tabpanel" aria-labelledby="overview-tab">
+
+                <!-- Status Banner -->
+                <div id="status-banner" class="status-banner mb-4">
+                    <div class="d-flex align-items-center justify-content-between flex-wrap">
+                        <div class="d-flex align-items-center">
+                            <i class="fas fa-signal me-2"></i>
+                            <span id="banner-text">Loading...</span>
+                        </div>
+                        <span id="banner-updated" class="small opacity-75"></span>
                     </div>
                 </div>
-            </div>
-            <!-- 서브 차트: 자산 구성 (Pie) -->
-            <div class="col-lg-4">
-                <div class="card border-0 shadow-sm h-100">
-                    <div class="card-header bg-white py-3">
-                        <h5 class="mb-0"><i class="fas fa-chart-pie me-2"></i>Current Holdings</h5>
-                    </div>
-                    <div class="card-body d-flex justify-content-center align-items-center">
-                        <div style="width: 250px; height: 250px;">
-                            <canvas id="allocationChart"></canvas>
-                        </div>
-                    </div>
-                    <div class="card-footer bg-white">
-                        <div class="d-flex justify-content-between">
-                            <span>Cash</span>
-                            <span id="cash-value" class="fw-bold">$-</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
 
-        <!-- 3. 전략 상세 차트 (Strategy Detail) -->
-        <!-- docs/index.html 내 Strategy Analysis 섹션 부분 수정 -->
-        <div class="row mb-4">
-            <div class="col-12">
-                <div class="card border-0 shadow-sm">
-                    <div class="card-header bg-white py-3 d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0"><i class="fas fa-microchip me-2"></i>Strategy Analysis & Decision Logic</h5>
-                        <span class="text-muted small">마우스를 그래프에 올리면 상세 지표가 표시됩니다.</span>
-                    </div>
-                    <div class="card-body">
-                        <div class="row">
-                        <!-- 왼쪽: 업그레이드된 그래프 -->
-                            <div class="col-lg-9">
-                                <canvas id="strategyChart" height="150"></canvas>
+                <!-- Key Metrics (4 cards) -->
+                <div class="row g-3 mb-4">
+                    <!-- Total Value & Return -->
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted"><i class="fas fa-wallet me-1"></i>Total Assets</h6>
+                                <h2 class="fw-bold mb-0" id="total-value">$-</h2>
+                                <div class="mt-2">
+                                    <span id="daily-return" class="badge rounded-pill bg-secondary">0.00%</span>
+                                    <span class="text-muted small ms-1">vs Yesterday</span>
+                                </div>
                             </div>
-                            <!-- 오른쪽: 전략 인사이트 (판단 근거) -->
-                            <div class="col-lg-3 border-start">
-                                <h6 class="fw-bold mb-3"><i class="fas fa-search-dollar me-2"></i>Decision Factors</h6>
+                        </div>
+                    </div>
+
+                    <!-- Current Regime -->
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted"><i class="fas fa-flag me-1"></i>Market Regime</h6>
+                                <h3 class="fw-bold mb-0" id="regime-text">-</h3>
+                                <div class="mt-1 text-muted small">
+                                    Momentum: <span id="momentum-score">-</span>
+                                </div>
+                                <div id="trigger-reason" class="mt-1 small text-muted fst-italic"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Target Exposure -->
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted"><i class="fas fa-balance-scale me-1"></i>Target Exposure</h6>
+                                <h3 class="fw-bold mb-0" id="target-exposure">-</h3>
+                                <div class="progress mt-2" style="height: 6px;">
+                                    <div id="exposure-bar" class="progress-bar bg-info" role="progressbar" style="width: 0%"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Risk Indicators -->
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted"><i class="fas fa-exclamation-triangle me-1"></i>Risk Indicators</h6>
+                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                    <span class="small">VIX</span>
+                                    <span id="vix-value" class="fw-bold">-</span>
+                                </div>
+                                <div class="d-flex justify-content-between align-items-center mb-1">
+                                    <span class="small">SPY MDD</span>
+                                    <span id="mdd-value" class="fw-bold text-danger">-</span>
+                                </div>
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <span class="small">Volatility</span>
+                                    <span id="volatility-value" class="fw-bold">-</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Holdings + Today's Activity -->
+                <div class="row g-4 mb-4">
+                    <!-- Holdings (Group Bar + Table) -->
+                    <div class="col-lg-7">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white py-3">
+                                <h5 class="mb-0"><i class="fas fa-layer-group me-2"></i>Asset Allocation</h5>
+                            </div>
+                            <div class="card-body">
+                                <div style="height: 60px;">
+                                    <canvas id="groupBarChart"></canvas>
+                                </div>
+                                <div class="table-responsive mt-3">
+                                    <table class="table table-sm table-hover mb-0">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th>Group</th>
+                                                <th>Ticker</th>
+                                                <th class="text-end">Qty</th>
+                                                <th class="text-end">Price</th>
+                                                <th class="text-end">Value</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="holdings-table-body">
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Today's Activity + Decision Factors -->
+                    <div class="col-lg-5">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white py-3">
+                                <h5 class="mb-0"><i class="fas fa-clipboard-check me-2"></i>Today's Activity</h5>
+                            </div>
+                            <div class="card-body">
+                                <!-- 오늘 거래 or 리밸런싱 불필요 -->
+                                <div id="today-activity" class="mb-3">
+                                </div>
+                                <!-- Decision Factors 인라인 -->
+                                <h6 class="fw-bold mt-3 mb-2"><i class="fas fa-search-dollar me-1"></i>Decision Factors</h6>
                                 <ul class="list-group list-group-flush small" id="decision-logic-list">
-                            <!-- JS에서 실시간으로 채워짐 -->
                                 </ul>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
 
-        <!-- 4. 매매 기록 (History Log) -->
-        <div class="row mb-5">
-            <div class="col-12">
-                <div class="card border-0 shadow-sm">
+            <!-- ==================== TAB 2: PERFORMANCE ==================== -->
+            <div class="tab-pane fade" id="performance" role="tabpanel" aria-labelledby="performance-tab">
+
+                <!-- Performance Summary Cards -->
+                <div class="row g-3 mb-4">
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted">Total Return</h6>
+                                <h3 class="fw-bold mb-0" id="perf-total-return">-</h3>
+                                <div class="small text-muted">Since inception</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted">SPY Return</h6>
+                                <h3 class="fw-bold mb-0" id="perf-spy-return">-</h3>
+                                <div class="small" id="perf-alpha">Alpha: -</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted">Max Drawdown</h6>
+                                <h3 class="fw-bold mb-0 text-danger" id="perf-max-mdd">-</h3>
+                                <div class="small text-muted" id="perf-max-mdd-date">-</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted">Current MDD</h6>
+                                <h3 class="fw-bold mb-0" id="perf-current-mdd">-</h3>
+                                <div class="small text-muted">From peak</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Performance Chart (Full Width) + Time Range Selector -->
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white py-3 d-flex justify-content-between align-items-center flex-wrap">
+                        <h5 class="mb-0"><i class="fas fa-chart-line me-2"></i>Performance History</h5>
+                        <div class="btn-group btn-group-sm" id="time-range-selector" role="group">
+                            <button type="button" class="btn btn-outline-secondary" data-range="1M">1M</button>
+                            <button type="button" class="btn btn-outline-secondary" data-range="3M">3M</button>
+                            <button type="button" class="btn btn-outline-secondary" data-range="6M">6M</button>
+                            <button type="button" class="btn btn-outline-secondary" data-range="1Y">1Y</button>
+                            <button type="button" class="btn btn-outline-secondary active" data-range="ALL">ALL</button>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div style="height: 300px;">
+                            <canvas id="performanceChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Two side-by-side charts -->
+                <div class="row g-4 mb-4">
+                    <!-- Asset Group Allocation Over Time -->
+                    <div class="col-lg-6">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white py-3">
+                                <h5 class="mb-0"><i class="fas fa-chart-area me-2"></i>Asset Group History</h5>
+                            </div>
+                            <div class="card-body">
+                                <div style="height: 250px;">
+                                    <canvas id="groupAllocationChart"></canvas>
+                                </div>
+                                <div id="group-allocation-placeholder" class="text-center text-muted py-4 d-none">
+                                    <i class="fas fa-info-circle me-1"></i>Group allocation data not available
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Strategy Chart -->
+                    <div class="col-lg-6">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white py-3">
+                                <h5 class="mb-0"><i class="fas fa-microchip me-2"></i>Strategy Analysis</h5>
+                            </div>
+                            <div class="card-body">
+                                <div style="height: 250px;">
+                                    <canvas id="strategyChart"></canvas>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ==================== TAB 3: TRADES ==================== -->
+            <div class="tab-pane fade" id="trades" role="tabpanel" aria-labelledby="trades-tab">
+
+                <!-- Trade Summary Stats -->
+                <div class="row g-3 mb-4">
+                    <div class="col-md-4">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center">
+                                <h6 class="text-muted">Total Trades</h6>
+                                <h3 class="fw-bold mb-0" id="trade-count">-</h3>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center">
+                                <h6 class="text-muted">Total Volume</h6>
+                                <h3 class="fw-bold mb-0" id="trade-volume">-</h3>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center">
+                                <h6 class="text-muted">Total Fees</h6>
+                                <h3 class="fw-bold mb-0" id="trade-fees">-</h3>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Trade History Table with Pagination -->
+                <div class="card border-0 shadow-sm mb-4">
                     <div class="card-header bg-white py-3 d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0"><i class="fas fa-history me-2"></i>Recent Trades</h5>
-                        <span class="badge bg-light text-dark border">Last 10 Actions</span>
+                        <h5 class="mb-0"><i class="fas fa-history me-2"></i>Trade History</h5>
+                        <span class="badge bg-light text-dark border" id="trade-page-info"></span>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -172,20 +331,29 @@
                                     <tr>
                                         <th>Date</th>
                                         <th>Reason</th>
-                                        <th>Scale</th>
+                                        <th class="text-end">Portfolio</th>
+                                        <th class="text-end">Amount</th>
+                                        <th class="text-end">Fees</th>
                                         <th>Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody id="history-table-body">
-                                    <!-- JS로 데이터 로드 -->
                                 </tbody>
                             </table>
                         </div>
                     </div>
+                    <!-- Pagination -->
+                    <div class="card-footer bg-white d-flex justify-content-center">
+                        <nav aria-label="Trade history pagination">
+                            <ul class="pagination pagination-sm mb-0" id="trade-pagination">
+                            </ul>
+                        </nav>
+                    </div>
                 </div>
             </div>
+
         </div>
-        
+
         <footer class="text-center text-muted pb-4">
             <small>Powered by SolidQuant & GitHub Actions</small>
         </footer>

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -1,40 +1,94 @@
 // docs/js/charts.js
 // Chart.js 차트 생성 및 관리
 
+import { filterByDateRange, getAssetGroup, formatCurrency } from './utils.js';
+
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
 let perfChart = null;
-let allocChart = null;
 let stratChart = null;
+let groupBarChartInstance = null;
+let groupAllocChart = null;
+
+// 원본 데이터 캐시 (기간 필터용)
+let cachedSummaryData = null;
 
 /**
  * Performance History 차트 렌더링 (Portfolio vs SPY 벤치마크)
+ * @param {Array} summaryData - summary 배열
+ * @param {string} range - 기간 필터 ('1M', '3M', '6M', '1Y', 'ALL')
  */
-export function renderPerformanceChart(summaryData) {
-    const labels = summaryData.map(d => d.date);
+export function renderPerformanceChart(summaryData, range) {
+    // 원본 데이터 캐시 (최초 호출 시)
+    if (range === undefined) {
+        cachedSummaryData = summaryData;
+        range = 'ALL';
+    }
 
-    // 수익률(%) 계산
-    const portfolioValues = summaryData.map(d => d.total_value);
-    const spyPrices = summaryData.map(d => d.spy_price);
+    const filtered = filterByDateRange(summaryData, range);
+    if (filtered.length === 0) return;
+
+    const labels = filtered.map(d => d.date);
+
+    // 수익률(%) 계산 - 필터된 범위의 첫 날 기준
+    const portfolioValues = filtered.map(d => d.total_value);
+    const spyPrices = filtered.map(d => d.spy_price);
     const initialPort = portfolioValues[0];
     const initialSpy = spyPrices[0];
     const portReturns = portfolioValues.map(v => (v / initialPort - 1) * 100);
     const spyReturns = spyPrices.map(v => (v / initialSpy - 1) * 100);
 
     if (perfChart) perfChart.destroy();
-    perfChart = new Chart(document.getElementById('performanceChart'), {
+
+    const canvas = document.getElementById('performanceChart');
+    if (!canvas) return;
+
+    perfChart = new Chart(canvas, {
         type: 'line',
         data: {
             labels: labels,
             datasets: [
-                { label: 'Portfolio (%)', data: portReturns, borderColor: '#0d6efd', fill: true, backgroundColor: 'rgba(13, 110, 253, 0.05)', tension: 0.1 },
-                { label: 'SPY Benchmark (%)', data: spyReturns, borderColor: '#adb5bd', borderDash: [5, 5], tension: 0.1, pointRadius: 0 }
+                {
+                    label: 'Portfolio (%)',
+                    data: portReturns,
+                    borderColor: '#0d6efd',
+                    fill: true,
+                    backgroundColor: 'rgba(13, 110, 253, 0.05)',
+                    tension: 0.1,
+                    pointRadius: portReturns.length > 50 ? 0 : 3
+                },
+                {
+                    label: 'SPY Benchmark (%)',
+                    data: spyReturns,
+                    borderColor: '#adb5bd',
+                    borderDash: [5, 5],
+                    tension: 0.1,
+                    pointRadius: 0,
+                    fill: false
+                }
             ]
         },
         options: {
-            responsive: true, maintainAspectRatio: false,
-            plugins: { tooltip: { mode: 'index', intersect: false } }
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                tooltip: { mode: 'index', intersect: false }
+            },
+            scales: {
+                y: {
+                    title: { display: true, text: 'Return (%)' }
+                }
+            }
         }
     });
+}
+
+/**
+ * 기간 필터 변경 핸들러
+ */
+export function updatePerformanceChartRange(range) {
+    if (cachedSummaryData) {
+        renderPerformanceChart(cachedSummaryData, range);
+    }
 }
 
 /**
@@ -46,7 +100,11 @@ export function renderStrategyChart(summaryData) {
     const spyMomentums = summaryData.map(d => d.spy_momentum * 100);
 
     if (stratChart) stratChart.destroy();
-    stratChart = new Chart(document.getElementById('strategyChart'), {
+
+    const canvas = document.getElementById('strategyChart');
+    if (!canvas) return;
+
+    stratChart = new Chart(canvas, {
         type: 'line',
         data: {
             labels: labels,
@@ -58,8 +116,7 @@ export function renderStrategyChart(summaryData) {
                     backgroundColor: 'rgba(23, 162, 184, 0.1)',
                     fill: true,
                     stepped: true,
-                    yAxisID: 'y',
-                    zIndex: 2
+                    yAxisID: 'y'
                 },
                 {
                     label: 'Momentum Score (%)',
@@ -68,8 +125,7 @@ export function renderStrategyChart(summaryData) {
                     borderWidth: 1,
                     fill: false,
                     pointRadius: 0,
-                    yAxisID: 'y1',
-                    zIndex: 1
+                    yAxisID: 'y1'
                 }
             ]
         },
@@ -111,43 +167,179 @@ export function renderStrategyChart(summaryData) {
 }
 
 /**
- * 현재 보유 자산 구성 차트 (Doughnut)
+ * Overview 탭 - 자산 그룹별 수평 Stacked Bar 차트
  */
-export function renderAllocationChart(statusData) {
+export function renderGroupBarChart(statusData) {
     const holdings = statusData.portfolio.holdings;
     const cash = statusData.portfolio.cash_balance;
+    const totalValue = statusData.portfolio.total_value;
 
-    const labels = holdings.map(h => h.ticker);
-    const values = holdings.map(h => h.value);
+    // 그룹별 합산
+    let groupA = 0, groupB = 0, groupC = 0;
+    holdings.forEach(h => {
+        const g = getAssetGroup(h.ticker);
+        if (g.group === 'A') groupA += h.value;
+        else if (g.group === 'B') groupB += h.value;
+        else if (g.group === 'C') groupC += h.value;
+    });
+    groupC += cash; // Cash를 C 그룹에 포함
 
-    // 현금 비중 추가
-    if (cash > 0) {
-        labels.push('Cash');
-        values.push(cash);
+    if (groupBarChartInstance) groupBarChartInstance.destroy();
+
+    const canvas = document.getElementById('groupBarChart');
+    if (!canvas) return;
+
+    groupBarChartInstance = new Chart(canvas, {
+        type: 'bar',
+        data: {
+            labels: [''],
+            datasets: [
+                {
+                    label: `A: Growth (${formatCurrency(groupA)})`,
+                    data: [totalValue > 0 ? (groupA / totalValue * 100) : 0],
+                    backgroundColor: '#0d6efd',
+                    barPercentage: 0.8
+                },
+                {
+                    label: `B: Safety (${formatCurrency(groupB)})`,
+                    data: [totalValue > 0 ? (groupB / totalValue * 100) : 0],
+                    backgroundColor: '#198754',
+                    barPercentage: 0.8
+                },
+                {
+                    label: `C: Cash (${formatCurrency(groupC)})`,
+                    data: [totalValue > 0 ? (groupC / totalValue * 100) : 0],
+                    backgroundColor: '#ffc107',
+                    barPercentage: 0.8
+                }
+            ]
+        },
+        options: {
+            indexAxis: 'y',
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                x: {
+                    stacked: true,
+                    max: 100,
+                    display: false
+                },
+                y: {
+                    stacked: true,
+                    display: false
+                }
+            },
+            plugins: {
+                legend: {
+                    position: 'bottom',
+                    labels: { boxWidth: 12, font: { size: 11 } }
+                },
+                tooltip: {
+                    callbacks: {
+                        label: function(context) {
+                            return context.dataset.label + ': ' + context.raw.toFixed(1) + '%';
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+/**
+ * Performance 탭 - 자산 그룹별 Stacked Area 차트 (시계열)
+ */
+export function renderGroupAllocationChart(summaryData) {
+    // group_a/b/c 필드가 있는지 확인
+    const hasGroupData = summaryData.some(d => d.group_a !== undefined);
+
+    const canvas = document.getElementById('groupAllocationChart');
+    const placeholder = document.getElementById('group-allocation-placeholder');
+
+    if (!hasGroupData) {
+        if (canvas) canvas.style.display = 'none';
+        if (placeholder) placeholder.classList.remove('d-none');
+        return;
     }
 
-    if (allocChart) allocChart.destroy();
-    const ctxAlloc = document.getElementById('allocationChart').getContext('2d');
-    allocChart = new Chart(ctxAlloc, {
-        type: 'doughnut',
+    if (canvas) canvas.style.display = 'block';
+    if (placeholder) placeholder.classList.add('d-none');
+
+    const labels = summaryData.map(d => d.date);
+    const groupAData = summaryData.map(d => d.group_a || 0);
+    const groupBData = summaryData.map(d => d.group_b || 0);
+    const groupCData = summaryData.map(d => d.group_c || 0);
+
+    if (groupAllocChart) groupAllocChart.destroy();
+
+    groupAllocChart = new Chart(canvas, {
+        type: 'line',
         data: {
             labels: labels,
-            datasets: [{
-                data: values,
-                backgroundColor: [
-                    '#0d6efd', '#6610f2', '#6f42c1', '#d63384',
-                    '#fd7e14', '#ffc107', '#20c997', '#adb5bd'
-                ],
-                hoverOffset: 4
-            }]
+            datasets: [
+                {
+                    label: 'A: Growth',
+                    data: groupAData,
+                    borderColor: '#0d6efd',
+                    backgroundColor: 'rgba(13, 110, 253, 0.3)',
+                    fill: true,
+                    tension: 0.1,
+                    pointRadius: groupAData.length > 50 ? 0 : 2
+                },
+                {
+                    label: 'B: Safety',
+                    data: groupBData,
+                    borderColor: '#198754',
+                    backgroundColor: 'rgba(25, 135, 84, 0.3)',
+                    fill: true,
+                    tension: 0.1,
+                    pointRadius: groupBData.length > 50 ? 0 : 2
+                },
+                {
+                    label: 'C: Cash',
+                    data: groupCData,
+                    borderColor: '#ffc107',
+                    backgroundColor: 'rgba(255, 193, 7, 0.3)',
+                    fill: true,
+                    tension: 0.1,
+                    pointRadius: groupCData.length > 50 ? 0 : 2
+                }
+            ]
         },
         options: {
             responsive: true,
             maintainAspectRatio: false,
-            plugins: {
-                legend: { position: 'bottom', labels: { boxWidth: 12 } }
+            scales: {
+                x: { display: true },
+                y: {
+                    stacked: true,
+                    title: { display: true, text: 'Value ($)' }
+                }
             },
-            cutout: '60%'
+            plugins: {
+                legend: {
+                    position: 'bottom',
+                    labels: { boxWidth: 12 }
+                },
+                tooltip: {
+                    mode: 'index',
+                    intersect: false,
+                    callbacks: {
+                        label: function(context) {
+                            return context.dataset.label + ': ' + formatCurrency(context.raw);
+                        }
+                    }
+                }
+            }
         }
+    });
+}
+
+/**
+ * 모든 차트 리사이즈 (탭 전환 시 사용)
+ */
+export function resizeAllCharts() {
+    [perfChart, stratChart, groupBarChartInstance, groupAllocChart].forEach(chart => {
+        if (chart) chart.resize();
     });
 }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,8 +1,26 @@
 // docs/js/main.js
-// 대시보드 진입점: 모드 감지, 데이터 로딩, 렌더링 오케스트레이션
+// 대시보드 진입점: 모드 감지, 데이터 로딩, 탭 라우팅, 렌더링 오케스트레이션
 
-import { renderPerformanceChart, renderStrategyChart, renderAllocationChart } from './charts.js';
-import { updateModeUI, updateSummaryCards, updateDecisionLogic, renderTradeHistory } from './ui.js';
+import {
+    renderPerformanceChart,
+    renderStrategyChart,
+    renderGroupBarChart,
+    renderGroupAllocationChart,
+    updatePerformanceChartRange,
+    resizeAllCharts
+} from './charts.js';
+
+import {
+    updateModeUI,
+    updateSummaryCards,
+    renderStatusBanner,
+    renderHoldingsTable,
+    renderTodayActivity,
+    updateDecisionLogic,
+    renderPerformanceSummaryCards,
+    renderTradeSummaryStats,
+    renderTradeHistory
+} from './ui.js';
 
 document.addEventListener('DOMContentLoaded', async function() {
     // 1. URL 파라미터에서 모드 확인 (?mode=backtest)
@@ -14,6 +32,9 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     // UI 초기화 (버튼 활성화 상태 및 배지 설정)
     updateModeUI(isBacktest);
+
+    // 2. 탭 해시 라우팅 설정
+    setupTabRouting();
 
     try {
         // 3개 JSON 파일 병렬 로드
@@ -27,13 +48,65 @@ document.addEventListener('DOMContentLoaded', async function() {
         const statusData = await statusRes.json();
         const historyData = await historyRes.json();
 
-        // 각 섹션 렌더링
+        // === Overview 탭 렌더링 ===
+        renderStatusBanner(statusData);
         updateSummaryCards(statusData, summaryData);
-        renderAllocationChart(statusData);
-        renderPerformanceChart(summaryData);
-        renderStrategyChart(summaryData);
+        renderGroupBarChart(statusData);
+        renderHoldingsTable(statusData);
+        renderTodayActivity(historyData, statusData);
         updateDecisionLogic(summaryData[summaryData.length - 1]);
-        renderTradeHistory(historyData);
+
+        // === Performance 탭 렌더링 (lazy - 탭 전환 시) ===
+        let perfRendered = false;
+        let tradesRendered = false;
+
+        function renderPerformanceTab() {
+            if (perfRendered) return;
+            renderPerformanceSummaryCards(summaryData);
+            renderPerformanceChart(summaryData);
+            renderGroupAllocationChart(summaryData);
+            renderStrategyChart(summaryData);
+            perfRendered = true;
+        }
+
+        function renderTradesTab() {
+            if (tradesRendered) return;
+            renderTradeSummaryStats(historyData);
+            renderTradeHistory(historyData);
+            tradesRendered = true;
+        }
+
+        // 탭 전환 이벤트: Chart.js hidden tab 이슈 해결
+        document.querySelectorAll('button[data-bs-toggle="tab"]').forEach(tab => {
+            tab.addEventListener('shown.bs.tab', (e) => {
+                const target = e.target.getAttribute('data-bs-target');
+
+                if (target === '#performance') {
+                    renderPerformanceTab();
+                    // Chart.js는 hidden 상태에서 렌더링하면 크기가 0이 됨 → resize
+                    setTimeout(() => resizeAllCharts(), 50);
+                } else if (target === '#trades') {
+                    renderTradesTab();
+                }
+
+                // URL 해시 업데이트
+                const tabName = target.replace('#', '');
+                history.replaceState(null, '', '#' + tabName);
+            });
+        });
+
+        // 현재 해시에 따라 해당 탭 활성화 및 렌더링
+        const currentHash = window.location.hash.replace('#', '') || 'overview';
+        if (currentHash === 'performance') {
+            activateTab('performance-tab');
+            renderPerformanceTab();
+        } else if (currentHash === 'trades') {
+            activateTab('trades-tab');
+            renderTradesTab();
+        }
+
+        // 기간 선택 버튼 이벤트 연결
+        setupTimeRangeSelector();
 
         // 마지막 업데이트 시간 표시
         document.getElementById('last-updated').innerText = `Last Update: ${statusData.last_updated || 'Unknown'}`;
@@ -46,3 +119,51 @@ document.addEventListener('DOMContentLoaded', async function() {
             </div>`);
     }
 });
+
+/**
+ * URL 해시 기반 탭 라우팅 설정
+ */
+function setupTabRouting() {
+    window.addEventListener('hashchange', () => {
+        const hash = window.location.hash.replace('#', '');
+        const tabMap = {
+            'overview': 'overview-tab',
+            'performance': 'performance-tab',
+            'trades': 'trades-tab'
+        };
+        if (tabMap[hash]) {
+            activateTab(tabMap[hash]);
+        }
+    });
+}
+
+/**
+ * 프로그래밍 방식으로 탭 활성화
+ */
+function activateTab(tabId) {
+    const tabEl = document.getElementById(tabId);
+    if (tabEl) {
+        const tab = new bootstrap.Tab(tabEl);
+        tab.show();
+    }
+}
+
+/**
+ * Performance 탭 - 기간 선택 버튼 이벤트 설정
+ */
+function setupTimeRangeSelector() {
+    const selector = document.getElementById('time-range-selector');
+    if (!selector) return;
+
+    selector.querySelectorAll('button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            // 활성 버튼 토글
+            selector.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+
+            // 차트 업데이트
+            const range = btn.dataset.range;
+            updatePerformanceChartRange(range);
+        });
+    });
+}

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -1,7 +1,16 @@
 // docs/js/ui.js
-// DOM 업데이트: 요약 카드, 결정 로직, 거래 내역
+// DOM 업데이트: 상태 배너, 요약 카드, 결정 로직, 거래 내역, 페이지네이션
 
-import { getRegimeColorClass } from './utils.js';
+import {
+    getRegimeColorClass,
+    getRegimeBannerClass,
+    getAssetGroup,
+    formatCurrency,
+    formatPercent,
+    computeReturns,
+    computeDrawdown,
+    computeTradeStats
+} from './utils.js';
 
 /**
  * 상단 내비게이션 바의 모드 버튼 및 상태 배지 업데이트
@@ -23,6 +32,25 @@ export function updateModeUI(isBacktest) {
 }
 
 /**
+ * 상태 배너 렌더링 (국면별 색상 + 주요 정보 한 줄)
+ */
+export function renderStatusBanner(statusData) {
+    const banner = document.getElementById('status-banner');
+    const bannerText = document.getElementById('banner-text');
+    const bannerUpdated = document.getElementById('banner-updated');
+
+    const strategy = statusData.strategy;
+    const regime = strategy.regime.replace('_', ' ');
+    const exposure = (strategy.target_exposure * 100).toFixed(0);
+    const reason = strategy.trigger_reason || '';
+
+    // 배너 색상 클래스 적용
+    banner.className = 'status-banner mb-4 ' + getRegimeBannerClass(strategy.regime);
+    bannerText.innerHTML = `<strong>${regime}</strong> &nbsp;|&nbsp; Exposure ${exposure}% &nbsp;|&nbsp; ${reason}`;
+    bannerUpdated.textContent = statusData.last_updated || '';
+}
+
+/**
  * 상단 4개 요약 카드 정보 업데이트
  */
 export function updateSummaryCards(statusData, summaryData) {
@@ -30,7 +58,7 @@ export function updateSummaryCards(statusData, summaryData) {
     const portfolio = statusData.portfolio;
 
     // [1] 총 자산 (Total Assets)
-    document.getElementById('total-value').innerText = `$${portfolio.total_value.toLocaleString(undefined, {minimumFractionDigits: 2})}`;
+    document.getElementById('total-value').innerText = formatCurrency(portfolio.total_value);
 
     // [1-2] 일간 수익률 계산 및 배지 업데이트 (vs Yesterday)
     const dailyReturnEl = document.getElementById('daily-return');
@@ -39,9 +67,8 @@ export function updateSummaryCards(statusData, summaryData) {
         const yesterdayVal = summaryData[summaryData.length - 2].total_value;
         const returnPct = ((todayVal / yesterdayVal) - 1) * 100;
 
-        dailyReturnEl.innerText = (returnPct >= 0 ? '+' : '') + returnPct.toFixed(2) + '%';
+        dailyReturnEl.innerText = formatPercent(returnPct);
 
-        // 수익률 상태에 따른 색상 변경
         if (returnPct > 0) {
             dailyReturnEl.className = 'badge rounded-pill bg-success';
         } else if (returnPct < 0) {
@@ -59,6 +86,12 @@ export function updateSummaryCards(statusData, summaryData) {
     // [2-2] 모멘텀 점수
     document.getElementById('momentum-score').innerText = (strategy.market_score.spy_momentum * 100).toFixed(2) + '%';
 
+    // [2-3] 트리거 사유
+    const triggerEl = document.getElementById('trigger-reason');
+    if (strategy.trigger_reason) {
+        triggerEl.innerText = strategy.trigger_reason;
+    }
+
     // [3] 목표 비중 (Target Exposure)
     const exposure = (strategy.target_exposure * 100).toFixed(0);
     document.getElementById('target-exposure').innerText = exposure + '%';
@@ -71,8 +104,98 @@ export function updateSummaryCards(statusData, summaryData) {
     mddEl.innerText = mddVal + '%';
     mddEl.className = 'fw-bold ' + (mddVal <= -10 ? 'text-danger' : 'text-dark');
 
-    // 현금 잔고 (Holdings 카드 하단)
-    document.getElementById('cash-value').innerText = `$${portfolio.cash_balance.toLocaleString(undefined, {minimumFractionDigits: 2})}`;
+    // [4-2] Volatility
+    const volEl = document.getElementById('volatility-value');
+    if (strategy.market_score.spy_volatility !== undefined) {
+        volEl.innerText = (strategy.market_score.spy_volatility * 100).toFixed(1) + '%';
+    }
+}
+
+/**
+ * 보유 자산 테이블 렌더링 (그룹별 분류)
+ */
+export function renderHoldingsTable(statusData) {
+    const tbody = document.getElementById('holdings-table-body');
+    const holdings = statusData.portfolio.holdings;
+    const cash = statusData.portfolio.cash_balance;
+
+    // 그룹별 정렬
+    const sorted = [...holdings].sort((a, b) => {
+        const ga = getAssetGroup(a.ticker);
+        const gb = getAssetGroup(b.ticker);
+        return ga.group.localeCompare(gb.group);
+    });
+
+    let rows = '';
+    sorted.forEach(h => {
+        if (h.value <= 0 && h.qty <= 0) return; // 보유량 0인 항목 제외
+        const g = getAssetGroup(h.ticker);
+        rows += `
+            <tr>
+                <td><span class="badge" style="background-color: ${g.color}">${g.group}: ${g.label}</span></td>
+                <td class="fw-bold">${h.ticker}</td>
+                <td class="text-end">${h.qty}</td>
+                <td class="text-end">${formatCurrency(h.price)}</td>
+                <td class="text-end">${formatCurrency(h.value)}</td>
+            </tr>
+        `;
+    });
+
+    // Cash 행 추가
+    if (cash > 0) {
+        rows += `
+            <tr class="table-light">
+                <td><span class="badge bg-secondary">Cash</span></td>
+                <td class="fw-bold">USD</td>
+                <td class="text-end">-</td>
+                <td class="text-end">-</td>
+                <td class="text-end">${formatCurrency(cash)}</td>
+            </tr>
+        `;
+    }
+
+    tbody.innerHTML = rows || '<tr><td colspan="5" class="text-center text-muted">No holdings</td></tr>';
+}
+
+/**
+ * 오늘의 활동 영역 렌더링
+ */
+export function renderTodayActivity(historyData, statusData) {
+    const container = document.getElementById('today-activity');
+    if (!historyData || historyData.length === 0) {
+        container.innerHTML = `
+            <div class="alert alert-light border mb-0">
+                <i class="fas fa-info-circle me-1 text-muted"></i>
+                <span class="small">No trade history available</span>
+            </div>
+        `;
+        return;
+    }
+
+    // 가장 최근 거래
+    const lastTrade = historyData[historyData.length - 1];
+    const tradeDate = lastTrade.date.split(' ')[0];
+
+    // 체결 종목 배지 생성
+    let actionsHtml = lastTrade.executions.map(ex => `
+        <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
+            ${ex.action} ${ex.ticker} (${ex.quantity})
+        </span>
+    `).join('');
+
+    container.innerHTML = `
+        <div class="border rounded p-3">
+            <div class="d-flex justify-content-between align-items-start mb-2">
+                <span class="badge bg-primary">Latest Trade</span>
+                <span class="small text-muted">${tradeDate}</span>
+            </div>
+            <p class="small text-muted mb-2">${lastTrade.reason}</p>
+            <div>${actionsHtml}</div>
+            <div class="small text-muted mt-2">
+                Amount: ${formatCurrency(lastTrade.total_trade_amount)}
+            </div>
+        </div>
+    `;
 }
 
 /**
@@ -87,19 +210,19 @@ export function updateDecisionLogic(lastData) {
     const isVixSafe = lastData.vix < 30;
 
     list.innerHTML = `
-        <li class="list-group-item d-flex justify-content-between align-items-center">
+        <li class="list-group-item d-flex justify-content-between align-items-center px-0">
             Price > MA180
             <i class="fas ${isAboveMA ? 'fa-check-circle text-success' : 'fa-times-circle text-danger'}"></i>
         </li>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
+        <li class="list-group-item d-flex justify-content-between align-items-center px-0">
             Momentum (+)
             <i class="fas ${isMomPositive ? 'fa-check-circle text-success' : 'fa-times-circle text-danger'}"></i>
         </li>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
+        <li class="list-group-item d-flex justify-content-between align-items-center px-0">
             VIX Safe (<30)
             <i class="fas ${isVixSafe ? 'fa-check-circle text-success' : 'fa-times-circle text-danger'}"></i>
         </li>
-        <li class="list-group-item mt-2 bg-light p-2 rounded">
+        <li class="list-group-item mt-2 bg-light p-2 rounded px-0">
             <small class="text-muted d-block">Current Logic:</small>
             <strong class="small">${lastData.regime}</strong>
         </li>
@@ -107,36 +230,151 @@ export function updateDecisionLogic(lastData) {
 }
 
 /**
- * 매매 기록 테이블 렌더링
+ * Performance 탭 - 성과 요약 카드 렌더링
  */
-export function renderTradeHistory(historyData) {
+export function renderPerformanceSummaryCards(summaryData) {
+    const returns = computeReturns(summaryData);
+    const drawdown = computeDrawdown(summaryData);
+
+    // Total Return
+    const totalReturnEl = document.getElementById('perf-total-return');
+    totalReturnEl.innerText = formatPercent(returns.portfolioReturn);
+    totalReturnEl.className = 'fw-bold mb-0 ' + (returns.portfolioReturn >= 0 ? 'text-success' : 'text-danger');
+
+    // SPY Return
+    const spyReturnEl = document.getElementById('perf-spy-return');
+    spyReturnEl.innerText = formatPercent(returns.spyReturn);
+    spyReturnEl.className = 'fw-bold mb-0 ' + (returns.spyReturn >= 0 ? 'text-success' : 'text-danger');
+
+    // Alpha
+    const alphaEl = document.getElementById('perf-alpha');
+    alphaEl.innerText = `Alpha: ${formatPercent(returns.alpha)}`;
+    alphaEl.className = 'small ' + (returns.alpha >= 0 ? 'text-success' : 'text-danger');
+
+    // Max Drawdown
+    document.getElementById('perf-max-mdd').innerText = (drawdown.maxMDD * 100).toFixed(2) + '%';
+    document.getElementById('perf-max-mdd-date').innerText = drawdown.maxMDDDate;
+
+    // Current MDD
+    const currentMDDEl = document.getElementById('perf-current-mdd');
+    currentMDDEl.innerText = (drawdown.currentMDD * 100).toFixed(2) + '%';
+    currentMDDEl.className = 'fw-bold mb-0 ' + (drawdown.currentMDD < -0.05 ? 'text-danger' : 'text-warning');
+}
+
+/**
+ * Trades 탭 - 거래 통계 카드 렌더링
+ */
+export function renderTradeSummaryStats(historyData) {
+    const stats = computeTradeStats(historyData);
+
+    document.getElementById('trade-count').innerText = stats.count.toLocaleString();
+    document.getElementById('trade-volume').innerText = formatCurrency(stats.totalVolume);
+    document.getElementById('trade-fees').innerText = formatCurrency(stats.totalFees);
+}
+
+// 거래 내역 페이지네이션 상태
+let currentPage = 1;
+const TRADES_PER_PAGE = 10;
+let cachedHistoryData = [];
+
+/**
+ * 매매 기록 테이블 렌더링 (페이지네이션 지원)
+ */
+export function renderTradeHistory(historyData, page) {
+    cachedHistoryData = historyData;
+    if (page !== undefined) currentPage = page;
+
     const tbody = document.getElementById('history-table-body');
     tbody.innerHTML = '';
 
-    // 최신 순 정렬 후 상위 10개만 추출
-    const recentTrades = historyData.slice().reverse().slice(0, 10);
+    // 최신 순 정렬
+    const sorted = historyData.slice().reverse();
+    const totalPages = Math.max(1, Math.ceil(sorted.length / TRADES_PER_PAGE));
 
-    if (recentTrades.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="4" class="text-center text-muted">No trade history found.</td></tr>';
+    // 현재 페이지 범위
+    if (currentPage > totalPages) currentPage = totalPages;
+    const start = (currentPage - 1) * TRADES_PER_PAGE;
+    const pageTrades = sorted.slice(start, start + TRADES_PER_PAGE);
+
+    if (pageTrades.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">No trade history found.</td></tr>';
+        renderPagination(0);
         return;
     }
 
-    recentTrades.forEach(tx => {
+    pageTrades.forEach(tx => {
         const row = document.createElement('tr');
 
         // 체결 종목 배지 생성
         let actionsHtml = tx.executions.map(ex => `
-            <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge">
+            <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
                 ${ex.action} ${ex.ticker} (${ex.quantity})
             </span>
         `).join('');
 
+        // 수수료 계산
+        let fee = tx.total_fee;
+        if (fee === undefined && tx.executions) {
+            fee = tx.executions.reduce((sum, ex) => sum + (ex.fee || 0), 0);
+        }
+
         row.innerHTML = `
             <td class="small fw-bold text-muted">${tx.date.split(' ')[0]}</td>
             <td class="small">${tx.reason}</td>
-            <td class="fw-bold text-dark">$${tx.total_trade_amount.toLocaleString(undefined, {maximumFractionDigits: 0})}</td>
+            <td class="text-end small">${tx.portfolio_value ? formatCurrency(tx.portfolio_value) : '-'}</td>
+            <td class="text-end fw-bold text-dark">${formatCurrency(tx.total_trade_amount)}</td>
+            <td class="text-end small">${fee !== undefined ? formatCurrency(fee) : '-'}</td>
             <td>${actionsHtml}</td>
         `;
         tbody.appendChild(row);
+    });
+
+    // 페이지 정보 배지
+    const pageInfo = document.getElementById('trade-page-info');
+    pageInfo.textContent = `${sorted.length} trades total`;
+
+    renderPagination(totalPages);
+}
+
+/**
+ * 페이지네이션 컨트롤 렌더링
+ */
+function renderPagination(totalPages) {
+    const pagination = document.getElementById('trade-pagination');
+    if (totalPages <= 1) {
+        pagination.innerHTML = '';
+        return;
+    }
+
+    let html = '';
+
+    // Previous
+    html += `<li class="page-item ${currentPage === 1 ? 'disabled' : ''}">
+        <a class="page-link" href="#" data-page="${currentPage - 1}">&laquo;</a>
+    </li>`;
+
+    // Page numbers
+    for (let i = 1; i <= totalPages; i++) {
+        html += `<li class="page-item ${i === currentPage ? 'active' : ''}">
+            <a class="page-link" href="#" data-page="${i}">${i}</a>
+        </li>`;
+    }
+
+    // Next
+    html += `<li class="page-item ${currentPage === totalPages ? 'disabled' : ''}">
+        <a class="page-link" href="#" data-page="${currentPage + 1}">&raquo;</a>
+    </li>`;
+
+    pagination.innerHTML = html;
+
+    // 페이지 클릭 이벤트
+    pagination.querySelectorAll('a[data-page]').forEach(a => {
+        a.addEventListener('click', (e) => {
+            e.preventDefault();
+            const page = parseInt(a.dataset.page);
+            if (page >= 1 && page <= totalPages) {
+                renderTradeHistory(cachedHistoryData, page);
+            }
+        });
     });
 }

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -14,3 +14,140 @@ export function getRegimeColorClass(regime) {
     if (regime.includes('crash')) return 'text-white bg-danger px-2 rounded';
     return 'text-muted';
 }
+
+/**
+ * 시장 국면에 따른 배너 CSS 클래스 반환
+ */
+export function getRegimeBannerClass(regime) {
+    regime = regime.toLowerCase();
+    if (regime.includes('bull')) return 'status-banner-bull';
+    if (regime.includes('crash')) return 'status-banner-crash';
+    if (regime.includes('bear')) return 'status-banner-bear';
+    if (regime.includes('sideways')) return 'status-banner-sideways';
+    return 'status-banner-default';
+}
+
+/**
+ * summary 데이터를 기간으로 필터링
+ * @param {Array} data - summary 배열
+ * @param {string} range - '1M', '3M', '6M', '1Y', 'ALL'
+ * @returns {Array} 필터링된 배열
+ */
+export function filterByDateRange(data, range) {
+    if (range === 'ALL' || !data.length) return data;
+
+    const lastDate = new Date(data[data.length - 1].date);
+    let cutoff = new Date(lastDate);
+
+    switch (range) {
+        case '1M': cutoff.setMonth(cutoff.getMonth() - 1); break;
+        case '3M': cutoff.setMonth(cutoff.getMonth() - 3); break;
+        case '6M': cutoff.setMonth(cutoff.getMonth() - 6); break;
+        case '1Y': cutoff.setFullYear(cutoff.getFullYear() - 1); break;
+        default: return data;
+    }
+
+    return data.filter(d => new Date(d.date) >= cutoff);
+}
+
+/**
+ * 누적 수익률 계산
+ * @param {Array} summaryData - summary 배열
+ * @returns {{portfolioReturn: number, spyReturn: number, alpha: number}}
+ */
+export function computeReturns(summaryData) {
+    if (!summaryData || summaryData.length < 2) {
+        return { portfolioReturn: 0, spyReturn: 0, alpha: 0 };
+    }
+    const first = summaryData[0];
+    const last = summaryData[summaryData.length - 1];
+
+    const portfolioReturn = (last.total_value / first.total_value - 1) * 100;
+    const spyReturn = (last.spy_price / first.spy_price - 1) * 100;
+    const alpha = portfolioReturn - spyReturn;
+
+    return { portfolioReturn, spyReturn, alpha };
+}
+
+/**
+ * 최대 MDD와 발생일 계산
+ * @param {Array} summaryData - summary 배열
+ * @returns {{maxMDD: number, maxMDDDate: string, currentMDD: number}}
+ */
+export function computeDrawdown(summaryData) {
+    if (!summaryData || summaryData.length === 0) {
+        return { maxMDD: 0, maxMDDDate: '-', currentMDD: 0 };
+    }
+
+    let maxMDD = 0;
+    let maxMDDDate = summaryData[0].date;
+
+    summaryData.forEach(d => {
+        if (d.mdd < maxMDD) {
+            maxMDD = d.mdd;
+            maxMDDDate = d.date;
+        }
+    });
+
+    const currentMDD = summaryData[summaryData.length - 1].mdd;
+
+    return { maxMDD, maxMDDDate, currentMDD };
+}
+
+/**
+ * 거래 내역 통계 계산
+ * @param {Array} historyData - history 배열
+ * @returns {{count: number, totalVolume: number, totalFees: number}}
+ */
+export function computeTradeStats(historyData) {
+    if (!historyData || historyData.length === 0) {
+        return { count: 0, totalVolume: 0, totalFees: 0 };
+    }
+
+    let totalVolume = 0;
+    let totalFees = 0;
+
+    historyData.forEach(tx => {
+        totalVolume += tx.total_trade_amount || 0;
+        // total_fee가 있으면 사용, 없으면 executions에서 합산
+        if (tx.total_fee !== undefined) {
+            totalFees += tx.total_fee;
+        } else if (tx.executions) {
+            totalFees += tx.executions.reduce((sum, ex) => sum + (ex.fee || 0), 0);
+        }
+    });
+
+    return { count: historyData.length, totalVolume, totalFees };
+}
+
+/**
+ * 자산 그룹 분류
+ * @param {string} ticker
+ * @returns {{group: string, label: string, color: string}}
+ */
+export function getAssetGroup(ticker) {
+    const groups = {
+        'SSO': { group: 'A', label: 'Growth', color: '#0d6efd' },
+        'QLD': { group: 'A', label: 'Growth', color: '#0d6efd' },
+        'IEF': { group: 'B', label: 'Safety', color: '#198754' },
+        'GLD': { group: 'B', label: 'Safety', color: '#198754' },
+        'PDBC': { group: 'B', label: 'Safety', color: '#198754' },
+        'SHV': { group: 'C', label: 'Cash', color: '#ffc107' },
+    };
+    return groups[ticker] || { group: '?', label: 'Other', color: '#adb5bd' };
+}
+
+/**
+ * 금액 포맷팅
+ */
+export function formatCurrency(value) {
+    return '$' + value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+/**
+ * 퍼센트 포맷팅 (부호 포함)
+ */
+export function formatPercent(value) {
+    const sign = value >= 0 ? '+' : '';
+    return sign + value.toFixed(2) + '%';
+}


### PR DESCRIPTION
단일 스크롤 페이지를 Bootstrap Tabs 기반 3탭(Overview/Performance/Trades)으로
재구성하여 사용자 페르소나별 최적 정보 제공.

Overview 탭: 상태 배너, 핵심 지표, 자산 그룹별 보유 현황, 오늘의 활동
Performance 탭: 누적 수익률/알파/MDD 카드, 기간 필터 성과 차트, 자산 그룹 추이
Trades 탭: 거래 통계, 전체 거래 내역 페이지네이션

- URL 해시 라우팅(#overview, #performance, #trades) 지원
- Chart.js hidden tab resize 처리 (lazy 초기화)
- 미활용 데이터 추가 표시: trigger_reason, spy_volatility, group_a/b/c, fees
- 모바일 반응형 대응

https://claude.ai/code/session_015ZZiWpQ2mQT9yg7uuXY2QP