### PR TITLE
refactor: CRASH 전용 분기 제거, 동일 리밸런싱 로직으로 통합

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -115,15 +115,9 @@ class TradingBot:
                 self.logger.error(msg)
                 self.notifier.send_alert(msg)
 
-            elif regime == MarketRegime.CRASH:
-                # CRASH: 매매 중단, 포지션 정보 포함 알림
-                signal = TradeSignal(0.0, [], "CRASH 감지 - 매매 중단")
-                msg = self._build_crash_alert(market_data, pre_trade_pf)
-                self.logger.error(msg)
-                self.notifier.send_alert(msg)
-
-            elif not self._is_rebalancing_due():
+            elif not self._is_rebalancing_due() and regime != MarketRegime.CRASH:
                 # 모니터링 날: 리밸런싱 인터벌 미충족 → 포트폴리오 기록만
+                # (CRASH는 긴급 상황이므로 인터벌 무시하고 즉시 리밸런싱)
                 signal = TradeSignal(exposure, [], f"{regime.value} (모니터링)")
                 self.logger.info(f">>> Step 5: Monitoring (리밸런싱 인터벌 미충족, {self.config.TRADING_INTERVAL_DAYS}일 기준)")
                 self.notifier.send_message(
@@ -131,10 +125,16 @@ class TradingBot:
                 )
 
             else:
-                # 리밸런싱 날: 전략 평가 + 필요 시 주문 실행
+                # 리밸런싱 실행 (CRASH 포함 — exposure=0으로 자연스럽게 현금화)
                 is_rebalancing_day = True
                 self.logger.info(f">>> Step 5: Rebalancing")
                 signal = self.rebalancer.generate_signal(pre_trade_pf, exposure, regime)
+
+                # CRASH 알림 발송
+                if regime == MarketRegime.CRASH:
+                    msg = self._build_crash_alert(market_data, pre_trade_pf)
+                    self.logger.error(msg)
+                    self.notifier.send_alert(msg)
 
                 if signal.has_orders:
                     self.logger.info(f"Signal Generated: {signal.reason}")
@@ -197,16 +197,14 @@ class TradingBot:
         holdings_info = "\n".join(holdings_lines)
 
         return (
-            f"🚨 CRASH Detected — 매매 중단\n"
+            f"🚨 CRASH Detected — 현금화 리밸런싱 실행\n"
             f"MDD: {market_data.spy_mdd:.1%} | VIX: {market_data.vix:.1f}\n"
             f"SPY: ${market_data.spy_price:.2f}\n"
             f"\n"
             f"📊 현재 포지션:\n"
             f"{holdings_info}\n"
             f"💰 현금: ${portfolio.total_cash:,.0f}\n"
-            f"📈 총 자산: ${portfolio.total_value:,.0f}\n"
-            f"\n"
-            f"⏸️ 사용자 액션 대기 중"
+            f"📈 총 자산: ${portfolio.total_value:,.0f}"
         )
 
 if __name__ == "__main__":

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -74,13 +74,18 @@ def test_bot_run_happy_path_no_trade(mock_dependencies):
 
 def test_bot_run_risk_condition_stop(mock_dependencies):
     """[시나리오 2: CRASH 감지]
-    CRASH 시: 전략 분석은 수행 → 매매 평가 없이 중단 → 포지션 포함 알림 → 데이터 저장
+    CRASH 시: 전략 분석 수행 → exposure=0으로 리밸런싱 실행(현금화) → 알림 → 데이터 저장
     """
     mock_dependencies['calc'].calculate.return_value = MarketData(
         "2024-01-01", 100, 90, 0.1, 0.1, -0.30, 40.0
     )
     mock_dependencies['analyzer'].analyze.return_value = MarketRegime.CRASH
     mock_dependencies['targeter'].calculate_exposure.return_value = 0.0
+
+    mock_dependencies['rebalancer'].generate_signal.return_value = TradeSignal(
+        0.0, [MagicMock()], "CRASH 현금화"
+    )
+    mock_dependencies['broker'].execute_orders.return_value = [MagicMock()]
 
     bot = TradingBot()
     bot.run()
@@ -89,16 +94,16 @@ def test_bot_run_risk_condition_stop(mock_dependencies):
     mock_dependencies['analyzer'].analyze.assert_called_once()
     mock_dependencies['targeter'].calculate_exposure.assert_called_once()
 
-    # 2. CRASH → 리밸런싱 평가 없음
-    mock_dependencies['rebalancer'].generate_signal.assert_not_called()
-    mock_dependencies['broker'].execute_orders.assert_not_called()
+    # 2. CRASH → exposure=0으로 리밸런싱 실행 (runner.py와 동일)
+    mock_dependencies['rebalancer'].generate_signal.assert_called_once()
+    mock_dependencies['broker'].execute_orders.assert_called_once()
 
-    # 3. 포지션 정보 포함 알림 전송
+    # 3. CRASH 알림 전송
     mock_dependencies['notifier'].send_alert.assert_called_once()
     alert_msg = mock_dependencies['notifier'].send_alert.call_args[0][0]
     assert "CRASH Detected" in alert_msg
     assert "현재 포지션" in alert_msg
-    assert "사용자 액션 대기" in alert_msg
+    assert "현금화 리밸런싱" in alert_msg
 
     # 4. 데이터 저장 (CRASH 날도 기록)
     mock_dependencies['repo'].save_daily_summary.assert_called_once()


### PR DESCRIPTION
main.py와 runner.py의 CRASH 처리 차이를 해소한다.
- CRASH 전용 분기(매매 중단) 제거 → 정상 리밸런싱 흐름에서 exposure=0으로 처리
- CRASH 시 리밸런싱 인터벌 무시하고 즉시 실행 (긴급 현금화)
- CRASH 알림 발송은 리밸런싱 블록 안에서 유지
- 테스트를 새 동작(CRASH → 리밸런싱 실행)에 맞게 업데이트

https://claude.ai/code/session_01Egr3DVZbmudxD5WNqyjBVE