### PR TITLE
feat: Performance 탭에 포트폴리오 vs SPY 벤치마크 비교 테이블 추가

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -193,42 +193,25 @@
             <!-- ==================== TAB 2: PERFORMANCE ==================== -->
             <div class="tab-pane fade" id="performance" role="tabpanel" aria-labelledby="performance-tab">
 
-                <!-- Performance Summary Cards -->
-                <div class="row g-3 mb-4">
-                    <div class="col-md-6 col-lg-3">
-                        <div class="card h-100 border-0 shadow-sm">
-                            <div class="card-body">
-                                <h6 class="text-muted">Total Return</h6>
-                                <h3 class="fw-bold mb-0" id="perf-total-return">-</h3>
-                                <div class="small text-muted">Since inception</div>
-                            </div>
-                        </div>
+                <!-- Performance Comparison Table -->
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white py-3">
+                        <h5 class="mb-0"><i class="fas fa-chart-bar me-2"></i>Portfolio vs SPY Benchmark</h5>
                     </div>
-                    <div class="col-md-6 col-lg-3">
-                        <div class="card h-100 border-0 shadow-sm">
-                            <div class="card-body">
-                                <h6 class="text-muted">SPY Return</h6>
-                                <h3 class="fw-bold mb-0" id="perf-spy-return">-</h3>
-                                <div class="small" id="perf-alpha">Alpha: -</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-6 col-lg-3">
-                        <div class="card h-100 border-0 shadow-sm">
-                            <div class="card-body">
-                                <h6 class="text-muted">Max Drawdown</h6>
-                                <h3 class="fw-bold mb-0 text-danger" id="perf-max-mdd">-</h3>
-                                <div class="small text-muted" id="perf-max-mdd-date">-</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-6 col-lg-3">
-                        <div class="card h-100 border-0 shadow-sm">
-                            <div class="card-body">
-                                <h6 class="text-muted">Current MDD</h6>
-                                <h3 class="fw-bold mb-0" id="perf-current-mdd">-</h3>
-                                <div class="small text-muted">From peak</div>
-                            </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0 align-middle" id="metrics-comparison-table">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th class="ps-3">Metric</th>
+                                        <th class="text-end">Portfolio</th>
+                                        <th class="text-end pe-3">SPY (Benchmark)</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr><td class="ps-3 text-muted" colspan="3">Loading...</td></tr>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -9,7 +9,8 @@ import {
     formatPercent,
     computeReturns,
     computeDrawdown,
-    computeTradeStats
+    computeTradeStats,
+    computeAdvancedMetrics
 } from './utils.js?v=2';
 
 /**
@@ -230,35 +231,72 @@ export function updateDecisionLogic(lastData) {
 }
 
 /**
- * Performance 탭 - 성과 요약 카드 렌더링
+ * Performance 탭 - 포트폴리오 vs SPY 비교 테이블 렌더링
  */
 export function renderPerformanceSummaryCards(summaryData) {
-    const returns = computeReturns(summaryData);
-    const drawdown = computeDrawdown(summaryData);
+    const metrics = computeAdvancedMetrics(summaryData);
+    const p = metrics.portfolio;
+    const s = metrics.spy;
 
-    // Total Return
-    const totalReturnEl = document.getElementById('perf-total-return');
-    totalReturnEl.innerText = formatPercent(returns.portfolioReturn);
-    totalReturnEl.className = 'fw-bold mb-0 ' + (returns.portfolioReturn >= 0 ? 'text-success' : 'text-danger');
+    // 지표 정의: [label, portValue, spyValue, format, higherIsBetter]
+    const rows = [
+        ['Total Return', p.totalReturn, s.totalReturn, 'percent', true],
+        ['CAGR', p.cagr, s.cagr, 'percent', true],
+        ['Max Drawdown', p.mdd, s.mdd, 'percent', false],
+        ['Volatility', p.volatility, s.volatility, 'percent_abs', false],
+        ['Sharpe Ratio', p.sharpe, s.sharpe, 'ratio', true],
+        ['Sortino Ratio', p.sortino, s.sortino, 'ratio', true],
+        ['Calmar Ratio', p.calmar, s.calmar, 'ratio', true],
+        ['Beta', p.beta, s.beta, 'ratio', null],
+    ];
 
-    // SPY Return
-    const spyReturnEl = document.getElementById('perf-spy-return');
-    spyReturnEl.innerText = formatPercent(returns.spyReturn);
-    spyReturnEl.className = 'fw-bold mb-0 ' + (returns.spyReturn >= 0 ? 'text-success' : 'text-danger');
+    function fmt(value, format) {
+        if (format === 'percent') {
+            const sign = value >= 0 ? '+' : '';
+            return sign + value.toFixed(2) + '%';
+        }
+        if (format === 'percent_abs') {
+            return value.toFixed(2) + '%';
+        }
+        return value.toFixed(2);
+    }
 
-    // Alpha
-    const alphaEl = document.getElementById('perf-alpha');
-    alphaEl.innerText = `Alpha: ${formatPercent(returns.alpha)}`;
-    alphaEl.className = 'small ' + (returns.alpha >= 0 ? 'text-success' : 'text-danger');
+    // 우열 판단: 포트폴리오가 우수하면 text-success, 열위하면 text-danger
+    function compareClass(portVal, spyVal, higherIsBetter) {
+        if (higherIsBetter === null) return ''; // Beta는 비교 안 함
+        if (Math.abs(portVal - spyVal) < 0.005) return ''; // 거의 동일
+        if (higherIsBetter) {
+            return portVal > spyVal ? 'text-success fw-bold' : 'text-danger';
+        } else {
+            // MDD, Volatility: 낮을수록 좋음 (MDD는 음수이므로 더 큰 값이 좋음)
+            return portVal > spyVal ? 'text-success fw-bold' : 'text-danger';
+        }
+    }
 
-    // Max Drawdown
-    document.getElementById('perf-max-mdd').innerText = (drawdown.maxMDD * 100).toFixed(2) + '%';
-    document.getElementById('perf-max-mdd-date').innerText = drawdown.maxMDDDate;
+    const tbody = document.querySelector('#metrics-comparison-table tbody');
+    let html = '';
+    rows.forEach(([label, portVal, spyVal, format, higherIsBetter]) => {
+        const portClass = compareClass(portVal, spyVal, higherIsBetter);
+        html += `
+            <tr>
+                <td class="ps-3">${label}</td>
+                <td class="text-end ${portClass}">${fmt(portVal, format)}</td>
+                <td class="text-end pe-3">${fmt(spyVal, format)}</td>
+            </tr>
+        `;
+    });
 
-    // Current MDD
-    const currentMDDEl = document.getElementById('perf-current-mdd');
-    currentMDDEl.innerText = (drawdown.currentMDD * 100).toFixed(2) + '%';
-    currentMDDEl.className = 'fw-bold mb-0 ' + (drawdown.currentMDD < -0.05 ? 'text-danger' : 'text-warning');
+    // Alpha 행 (포트폴리오 전용)
+    const alpha = p.totalReturn - s.totalReturn;
+    const alphaClass = alpha >= 0 ? 'text-success fw-bold' : 'text-danger fw-bold';
+    html += `
+        <tr class="table-light">
+            <td class="ps-3 fw-bold">Alpha</td>
+            <td class="text-end ${alphaClass}" colspan="2">${alpha >= 0 ? '+' : ''}${alpha.toFixed(2)}%</td>
+        </tr>
+    `;
+
+    tbody.innerHTML = html;
 }
 
 /**

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -138,6 +138,93 @@ export function getAssetGroup(ticker, groupConfig) {
 }
 
 /**
+ * 포트폴리오 & SPY 벤치마크 고급 지표 계산
+ * @param {Array} summaryData - summary 배열 (total_value, spy_price 포함)
+ * @returns {{portfolio: Object, spy: Object}} 양쪽 지표 객체
+ */
+export function computeAdvancedMetrics(summaryData) {
+    const empty = { totalReturn: 0, cagr: 0, mdd: 0, volatility: 0, sharpe: 0, sortino: 0, calmar: 0, beta: 1.0 };
+    if (!summaryData || summaryData.length < 2) {
+        return { portfolio: { ...empty }, spy: { ...empty, beta: 1.0 } };
+    }
+
+    const first = summaryData[0];
+    const last = summaryData[summaryData.length - 1];
+    const n = summaryData.length;
+
+    // 기간 (연 단위)
+    const msPerYear = 365.25 * 24 * 60 * 60 * 1000;
+    const years = Math.max((new Date(last.date) - new Date(first.date)) / msPerYear, 1 / 365);
+
+    // 일간 수익률 배열
+    const portReturns = [];
+    const spyReturns = [];
+    for (let i = 1; i < n; i++) {
+        portReturns.push(summaryData[i].total_value / summaryData[i - 1].total_value - 1);
+        spyReturns.push(summaryData[i].spy_price / summaryData[i - 1].spy_price - 1);
+    }
+
+    function calcMetrics(values, dailyReturns) {
+        const firstVal = values[0];
+        const lastVal = values[values.length - 1];
+        const totalReturn = (lastVal / firstVal - 1) * 100;
+        const cagr = (Math.pow(lastVal / firstVal, 1 / years) - 1) * 100;
+
+        // MDD
+        let peak = -Infinity;
+        let mdd = 0;
+        values.forEach(v => {
+            if (v > peak) peak = v;
+            const dd = (v - peak) / peak;
+            if (dd < mdd) mdd = dd;
+        });
+        mdd = mdd * 100;
+
+        // Volatility (연환산)
+        const meanRet = dailyReturns.reduce((s, r) => s + r, 0) / dailyReturns.length;
+        const variance = dailyReturns.reduce((s, r) => s + Math.pow(r - meanRet, 2), 0) / dailyReturns.length;
+        const volatility = Math.sqrt(variance) * Math.sqrt(252) * 100;
+
+        // Sharpe Ratio (무위험 수익률 0 가정)
+        const sharpe = volatility !== 0 ? (meanRet / Math.sqrt(variance)) * Math.sqrt(252) : 0;
+
+        // Sortino Ratio (하방 변동성만)
+        const downsideReturns = dailyReturns.filter(r => r < 0);
+        const downsideVariance = downsideReturns.length > 0
+            ? downsideReturns.reduce((s, r) => s + Math.pow(r, 2), 0) / dailyReturns.length
+            : 0;
+        const downsideStd = Math.sqrt(downsideVariance);
+        const sortino = downsideStd !== 0 ? (meanRet / downsideStd) * Math.sqrt(252) : 0;
+
+        // Calmar Ratio (CAGR / |MDD|)
+        const calmar = mdd !== 0 ? (cagr / 100) / Math.abs(mdd / 100) : 0;
+
+        return { totalReturn, cagr, mdd, volatility, sharpe, sortino, calmar };
+    }
+
+    const portValues = summaryData.map(d => d.total_value);
+    const spyValues = summaryData.map(d => d.spy_price);
+
+    const portMetrics = calcMetrics(portValues, portReturns);
+    const spyMetrics = calcMetrics(spyValues, spyReturns);
+
+    // Beta = Cov(port, spy) / Var(spy)
+    const meanPort = portReturns.reduce((s, r) => s + r, 0) / portReturns.length;
+    const meanSpy = spyReturns.reduce((s, r) => s + r, 0) / spyReturns.length;
+    let cov = 0, varSpy = 0;
+    for (let i = 0; i < portReturns.length; i++) {
+        cov += (portReturns[i] - meanPort) * (spyReturns[i] - meanSpy);
+        varSpy += Math.pow(spyReturns[i] - meanSpy, 2);
+    }
+    const beta = varSpy !== 0 ? cov / varSpy : 1.0;
+
+    portMetrics.beta = beta;
+    spyMetrics.beta = 1.0;
+
+    return { portfolio: portMetrics, spy: spyMetrics };
+}
+
+/**
  * 금액 포맷팅
  */
 export function formatCurrency(value) {


### PR DESCRIPTION
기존 4개 요약 카드를 비교 테이블로 교체하여 포트폴리오와 SPY를
동일한 지표 세트로 나란히 비교할 수 있도록 개선.

추가된 지표: CAGR, Max Drawdown, Volatility, Sharpe Ratio,
Sortino Ratio, Calmar Ratio, Beta, Alpha
포트폴리오 우열에 따라 초록/빨강 하이라이트 적용.

https://claude.ai/code/session_01HSCxuEAqjkLBeJNsXa5TQN