### PR TITLE
Add null checks to currency and percent formatting functions

### DIFF
--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -228,6 +228,7 @@ export function computeAdvancedMetrics(summaryData) {
  * 금액 포맷팅
  */
 export function formatCurrency(value) {
+    if (value == null) return '-';
     return '$' + value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
@@ -235,6 +236,7 @@ export function formatCurrency(value) {
  * 퍼센트 포맷팅 (부호 포함)
  */
 export function formatPercent(value) {
+    if (value == null) return '-';
     const sign = value >= 0 ? '+' : '';
     return sign + value.toFixed(2) + '%';
 }


### PR DESCRIPTION
## Summary
Added null/undefined safety checks to the `formatCurrency` and `formatPercent` utility functions to gracefully handle missing values.

## Key Changes
- **formatCurrency()**: Returns '-' when value is null or undefined, preventing errors from calling `toLocaleString()` on invalid values
- **formatPercent()**: Returns '-' when value is null or undefined, preventing errors from calling `toFixed()` on invalid values

## Implementation Details
Both functions now use a simple null coalescing check (`if (value == null)`) at the start to return a dash character as a placeholder for missing data. This prevents runtime errors and provides a consistent visual indicator for empty/missing metric values in the UI.

https://claude.ai/code/session_01Fy2gqK4uqUas9VNGuyDb8x