### PR TITLE
fix: SCHD가 Other로 표시되는 브라우저 캐시 문제 해결

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -358,6 +358,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/main.js?v=2"></script>
 </body>
 </html>

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -1,7 +1,7 @@
 // docs/js/charts.js
 // Chart.js 차트 생성 및 관리
 
-import { filterByDateRange, getAssetGroup, formatCurrency } from './utils.js';
+import { filterByDateRange, getAssetGroup, formatCurrency } from './utils.js?v=2';
 
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
 let perfChart = null;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -9,7 +9,7 @@ import {
     renderGroupAllocationChart,
     updatePerformanceChartRange,
     resizeAllCharts
-} from './charts.js';
+} from './charts.js?v=2';
 
 import {
     updateModeUI,
@@ -21,7 +21,7 @@ import {
     renderPerformanceSummaryCards,
     renderTradeSummaryStats,
     renderTradeHistory
-} from './ui.js';
+} from './ui.js?v=2';
 
 document.addEventListener('DOMContentLoaded', async function() {
     // 1. URL 파라미터에서 모드 확인 (?mode=backtest)
@@ -39,11 +39,13 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     try {
         // 4개 JSON 파일 병렬 로드 (asset_groups.json은 현재 모드 데이터 경로 기준)
+        // cache-bust: 브라우저 캐시로 인한 구 버전 데이터 방지
+        const cacheBust = `v=${Date.now()}`;
         const [summaryRes, statusRes, historyRes, groupConfigRes] = await Promise.all([
-            fetch(`${dataPath}summary.json`),
-            fetch(`${dataPath}status.json`),
-            fetch(`${dataPath}history.json`),
-            fetch(`${dataPath}asset_groups.json`)
+            fetch(`${dataPath}summary.json?${cacheBust}`),
+            fetch(`${dataPath}status.json?${cacheBust}`),
+            fetch(`${dataPath}history.json?${cacheBust}`),
+            fetch(`${dataPath}asset_groups.json?${cacheBust}`)
         ]);
 
         const summaryData = await summaryRes.json();

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -10,7 +10,7 @@ import {
     computeReturns,
     computeDrawdown,
     computeTradeStats
-} from './utils.js';
+} from './utils.js?v=2';
 
 /**
  * 상단 내비게이션 바의 모드 버튼 및 상태 배지 업데이트


### PR DESCRIPTION
- 구 버전 utils.js의 하드코딩된 ticker 매핑(SSO, QLD, IEF, GLD, PDBC, SHV)에
  SCHD가 없어서 브라우저 캐시 시 Other로 분류되는 문제
- JS 모듈 import에 ?v=2 캐시버스팅 추가 (index.html, main.js, charts.js, ui.js)
- JSON fetch에 Date.now() 기반 캐시버스팅 추가하여 항상 최신 데이터 로드

https://claude.ai/code/session_01Uu822mnVwF4DEMfPoPk6wB