### PR TITLE
Extract trading cycle logic into reusable TradingEngine class

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -8,8 +8,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 from src.config import Config
-from src.core.models import MarketRegime, TradeExecution, TradeSignal
+from src.core.models import TradeExecution
 from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
+from src.core.engine import TradingEngine
 from src.infra.repo import JsonRepository
 from src.utils.calculator import IndicatorCalculator
 from src.utils.logger import TradeLogger
@@ -62,7 +63,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
     tickers = []
     for group in config.ASSET_GROUPS.values():
         tickers.extend(group)
-    tickers = list(set(tickers)) # 중복 제거
+    tickers = list(set(tickers))  # 중복 제거
     if "SPY" not in tickers:
         tickers.append("SPY")  # 벤치마크 계산에 필요
 
@@ -81,131 +82,87 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
     shutil.rmtree(backtest_data_path, ignore_errors=True)
     backtest_repo = JsonRepository(backtest_data_path)
 
-    # Core Logic (그대로 재사용!)
+    # Core Logic (TradingEngine으로 조립)
     calculator = IndicatorCalculator()
     analyzer = RegimeAnalyzer()
     targeter = VolatilityTargeter(target_vol=0.15)
     rebalancer = Rebalancer(config.ASSET_GROUPS, logger=logger)
 
-    # 4. 루프 실행 (Time Travel)
-    # 실제 데이터가 있는 날짜(거래일)만 루프
-    trading_days = full_df.index
-    # 사용자가 요청한 구간으로 필터링
-    sim_days = [d for d in trading_days if start_date <= d.strftime("%Y-%m-%d") <= end_date]
-
-    all_executions: List[TradeExecution] = []
-    trade_reason_counter: Dict[str, int] = {}  # 매매 사유별 카운터
-
-    # 히스테리시스 상태 복원 (main.py 방식: repo에서 마지막 국면 로드)
+    # 히스테리시스 상태 복원 (main.py 방식과 동일)
     last_regime = backtest_repo.load_last_regime()
     if last_regime is not None:
         analyzer._prev_regime = last_regime
         logger.info(f"Restored previous regime: {last_regime.value}")
 
+    engine = TradingEngine(
+        calculator=calculator,
+        analyzer=analyzer,
+        targeter=targeter,
+        rebalancer=rebalancer,
+        broker=broker,
+        repo=backtest_repo,
+        logger=logger,
+        all_tickers=tickers,
+        trading_interval_days=execution_interval,
+        notifier=None,          # 백테스트는 알림 없음
+        is_live_trading=False,
+    )
+
+    # 4. 루프 실행 (Time Travel)
+    trading_days = full_df.index
+    sim_days = [d for d in trading_days if start_date <= d.strftime("%Y-%m-%d") <= end_date]
+
+    all_executions: List[TradeExecution] = []
+    trade_reason_counter: Dict[str, int] = {}
+
     logger.info(f"--- Starting Backtest ({len(sim_days)} trading days, interval={execution_interval}) ---")
 
     for today in sim_days:
         logger.info(f"[{today.date()}]시작")
+
         # [Time Setting] 오늘 날짜 설정
         loader.set_date(today)
         broker.set_date(today)
 
         # [Price Injection] 오늘 종가를 브로커에 주입 (종가 매매 가정)
-        current_prices = {}
         try:
-            # 가장 확실한 방법: full_df['Close']에서 추출
             close_prices = full_df['Close'].loc[today]
             current_prices = close_prices.to_dict()
-
         except Exception as e:
             logger.warning(f"[{today.date()}] 종가 추출 실패, 건너뜀: {e}")
             continue
 
         broker.set_prices(current_prices)
+        sim_date = today.strftime("%Y-%m-%d")
 
-        # 실행 간격 체크: 마지막 리밸런싱 날짜 기준 (main.py _is_rebalancing_due 방식)
-        _last_reb = backtest_repo.get_last_rebalancing_date()
-        if _last_reb is None:
-            is_execution_day = True
-        else:
-            try:
-                is_execution_day = (today - pd.Timestamp(_last_reb)).days >= execution_interval
-            except Exception:
-                is_execution_day = True
-
-        # === 봇 로직 실행 (Main.py와 동일 흐름) ===
         try:
-            # 1. 지표 계산 (항상 실행)
-            df_slice = loader.fetch_ohlcv(["SPY"], days=400)
-            vix_val = loader.fetch_vix()
-            market_data = calculator.calculate(df_slice, vix_val)
+            result = engine.run_one_cycle(loader, sim_date=sim_date)
 
-            # 2. 전략 판단 (NaN 체크 + 국면/노출도 계산)
-            nan_fields = market_data.nan_fields()
-            nan_triggered = bool(nan_fields)  # NaN 여부를 별도로 추적
-            # 국면 변화 감지를 위해 analyze() 호출 전에 캡처 (main.py 방식과 동일)
-            prev_regime_for_log = analyzer._prev_regime
-            if nan_triggered:
-                # NaN → 데이터 품질 이상으로 매매 중단 (신뢰할 수 없는 데이터로 거래 불가)
-                regime = MarketRegime.CRASH
-                exposure = 0.0
-            else:
-                regime = analyzer.analyze(market_data)
-                exposure = targeter.calculate_exposure(regime, market_data.spy_volatility)
+            all_executions.extend(result.executions)
 
-            # 국면 변화 로그 (analyzer._prev_regime은 analyze() 내부에서 자동 갱신됨)
-            if prev_regime_for_log is not None and regime != prev_regime_for_log:
-                logger.info(
-                    f"[{today.date()}] Regime Change: {prev_regime_for_log.value} → {regime.value} "
-                    f"(Price={market_data.spy_price:.2f}, MA180={market_data.spy_ma180:.2f}, "
-                    f"Momentum={market_data.spy_momentum:.4f}, VIX={market_data.vix:.1f}, MDD={market_data.spy_mdd:.2%})"
+            # 매매 사유 카운터 집계
+            if result.signal.has_orders:
+                trade_reason_counter[result.signal.reason] = (
+                    trade_reason_counter.get(result.signal.reason, 0) + 1
                 )
 
-            # 3. 포트폴리오 현황 조회 (main.py Step 4 방식 — 조건 분기 전 무조건 실행)
-            current_pf = broker.get_portfolio()
-            current_pf.current_prices = current_prices  # 가격 동기화
-
-            # 4. 조건 분기 (main.py 동기화)
-            day_executions: List[TradeExecution] = []
-            is_rebalancing_day = False
-            if nan_triggered:
-                # NaN: signal 생성 후 저장까지 진행
-                signal = TradeSignal(0.0, [], f"데이터 이상 - NaN: {', '.join(nan_fields)}")
-            elif not is_execution_day and regime != MarketRegime.CRASH:
-                # 모니터링 날: 인터벌 미충족 & non-CRASH → 리밸런싱 없이 저장만
-                signal = TradeSignal(exposure, [], f"{regime.value} (모니터링)")
-            else:
-                # 리밸런싱 실행 (CRASH는 인터벌 무시하고 즉시 실행)
-                is_rebalancing_day = True
-                signal = rebalancer.generate_signal(current_pf, exposure, regime)
-
-                if signal.has_orders:
-                    # 매매 사유 로그: 왜 매수/매도하는지 기록
+            # 백테스트 전용: 리밸런싱 상세 로그
+            if result.is_rebalancing and result.signal.has_orders:
+                logger.info(
+                    f"[{today.date()}] {result.regime.value} | Exposure={result.exposure:.2f} | "
+                    f"Reason: {result.signal.reason}"
+                )
+                logger.info(
+                    f"  Market: SPY={result.market_data.spy_price:.2f}, "
+                    f"MA180={result.market_data.spy_ma180:.2f}, "
+                    f"Momentum={result.market_data.spy_momentum:.4f}, "
+                    f"Vol={result.market_data.spy_volatility:.4f}, "
+                    f"VIX={result.market_data.vix:.1f}, MDD={result.market_data.spy_mdd:.2%}"
+                )
+                for order in result.signal.orders:
                     logger.info(
-                        f"[{today.date()}] {regime.value} | Exposure={exposure:.2f} | "
-                        f"Reason: {signal.reason}"
+                        f"  → {order.action} {order.ticker} x{order.quantity} @${order.price:.2f}"
                     )
-                    logger.info(
-                        f"  Market: SPY={market_data.spy_price:.2f}, MA180={market_data.spy_ma180:.2f}, "
-                        f"Momentum={market_data.spy_momentum:.4f}, Vol={market_data.spy_volatility:.4f}, "
-                        f"VIX={market_data.vix:.1f}, MDD={market_data.spy_mdd:.2%}"
-                    )
-                    for order in signal.orders:
-                        logger.info(
-                            f"  → {order.action} {order.ticker} x{order.quantity} @${order.price:.2f}"
-                        )
-                    day_executions = broker.execute_orders(signal.orders)
-                    all_executions.extend(day_executions)
-                    # 매매 사유 카운터 집계
-                    trade_reason_counter[signal.reason] = trade_reason_counter.get(signal.reason, 0) + 1
-
-            # 5. 결과 기록 (NaN 포함 항상 실행 — main.py 동기화)
-            final_pf = broker.get_portfolio()
-            sim_date_str = today.strftime("%Y-%m-%d")
-            rebalancing_date = sim_date_str if is_rebalancing_day else None
-            backtest_repo.save_daily_summary(market_data, signal, final_pf, regime)
-            backtest_repo.save_trade_history(day_executions, final_pf, signal.reason, sim_date=sim_date_str)
-            backtest_repo.update_status(regime, exposure, final_pf, market_data, signal.reason, sim_date=sim_date_str, rebalancing_date=rebalancing_date)
 
         except Exception as e:
             logger.error(f"Error on {today.date()}: {e}")

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -1,0 +1,279 @@
+# src/core/engine.py
+import time
+from typing import List, Optional, Tuple
+
+import pandas as pd
+
+from src.core.interfaces import IDataProvider, IBrokerAdapter, IRepository, ILogger, INotifier
+from src.core.models import (
+    MarketData, MarketRegime, Portfolio, TradeSignal, TradeExecution, DayResult
+)
+from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
+from src.utils.calculator import IndicatorCalculator
+
+
+class TradingEngine:
+    """핵심 트레이딩 사이클 엔진.
+
+    main.py (실시간)와 runner.py (백테스트) 모두 이 엔진을 재사용한다.
+    환경별 차이는 주입되는 구현체(broker, data_provider, notifier)가 담당하며,
+    비즈니스 로직 자체는 단일 위치(이 클래스)에서만 관리된다.
+    """
+
+    def __init__(
+        self,
+        calculator: IndicatorCalculator,
+        analyzer: RegimeAnalyzer,
+        targeter: VolatilityTargeter,
+        rebalancer: Rebalancer,
+        broker: IBrokerAdapter,
+        repo: IRepository,
+        logger: ILogger,
+        all_tickers: List[str],
+        trading_interval_days: int = 5,
+        notifier: Optional[INotifier] = None,  # 백테스트는 None
+        is_live_trading: bool = False,
+    ):
+        self.calculator = calculator
+        self.analyzer = analyzer
+        self.targeter = targeter
+        self.rebalancer = rebalancer
+        self.broker = broker
+        self.repo = repo
+        self.logger = logger
+        self.all_tickers = all_tickers
+        self.trading_interval_days = trading_interval_days
+        self.notifier = notifier
+        self.is_live_trading = is_live_trading
+
+    def run_one_cycle(
+        self,
+        data_provider: IDataProvider,
+        sim_date: Optional[str] = None,
+    ) -> DayResult:
+        """하루치 트레이딩 사이클 전체를 실행한다.
+
+        Args:
+            data_provider: OHLCV / VIX 데이터 소스.
+                실시간: YFinanceLoader, 백테스트: BacktestDataLoader
+            sim_date: 시뮬레이션 날짜 ("YYYY-MM-DD").
+                None이면 오늘 날짜 사용 (실시간 모드).
+
+        Returns:
+            DayResult: 사이클 실행 결과 (regime, signal, executions, portfolio 등)
+        """
+        # Step 1~2: 데이터 수집 & 지표 계산
+        self.logger.info(">>> Step 1: Data Collection")
+        spy_df = data_provider.fetch_ohlcv(["SPY"], days=400)
+        vix = data_provider.fetch_vix()
+
+        self.logger.info(">>> Step 2: Indicator Calculation")
+        market_data = self.calculator.calculate(spy_df, vix)
+        self.logger.info(
+            f"Market Data: Price={market_data.spy_price}, "
+            f"VIX={market_data.vix}, MDD={market_data.spy_mdd:.2%}"
+        )
+
+        # Step 3: 국면 분석
+        self.logger.info(">>> Step 3: Strategy Analysis")
+        regime, exposure, nan_fields = self._analyze_regime(market_data)
+        self.logger.info(f"Regime: {regime.value} | Target Exposure: {exposure:.2f}")
+
+        # Step 4: 포트폴리오 조회 + 실시간 가격
+        self.logger.info(">>> Step 4: Portfolio Status")
+        portfolio = self._get_portfolio()
+        self.logger.info(
+            f"Current Portfolio: Cash=${portfolio.total_cash:,.0f}, "
+            f"Value=${portfolio.total_value:,.0f}"
+        )
+
+        # Step 5: 조건 분기 & 실행
+        signal, executions, final_pf, is_rebalancing = self._execute_cycle(
+            market_data, portfolio, regime, exposure, nan_fields, sim_date
+        )
+
+        # Step 6: 저장
+        self.logger.info(">>> Step 6: Archiving Data")
+        self._persist(market_data, signal, executions, final_pf, regime, exposure, is_rebalancing, sim_date)
+
+        return DayResult(
+            market_data=market_data,
+            regime=regime,
+            exposure=exposure,
+            signal=signal,
+            executions=executions,
+            final_pf=final_pf,
+            is_rebalancing=is_rebalancing,
+            nan_fields=nan_fields,
+        )
+
+    # ── Private helpers ───────────────────────────────────────────────────────
+
+    def _analyze_regime(
+        self, market_data: MarketData
+    ) -> Tuple[MarketRegime, float, List[str]]:
+        """NaN 감지 + 국면/노출도 계산."""
+        nan_fields = market_data.nan_fields()
+        prev_regime = self.analyzer._prev_regime
+
+        if nan_fields:
+            self.logger.error(
+                f"NaN detected in: {', '.join(nan_fields)}. Treating as CRASH."
+            )
+            regime = MarketRegime.CRASH
+            exposure = 0.0
+        else:
+            regime = self.analyzer.analyze(market_data)
+            exposure = self.targeter.calculate_exposure(regime, market_data.spy_volatility)
+
+        # 국면 변화 로그
+        if prev_regime is not None and regime != prev_regime:
+            self.logger.info(
+                f"Regime Change: {prev_regime.value} → {regime.value} "
+                f"(Price={market_data.spy_price:.2f}, MA180={market_data.spy_ma180:.2f}, "
+                f"Momentum={market_data.spy_momentum:.4f}, "
+                f"VIX={market_data.vix:.1f}, MDD={market_data.spy_mdd:.2%})"
+            )
+
+        return regime, exposure, nan_fields
+
+    def _get_portfolio(self) -> Portfolio:
+        """포트폴리오 조회 후 실시간 가격 업데이트."""
+        portfolio = self.broker.get_portfolio()
+        self.logger.info("Fetching Real-time prices from Broker...")
+        real_time_prices = self.broker.fetch_current_prices(self.all_tickers)
+        for ticker, price in real_time_prices.items():
+            if price > 0:
+                portfolio.current_prices[ticker] = price
+        return portfolio
+
+    def _execute_cycle(
+        self,
+        market_data: MarketData,
+        portfolio: Portfolio,
+        regime: MarketRegime,
+        exposure: float,
+        nan_fields: List[str],
+        sim_date: Optional[str],
+    ) -> Tuple[TradeSignal, List[TradeExecution], Portfolio, bool]:
+        """3-way 조건 분기: NaN이상 / 모니터링 / 리밸런싱."""
+        executions: List[TradeExecution] = []
+        final_pf = portfolio
+        is_rebalancing = False
+
+        if nan_fields:
+            signal = TradeSignal(0.0, [], f"데이터 이상 - NaN: {', '.join(nan_fields)}")
+            msg = (
+                f"⚠️ Data Quality Alert — 매매 중단\n"
+                f"날짜: {market_data.date}\n"
+                f"NaN 필드: {', '.join(nan_fields)}\n"
+                f"데이터 품질 이상으로 매매를 중단합니다."
+            )
+            self.logger.error(msg)
+            self._notify_alert(msg)
+
+        elif not self._is_due(sim_date) and regime != MarketRegime.CRASH:
+            signal = TradeSignal(exposure, [], f"{regime.value} (모니터링)")
+            self.logger.info(
+                f">>> Step 5: Monitoring "
+                f"(리밸런싱 인터벌 미충족, {self.trading_interval_days}일 기준)"
+            )
+            self._notify_message(
+                f"모니터링 완료. {regime.value} | ${portfolio.total_value:,.0f}"
+            )
+
+        else:
+            is_rebalancing = True
+            self.logger.info(">>> Step 5: Rebalancing")
+            signal = self.rebalancer.generate_signal(portfolio, exposure, regime)
+
+            # CRASH 알림 발송
+            if regime == MarketRegime.CRASH:
+                crash_msg = self._build_crash_alert(market_data, portfolio)
+                self.logger.error(crash_msg)
+                self._notify_alert(crash_msg)
+
+            if signal.has_orders:
+                self.logger.info(f"Signal Generated: {signal.reason}")
+                self.logger.info(f"Executing {len(signal.orders)} orders...")
+                executions = self.broker.execute_orders(signal.orders)
+
+                if executions:
+                    self._notify_message(f"✅ Orders Executed. Count: {len(executions)}")
+                    if self.is_live_trading:
+                        time.sleep(3)
+                    final_pf = self.broker.get_portfolio()
+                    self.logger.info(
+                        f"Updated Portfolio: Cash=${final_pf.total_cash:,.0f}, "
+                        f"Value=${final_pf.total_value:,.0f}"
+                    )
+                else:
+                    self._notify_alert("⚠️ Orders sent but NO execution result returned.")
+            else:
+                self.logger.info("No Rebalance Needed.")
+                self._notify_message(f"Bot Finished. Hold. ({regime.value})")
+
+        return signal, executions, final_pf, is_rebalancing
+
+    def _is_due(self, sim_date: Optional[str]) -> bool:
+        """마지막 리밸런싱 이후 trading_interval_days 이상 경과했으면 True."""
+        last_str = self.repo.get_last_rebalancing_date()
+        if last_str is None:
+            return True
+        try:
+            last = pd.Timestamp(last_str)
+            today = pd.Timestamp(sim_date) if sim_date else pd.Timestamp.today().normalize()
+            return (today - last).days >= self.trading_interval_days
+        except Exception:
+            return True  # 파싱 실패 시 안전하게 리밸런싱 실행
+
+    def _persist(
+        self,
+        market_data: MarketData,
+        signal: TradeSignal,
+        executions: List[TradeExecution],
+        final_pf: Portfolio,
+        regime: MarketRegime,
+        exposure: float,
+        is_rebalancing: bool,
+        sim_date: Optional[str],
+    ) -> None:
+        """저장 3종 호출."""
+        rebalancing_date = (sim_date or market_data.date) if is_rebalancing else None
+        self.repo.save_daily_summary(market_data, signal, final_pf, regime)
+        self.repo.save_trade_history(executions, final_pf, signal.reason, sim_date=sim_date)
+        self.repo.update_status(
+            regime, exposure, final_pf, market_data, signal.reason,
+            sim_date=sim_date,
+            rebalancing_date=rebalancing_date,
+        )
+
+    def _build_crash_alert(self, market_data: MarketData, portfolio: Portfolio) -> str:
+        """CRASH 알림 메시지 생성 (포지션 정보 포함)."""
+        holdings_lines = []
+        for ticker, qty in portfolio.holdings.items():
+            if qty > 0:
+                price = portfolio.current_prices.get(ticker, 0)
+                value = qty * price
+                holdings_lines.append(f"  • {ticker}: {qty}주 (${value:,.0f})")
+        if not holdings_lines:
+            holdings_lines.append("  • (보유 종목 없음)")
+        holdings_info = "\n".join(holdings_lines)
+        return (
+            f"🚨 CRASH Detected — 현금화 리밸런싱 실행\n"
+            f"MDD: {market_data.spy_mdd:.1%} | VIX: {market_data.vix:.1f}\n"
+            f"SPY: ${market_data.spy_price:.2f}\n"
+            f"\n"
+            f"📊 현재 포지션:\n"
+            f"{holdings_info}\n"
+            f"💰 현금: ${portfolio.total_cash:,.0f}\n"
+            f"📈 총 자산: ${portfolio.total_value:,.0f}"
+        )
+
+    def _notify_message(self, msg: str) -> None:
+        if self.notifier:
+            self.notifier.send_message(msg)
+
+    def _notify_alert(self, msg: str) -> None:
+        if self.notifier:
+            self.notifier.send_alert(msg)

--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Dict
+from typing import List, Dict, Optional
 import pandas as pd
 from src.core.models import Portfolio, Order, MarketData, TradeSignal, MarketRegime, TradeExecution
 
@@ -51,3 +51,20 @@ class INotifier(ABC):
     def send_message(self, message: str) -> None: ...
     @abstractmethod
     def send_alert(self, message: str) -> None: ...
+
+class IRepository(ABC):
+    @abstractmethod
+    def get_last_rebalancing_date(self) -> Optional[str]: ...
+    @abstractmethod
+    def load_last_regime(self) -> Optional[MarketRegime]: ...
+    @abstractmethod
+    def save_daily_summary(self, market_data: MarketData, signal: TradeSignal,
+                           portfolio: Portfolio, regime: MarketRegime) -> None: ...
+    @abstractmethod
+    def save_trade_history(self, executions: List[TradeExecution], portfolio: Portfolio,
+                           reason: str, sim_date: Optional[str] = None) -> None: ...
+    @abstractmethod
+    def update_status(self, regime: MarketRegime, exposure: float, portfolio: Portfolio,
+                      market_data: MarketData, reason: str,
+                      sim_date: Optional[str] = None,
+                      rebalancing_date: Optional[str] = None) -> None: ...

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -91,3 +91,15 @@ class TradeExecution:
     date: str     # 체결 시간
     status: ExecutionStatus
     reason: str = "" # 거부 사유 등
+
+@dataclass
+class DayResult:
+    """하루치 트레이딩 사이클 실행 결과"""
+    market_data: MarketData
+    regime: MarketRegime
+    exposure: float
+    signal: TradeSignal
+    executions: List[TradeExecution]
+    final_pf: Portfolio
+    is_rebalancing: bool
+    nan_fields: List[str]

--- a/src/infra/repo.py
+++ b/src/infra/repo.py
@@ -5,9 +5,10 @@ from typing import List, Dict, Optional
 from dataclasses import asdict
 from datetime import datetime
 from src.core.models import MarketData, Portfolio, TradeSignal, MarketRegime, TradeExecution
+from src.core.interfaces import IRepository
 from src.config import Config
 
-class JsonRepository:
+class JsonRepository(IRepository):
     def __init__(self, root_path: str = "docs/data", max_summary_records: int = 2000, max_history_records: int = 100):
         self.root = root_path
         self.max_summary_records = max_summary_records

--- a/src/main.py
+++ b/src/main.py
@@ -1,23 +1,19 @@
 # src/main.py
 import sys
 import traceback
-import pandas as pd
-import time
-
-# 모듈 경로 설정
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
 from src.config import Config
 from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
+from src.core.engine import TradingEngine
 from src.utils.calculator import IndicatorCalculator
 from src.utils.logger import TradeLogger
 from src.infra.data import YFinanceLoader
 from src.infra.broker import MockBroker, KisPaperBroker, KisLiveBroker
-from src.infra.notifier import TelegramNotifier
 from src.infra.notifier import SlackNotifier
 from src.infra.repo import JsonRepository
-from src.core.models import MarketRegime, Portfolio, MarketData, TradeSignal
+
 
 class TradingBot:
     def __init__(self):
@@ -27,14 +23,13 @@ class TradingBot:
 
         self.logger.info("=== Initializing Trading Bot ===")
 
-        # 2. 인프라 객체 생성 (DI)
+        # 2. 인프라 객체 생성
         self.data_loader = YFinanceLoader(self.logger)
         self.repo = JsonRepository(
             self.config.DATA_PATH,
             max_summary_records=self.config.MAX_SUMMARY_RECORDS,
             max_history_records=self.config.MAX_HISTORY_RECORDS,
         )
-        #self.notifier = TelegramNotifier(self.config.TELEGRAM_TOKEN, self.config.TELEGRAM_CHAT_ID)
         self.notifier = SlackNotifier(self.config.SLACK_WEBHOOK_URL, self.logger)
 
         # 브로커 선택 (실전 vs 모의)
@@ -44,17 +39,17 @@ class TradingBot:
                 self.config.KIS_APP_KEY,
                 self.config.KIS_APP_SECRET,
                 self.config.KIS_ACC_NO,
-                self.logger
+                self.logger,
             )
         else:
             self.logger.info("Mode: PAPER TRADING (MockBroker)")
-            self.broker = MockBroker(initial_cash=10000.0, logger=self.logger) # 테스트용 초기자금
+            self.broker = MockBroker(initial_cash=10000.0, logger=self.logger)
 
-        # 3. 도메인 서비스 및 유틸 생성
-        self.calculator = IndicatorCalculator()
+        # 3. 도메인 서비스 생성
+        calculator = IndicatorCalculator()
         self.analyzer = RegimeAnalyzer()
-        self.targeter = VolatilityTargeter(target_vol=0.15)
-        self.rebalancer = Rebalancer(self.config.ASSET_GROUPS, logger=self.logger)
+        targeter = VolatilityTargeter(target_vol=0.15)
+        rebalancer = Rebalancer(self.config.ASSET_GROUPS, logger=self.logger)
 
         # 4. 히스테리시스 상태 복원 (프로세스 재시작 시 이전 국면 유지)
         last_regime = self.repo.load_last_regime()
@@ -62,160 +57,35 @@ class TradingBot:
             self.analyzer._prev_regime = last_regime
             self.logger.info(f"Restored previous regime: {last_regime.value}")
 
+        # 5. TradingEngine 조립
+        all_tickers = sum(self.config.ASSET_GROUPS.values(), [])
+        self.engine = TradingEngine(
+            calculator=calculator,
+            analyzer=self.analyzer,
+            targeter=targeter,
+            rebalancer=rebalancer,
+            broker=self.broker,
+            repo=self.repo,
+            logger=self.logger,
+            all_tickers=all_tickers,
+            trading_interval_days=self.config.TRADING_INTERVAL_DAYS,
+            notifier=self.notifier,
+            is_live_trading=self.config.IS_LIVE_TRADING,
+        )
+
     def run(self):
         try:
-            # ── Step 1: 데이터 수집 (항상 실행) ──────────────────────────────
-            self.logger.info(">>> Step 1: Data Collection")
-            spy_df = self.data_loader.fetch_ohlcv(["SPY"], days=400)
-            vix = self.data_loader.fetch_vix()
-
-            # ── Step 2: 지표 계산 (항상 실행) ──────────────────────────────
-            self.logger.info(">>> Step 2: Indicator Calculation")
-            market_data = self.calculator.calculate(spy_df, vix)
-            self.logger.info(f"Market Data: Price={market_data.spy_price}, VIX={market_data.vix}, MDD={market_data.spy_mdd:.2%}")
-
-            # ── Step 3: 전략 분석 (항상 실행) ──────────────────────────────
-            self.logger.info(">>> Step 3: Strategy Analysis")
-            nan_fields = market_data.nan_fields()
-            # 국면 변화 감지를 위해 analyze() 호출 전에 캡처
-            prev_regime_for_log = self.analyzer._prev_regime
-            if nan_fields:
-                self.logger.error(f"NaN detected in: {', '.join(nan_fields)}. Treating as CRASH.")
-                regime = MarketRegime.CRASH
-                exposure = 0.0
-            else:
-                regime = self.analyzer.analyze(market_data)
-                exposure = self.targeter.calculate_exposure(regime, market_data.spy_volatility)
-            self.logger.info(f"Regime: {regime.value} | Target Exposure: {exposure:.2f}")
-
-            # 국면 변화 로그
-            if prev_regime_for_log is not None and regime != prev_regime_for_log:
-                self.logger.info(
-                    f"Regime Change: {prev_regime_for_log.value} → {regime.value} "
-                    f"(Price={market_data.spy_price:.2f}, MA180={market_data.spy_ma180:.2f}, "
-                    f"Momentum={market_data.spy_momentum:.4f}, VIX={market_data.vix:.1f}, MDD={market_data.spy_mdd:.2%})"
-                )
-
-            # ── Step 4: 포트폴리오 현황 조회 (항상 실행) ──────────────────
-            self.logger.info(">>> Step 4: Portfolio Status")
-            pre_trade_pf = self.broker.get_portfolio()
-            self.logger.info(f"Current Portfolio: Cash=${pre_trade_pf.total_cash:,.0f}, Value=${pre_trade_pf.total_value:,.0f}")
-
-            self.logger.info("Fetching Real-time prices from Broker...")
-            all_tickers = sum(self.config.ASSET_GROUPS.values(), [])
-            real_time_prices = self.broker.fetch_current_prices(all_tickers)
-            for t, price in real_time_prices.items():
-                if price > 0:
-                    pre_trade_pf.current_prices[t] = price
-
-            # ── Step 5: 조건 분기 ──────────────────────────────────────────
-            final_pf = pre_trade_pf
-            executions = []
-            is_rebalancing_day = False
-
-            if nan_fields:
-                # NaN: 데이터 품질 이상 → 매매 중단, 알림만
-                signal = TradeSignal(0.0, [], f"데이터 이상 - NaN: {', '.join(nan_fields)}")
-                msg = (
-                    f"⚠️ Data Quality Alert — 매매 중단\n"
-                    f"날짜: {market_data.date}\n"
-                    f"NaN 필드: {', '.join(nan_fields)}\n"
-                    f"데이터 품질 이상으로 매매를 중단합니다."
-                )
-                self.logger.error(msg)
-                self.notifier.send_alert(msg)
-
-            elif not self._is_rebalancing_due() and regime != MarketRegime.CRASH:
-                # 모니터링 날: 리밸런싱 인터벌 미충족 → 포트폴리오 기록만
-                # (CRASH는 긴급 상황이므로 인터벌 무시하고 즉시 리밸런싱)
-                signal = TradeSignal(exposure, [], f"{regime.value} (모니터링)")
-                self.logger.info(f">>> Step 5: Monitoring (리밸런싱 인터벌 미충족, {self.config.TRADING_INTERVAL_DAYS}일 기준)")
-                self.notifier.send_message(
-                    f"모니터링 완료. {regime.value} | ${pre_trade_pf.total_value:,.0f}"
-                )
-
-            else:
-                # 리밸런싱 실행 (CRASH 포함 — exposure=0으로 자연스럽게 현금화)
-                is_rebalancing_day = True
-                self.logger.info(f">>> Step 5: Rebalancing")
-                signal = self.rebalancer.generate_signal(pre_trade_pf, exposure, regime)
-
-                # CRASH 알림 발송
-                if regime == MarketRegime.CRASH:
-                    msg = self._build_crash_alert(market_data, pre_trade_pf)
-                    self.logger.error(msg)
-                    self.notifier.send_alert(msg)
-
-                if signal.has_orders:
-                    self.logger.info(f"Signal Generated: {signal.reason}")
-                    self.logger.info(f"Executing {len(signal.orders)} orders...")
-
-                    executions = self.broker.execute_orders(signal.orders)
-
-                    if executions:
-                        msg = f"✅ Orders Executed. Count: {len(executions)}"
-                        self.notifier.send_message(msg)
-                        if self.config.IS_LIVE_TRADING:
-                            time.sleep(3)
-
-                        final_pf = self.broker.get_portfolio()
-                        self.logger.info(f"Updated Portfolio: Cash=${final_pf.total_cash:,.0f}, Value=${final_pf.total_value:,.0f}")
-                    else:
-                        self.notifier.send_alert("⚠️ Orders sent but NO execution result returned.")
-                else:
-                    self.logger.info("No Rebalance Needed.")
-                    self.notifier.send_message(f"Bot Finished. Hold. ({regime.value})")
-
-            # ── Step 6: 데이터 저장 (항상 실행) ───────────────────────────
-            self.logger.info(">>> Step 6: Archiving Data")
-            rebalancing_date = market_data.date if is_rebalancing_day else None
-            self.repo.save_daily_summary(market_data, signal, final_pf, regime)
-            self.repo.save_trade_history(executions, final_pf, signal.reason)
-            self.repo.update_status(regime, exposure, final_pf, market_data, signal.reason,
-                                    rebalancing_date=rebalancing_date)
-
+            self.engine.run_one_cycle(self.data_loader)
         except Exception as e:
             error_msg = f"Critical Error:\n{traceback.format_exc()}"
             self.logger.error(error_msg)
             self.notifier.send_alert(f"🔥 Bot Crashed!\n{str(e)}")
-            raise e # GitHub Actions 실패 처리를 위해 raise
+            raise e  # GitHub Actions 실패 처리를 위해 raise
 
     def _is_rebalancing_due(self) -> bool:
-        """마지막 리밸런싱 이후 TRADING_INTERVAL_DAYS 이상 경과했으면 True"""
-        last_date_str = self.repo.get_last_rebalancing_date()
-        if last_date_str is None:
-            return True  # 최초 실행 → 항상 리밸런싱
-        try:
-            last_date = pd.Timestamp(last_date_str)
-            today = pd.Timestamp.today().normalize()
-            return (today - last_date).days >= self.config.TRADING_INTERVAL_DAYS
-        except Exception:
-            return True  # 파싱 실패 시 안전하게 리밸런싱 실행
+        """후방 호환성 유지 — engine._is_due()에 위임."""
+        return self.engine._is_due(sim_date=None)
 
-    def _build_crash_alert(self, market_data: MarketData, portfolio: Portfolio) -> str:
-        """CRASH 알림 메시지 생성 (포지션 정보 포함)"""
-        holdings_lines = []
-        for ticker, qty in portfolio.holdings.items():
-            if qty > 0:
-                price = portfolio.current_prices.get(ticker, 0)
-                value = qty * price
-                holdings_lines.append(f"  • {ticker}: {qty}주 (${value:,.0f})")
-
-        if not holdings_lines:
-            holdings_lines.append("  • (보유 종목 없음)")
-
-        holdings_info = "\n".join(holdings_lines)
-
-        return (
-            f"🚨 CRASH Detected — 현금화 리밸런싱 실행\n"
-            f"MDD: {market_data.spy_mdd:.1%} | VIX: {market_data.vix:.1f}\n"
-            f"SPY: ${market_data.spy_price:.2f}\n"
-            f"\n"
-            f"📊 현재 포지션:\n"
-            f"{holdings_info}\n"
-            f"💰 현금: ${portfolio.total_cash:,.0f}\n"
-            f"📈 총 자산: ${portfolio.total_value:,.0f}"
-        )
 
 if __name__ == "__main__":
     bot = TradingBot()

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1,0 +1,418 @@
+# tests/test_core_engine.py
+"""TradingEngine 단위 테스트.
+
+모든 외부 의존성(broker, repo, notifier, data_provider)을 Mock으로 격리하여
+TradingEngine의 비즈니스 로직을 검증한다.
+"""
+import pytest
+from unittest.mock import MagicMock, patch, call
+from src.core.engine import TradingEngine
+from src.core.models import (
+    MarketData, MarketRegime, Portfolio, TradeSignal, TradeExecution,
+    Order, OrderAction, ExecutionStatus, DayResult
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# 공통 헬퍼
+# ─────────────────────────────────────────────────────────────────
+
+def _make_market_data(nan_vol=False) -> MarketData:
+    import math
+    return MarketData(
+        date="2024-01-10",
+        spy_price=450.0,
+        spy_ma180=420.0,
+        spy_volatility=math.nan if nan_vol else 0.12,
+        spy_momentum=0.05,
+        spy_mdd=-0.08,
+        vix=18.0,
+    )
+
+
+def _make_portfolio(cash=10000.0) -> Portfolio:
+    return Portfolio(
+        total_cash=cash,
+        holdings={"SSO": 10},
+        current_prices={"SSO": 100.0},
+    )
+
+
+def _make_engine(
+    repo_last_reb=None,
+    notifier=None,
+    trading_interval_days=5,
+    is_live_trading=False,
+):
+    """공통 TradingEngine Mock 조립."""
+    calculator = MagicMock()
+    analyzer = MagicMock()
+    analyzer._prev_regime = None
+    targeter = MagicMock()
+    rebalancer = MagicMock()
+    broker = MagicMock()
+    repo = MagicMock()
+    logger = MagicMock()
+    data_provider = MagicMock()
+
+    # 기본값 세팅
+    repo.get_last_rebalancing_date.return_value = repo_last_reb
+    broker.get_portfolio.return_value = _make_portfolio()
+    broker.fetch_current_prices.return_value = {}
+
+    engine = TradingEngine(
+        calculator=calculator,
+        analyzer=analyzer,
+        targeter=targeter,
+        rebalancer=rebalancer,
+        broker=broker,
+        repo=repo,
+        logger=logger,
+        all_tickers=["SSO", "IEF", "SHV"],
+        trading_interval_days=trading_interval_days,
+        notifier=notifier,
+        is_live_trading=is_live_trading,
+    )
+
+    return engine, {
+        "calculator": calculator,
+        "analyzer": analyzer,
+        "targeter": targeter,
+        "rebalancer": rebalancer,
+        "broker": broker,
+        "repo": repo,
+        "logger": logger,
+        "data_provider": data_provider,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 1: 정상 리밸런싱 사이클
+# ─────────────────────────────────────────────────────────────────
+
+def test_rebalancing_cycle_executes_orders():
+    """인터벌 충족 + BULL → 주문 실행, DayResult.is_rebalancing=True"""
+    engine, mocks = _make_engine(repo_last_reb=None)  # 최초 실행 → 인터벌 충족
+    md = _make_market_data()
+    fake_order = Order("SSO", OrderAction.BUY, 5, 100.0)
+    fake_exec = TradeExecution("SSO", OrderAction.BUY, 5, 100.0, 0.1, "2024-01-10", ExecutionStatus.FILLED)
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [fake_order], "Rebalance")
+    mocks["broker"].execute_orders.return_value = [fake_exec]
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    assert result.is_rebalancing is True
+    assert result.regime == MarketRegime.BULL
+    assert result.executions == [fake_exec]
+    mocks["broker"].execute_orders.assert_called_once()
+    mocks["repo"].save_daily_summary.assert_called_once()
+    mocks["repo"].save_trade_history.assert_called_once()
+    mocks["repo"].update_status.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 2: 모니터링 사이클 (인터벌 미충족, non-CRASH)
+# ─────────────────────────────────────────────────────────────────
+
+def test_monitoring_cycle_skips_orders():
+    """최근 리밸런싱(1일 전) + BULL → 주문 없음, is_rebalancing=False"""
+    from datetime import date, timedelta
+    yesterday = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+    engine, mocks = _make_engine(repo_last_reb=yesterday)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    assert result.is_rebalancing is False
+    assert result.executions == []
+    mocks["rebalancer"].generate_signal.assert_not_called()
+    mocks["broker"].execute_orders.assert_not_called()
+    # 저장은 수행
+    mocks["repo"].save_daily_summary.assert_called_once()
+    _, kwargs = mocks["repo"].update_status.call_args
+    assert kwargs.get("rebalancing_date") is None
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 3: CRASH 사이클 (인터벌 무관하게 즉시 리밸런싱)
+# ─────────────────────────────────────────────────────────────────
+
+def test_crash_bypasses_interval():
+    """CRASH 국면은 인터벌(1일 전) 무관하게 리밸런싱 실행."""
+    from datetime import date, timedelta
+    yesterday = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+    engine, mocks = _make_engine(repo_last_reb=yesterday)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.CRASH
+    mocks["targeter"].calculate_exposure.return_value = 0.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(0.0, [], "CRASH Hold")
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    assert result.is_rebalancing is True
+    mocks["rebalancer"].generate_signal.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 4: NaN 데이터 → 매매 중단
+# ─────────────────────────────────────────────────────────────────
+
+def test_nan_data_skips_trade():
+    """NaN 필드 감지 → analyzer/targeter 미호출, 주문 없음, exposure=0."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    md = _make_market_data(nan_vol=True)  # spy_volatility = NaN
+
+    mocks["calculator"].calculate.return_value = md
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    assert result.nan_fields == ["spy_volatility"]
+    assert result.exposure == 0.0
+    assert result.signal.orders == []
+    assert result.is_rebalancing is False
+    mocks["analyzer"].analyze.assert_not_called()
+    mocks["targeter"].calculate_exposure.assert_not_called()
+    mocks["broker"].execute_orders.assert_not_called()
+    # 저장은 수행
+    mocks["repo"].save_daily_summary.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 5: 최초 실행 (last_rebalancing_date=None → is_due=True)
+# ─────────────────────────────────────────────────────────────────
+
+def test_first_run_is_always_due():
+    """마지막 리밸런싱 기록 없음 → _is_due()=True → 리밸런싱 실행."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [], "Hold")
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    assert result.is_rebalancing is True
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 6: sim_date 전달 → 저장 시 해당 날짜 사용
+# ─────────────────────────────────────────────────────────────────
+
+def test_sim_date_passed_to_repo():
+    """sim_date='2023-06-01' 전달 시 repo.save_trade_history에 해당 날짜 전달됨."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [], "Hold")
+
+    engine.run_one_cycle(mocks["data_provider"], sim_date="2023-06-01")
+
+    _, kwargs = mocks["repo"].save_trade_history.call_args
+    assert kwargs.get("sim_date") == "2023-06-01"
+
+    _, kwargs = mocks["repo"].update_status.call_args
+    assert kwargs.get("sim_date") == "2023-06-01"
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 7: notifier=None → 알림 없이 정상 동작
+# ─────────────────────────────────────────────────────────────────
+
+def test_no_notifier_does_not_raise():
+    """notifier=None (백테스트 모드)이어도 예외 없이 사이클 완료."""
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=None)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [], "Hold")
+
+    result = engine.run_one_cycle(mocks["data_provider"])  # 예외 없어야 함
+    assert isinstance(result, DayResult)
+
+
+# ─────────────────────────────────────────────────────────────────
+# 알림 시나리오
+# ─────────────────────────────────────────────────────────────────
+
+def test_nan_sends_alert_with_notifier():
+    """NaN 감지 시 notifier.send_alert()가 호출되고 메시지에 'Data Quality Alert' 포함."""
+    notifier = MagicMock()
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=notifier)
+    md = _make_market_data(nan_vol=True)
+
+    mocks["calculator"].calculate.return_value = md
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    notifier.send_alert.assert_called_once()
+    msg = notifier.send_alert.call_args[0][0]
+    assert "Data Quality Alert" in msg
+    assert "spy_volatility" in msg
+
+
+def test_crash_sends_alert_with_notifier():
+    """CRASH 국면 시 notifier.send_alert()가 호출되고 'CRASH Detected' 포함."""
+    notifier = MagicMock()
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=notifier)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.CRASH
+    mocks["targeter"].calculate_exposure.return_value = 0.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(0.0, [], "CRASH")
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    notifier.send_alert.assert_called_once()
+    msg = notifier.send_alert.call_args[0][0]
+    assert "CRASH Detected" in msg
+    assert "현재 포지션" in msg
+
+
+def test_orders_executed_sends_message():
+    """주문 성공 시 notifier.send_message()가 '✅ Orders Executed' 포함하여 호출됨."""
+    notifier = MagicMock()
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=notifier)
+    md = _make_market_data()
+    fake_order = Order("SSO", OrderAction.BUY, 5, 100.0)
+    fake_exec = TradeExecution("SSO", OrderAction.BUY, 5, 100.0, 0.0, "2024-01-10", ExecutionStatus.FILLED)
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [fake_order], "Buy")
+    mocks["broker"].execute_orders.return_value = [fake_exec]
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    calls = [str(c) for c in notifier.send_message.call_args_list]
+    assert any("Orders Executed" in c for c in calls)
+
+
+def test_empty_executions_sends_alert():
+    """주문 전송 후 빈 체결 결과 시 notifier.send_alert() '⚠️ NO execution result' 호출."""
+    notifier = MagicMock()
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=notifier)
+    md = _make_market_data()
+    fake_order = Order("SSO", OrderAction.BUY, 5, 100.0)
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [fake_order], "Buy")
+    mocks["broker"].execute_orders.return_value = []  # 빈 체결
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    notifier.send_alert.assert_called_once()
+    msg = notifier.send_alert.call_args[0][0]
+    assert "NO execution result" in msg
+
+
+# ─────────────────────────────────────────────────────────────────
+# _is_due() 단위 테스트
+# ─────────────────────────────────────────────────────────────────
+
+def test_is_due_no_history():
+    """마지막 리밸런싱 없음 → True."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    assert engine._is_due(None) is True
+
+
+def test_is_due_recent_date():
+    """1일 전 리밸런싱 (인터벌 5일) → False."""
+    from datetime import date, timedelta
+    yesterday = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+    engine, mocks = _make_engine(repo_last_reb=yesterday, trading_interval_days=5)
+    assert engine._is_due(None) is False
+
+
+def test_is_due_old_date():
+    """10일 전 리밸런싱 (인터벌 5일) → True."""
+    from datetime import date, timedelta
+    old = (date.today() - timedelta(days=10)).strftime("%Y-%m-%d")
+    engine, mocks = _make_engine(repo_last_reb=old, trading_interval_days=5)
+    assert engine._is_due(None) is True
+
+
+def test_is_due_with_sim_date():
+    """sim_date 기준으로 인터벌 판단 (백테스트 시뮬레이션)."""
+    engine, mocks = _make_engine(repo_last_reb="2023-01-01", trading_interval_days=5)
+    assert engine._is_due("2023-01-10") is True   # 9일 경과 → True
+    assert engine._is_due("2023-01-03") is False  # 2일 경과 → False
+
+
+def test_is_due_invalid_date_returns_true():
+    """파싱 불가 날짜 → 안전하게 True."""
+    engine, mocks = _make_engine(repo_last_reb="not-a-date")
+    assert engine._is_due(None) is True
+
+
+# ─────────────────────────────────────────────────────────────────
+# rebalancing_date 전달 검증
+# ─────────────────────────────────────────────────────────────────
+
+def test_rebalancing_date_set_on_rebalancing_day():
+    """리밸런싱 날: update_status에 market_data.date가 rebalancing_date로 전달."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    md = _make_market_data()  # date="2024-01-10"
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [], "Hold")
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    _, kwargs = mocks["repo"].update_status.call_args
+    assert kwargs.get("rebalancing_date") == "2024-01-10"
+
+
+def test_rebalancing_date_none_on_monitoring_day():
+    """모니터링 날: update_status에 rebalancing_date=None이 전달."""
+    from datetime import date, timedelta
+    yesterday = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+    engine, mocks = _make_engine(repo_last_reb=yesterday)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    _, kwargs = mocks["repo"].update_status.call_args
+    assert kwargs.get("rebalancing_date") is None
+
+
+def test_rebalancing_date_uses_sim_date_when_provided():
+    """sim_date 지정 시 rebalancing_date에 sim_date가 사용됨."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [], "Hold")
+
+    engine.run_one_cycle(mocks["data_provider"], sim_date="2023-06-01")
+
+    _, kwargs = mocks["repo"].update_status.call_args
+    assert kwargs.get("rebalancing_date") == "2023-06-01"

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -275,7 +275,7 @@ class TestTradingBotEdgeCases:
                 'rebalancer': rebalancer
             }
 
-    @patch('src.main.time.sleep')
+    @patch('src.core.engine.time.sleep')
     def test_bot_live_trading_mode_init(self, mock_sleep, mock_deps_live):
         """실전 모드에서 KisLiveBroker가 초기화되는지 확인 (lines 38-40)"""
         from src.main import TradingBot
@@ -295,7 +295,7 @@ class TestTradingBotEdgeCases:
         # KisLiveBroker가 사용되었는지 확인
         mock_deps_live['repo'].save_daily_summary.assert_called()
 
-    @patch('src.main.time.sleep')
+    @patch('src.core.engine.time.sleep')
     def test_bot_live_trading_with_execution(self, mock_sleep, mock_deps_live):
         """실전 모드에서 매매 실행 후 sleep(3) 호출 확인 (line 104)"""
         from src.main import TradingBot


### PR DESCRIPTION
## Summary
Refactored the core trading cycle logic from `main.py` into a new `TradingEngine` class that can be reused by both real-time trading (`main.py`) and backtesting (`runner.py`). This eliminates code duplication and establishes a single source of truth for the trading algorithm.

## Key Changes

- **New `TradingEngine` class** (`src/core/engine.py`):
  - Encapsulates the complete 6-step trading cycle (data collection → indicator calculation → regime analysis → portfolio status → execution logic → data persistence)
  - Accepts injected dependencies (calculator, analyzer, targeter, rebalancer, broker, repo, logger, notifier)
  - Provides `run_one_cycle()` method that returns a `DayResult` object with all cycle outputs
  - Handles all conditional branching: NaN detection, monitoring vs. rebalancing, CRASH regime handling
  - Supports both real-time and backtesting modes via optional `sim_date` parameter

- **New `DayResult` dataclass** (`src/core/models.py`):
  - Captures complete cycle output: market data, regime, exposure, signal, executions, portfolio, rebalancing flag, NaN fields
  - Enables clean return value from `run_one_cycle()`

- **Updated `IRepository` interface** (`src/core/interfaces.py`):
  - Formalized repository contract with abstract methods for persistence operations

- **Refactored `main.py`**:
  - Removed 170+ lines of inline trading logic
  - Now instantiates `TradingEngine` with all dependencies and calls `engine.run_one_cycle()`
  - Maintains identical behavior while being significantly simpler

- **Refactored `runner.py`** (backtest):
  - Replaced inline trading loop logic with `engine.run_one_cycle(loader, sim_date=sim_date)`
  - Removed duplicate regime analysis, signal generation, and persistence code
  - Now reuses exact same engine as production

- **Comprehensive unit tests** (`tests/test_core_engine.py`):
  - 418 lines of tests covering all scenarios: rebalancing cycles, monitoring cycles, CRASH handling, NaN detection, interval logic, notifier integration
  - All external dependencies mocked for isolation
  - Tests verify correct behavior for first run, sim_date handling, and all notification paths

## Notable Implementation Details

- **Hysteresis preservation**: Engine respects `analyzer._prev_regime` state for regime change detection
- **Flexible date handling**: `sim_date` parameter enables backtesting while defaulting to current date for live trading
- **Graceful degradation**: Works with `notifier=None` for backtesting mode
- **Interval logic**: `_is_due()` method centralizes rebalancing interval calculation with safe date parsing
- **CRASH override**: CRASH regime bypasses trading interval for immediate risk mitigation
- **NaN safety**: Detects invalid data and halts trading with alerts before any analysis

https://claude.ai/code/session_01DH3cw8cuygwAXnY3xaws6G