### PR TITLE
Add time range selector for performance chart filtering

### DIFF
--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -255,7 +255,7 @@ export function renderUnifiedChart(summaryData) {
         type: 'line',
         data: {
             labels: labels,
-            datasets:[
+            datasets: [
                 {
                     label: 'Total Portfolio ($)',
                     data: portfolioData,
@@ -362,4 +362,14 @@ export function renderUnifiedChart(summaryData) {
             }
         }
     });
+}
+
+/**
+ * 기간 선택 버튼(1M/3M/6M/1Y/ALL)에 따라 통합 차트를 재렌더링
+ * @param {Array} summaryData - 전체 summary 배열
+ * @param {string} range - '1M' | '3M' | '6M' | '1Y' | 'ALL'
+ */
+export function updatePerformanceChartRange(summaryData, range) {
+    const filtered = filterByDateRange(summaryData, range);
+    renderUnifiedChart(filtered);
 }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -5,7 +5,8 @@ import {
     renderStrategyChart,
     renderUnifiedChart,
     renderGroupBarChart,
-    resizeAllCharts
+    resizeAllCharts,
+    updatePerformanceChartRange
 } from './charts.js?v=2';
 
 import {
@@ -67,6 +68,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             renderPerformanceSummaryCards(summaryData);
             renderUnifiedChart(summaryData);
             renderStrategyChart(summaryData);
+            setupTimeRangeSelector(summaryData);
             perfRendered = true;
         }
 
@@ -144,5 +146,25 @@ function activateTab(tabId) {
         const tab = new bootstrap.Tab(tabEl);
         tab.show();
     }
+}
+
+/**
+ * 기간 선택 버튼(1M/3M/6M/1Y/ALL) 클릭 이벤트 설정
+ * @param {Array} summaryData - 전체 summary 배열
+ */
+function setupTimeRangeSelector(summaryData) {
+    const selector = document.getElementById('time-range-selector');
+    if (!selector) return;
+
+    selector.querySelectorAll('button[data-range]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            // active 상태 갱신
+            selector.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+
+            const range = btn.getAttribute('data-range');
+            updatePerformanceChartRange(summaryData, range);
+        });
+    });
 }
 


### PR DESCRIPTION
## Summary
Added functionality to filter the performance chart by different time ranges (1M, 3M, 6M, 1Y, ALL) through a new time range selector UI component.

## Key Changes
- **main.js**: 
  - Imported `updatePerformanceChartRange` function from charts.js
  - Added `setupTimeRangeSelector()` function to initialize time range button event listeners
  - Called `setupTimeRangeSelector()` after rendering performance charts during data load

- **charts.js**:
  - Exported new `updatePerformanceChartRange()` function that filters summary data by date range and re-renders the unified chart
  - Fixed minor formatting inconsistency (spacing in `datasets:` array declaration)

## Implementation Details
- The time range selector expects HTML buttons with `data-range` attributes (1M, 3M, 6M, 1Y, ALL)
- Clicking a range button updates the active state and triggers chart re-rendering with filtered data
- The filtering logic reuses the existing `filterByDateRange()` utility function
- All changes are backward compatible with existing chart rendering functionality

https://claude.ai/code/session_01RF91eUngzV5qQ8DBqDqQUq