### PR TITLE
fix: dead CSS 셀렉터 제거 및 실제 사용 ID로 교체 (issue #155)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -148,9 +148,8 @@ body {
     }
 
     /* 차트 높이 축소 */
-    #performanceChart,
-    #strategyChart,
-    #groupAllocationChart {
+    #unifiedPerformanceChart,
+    #strategyChart {
         max-height: 200px;
     }
 }


### PR DESCRIPTION
#performanceChart, #groupAllocationChart는 HTML에 더 이상 존재하지 않는
dead CSS 셀렉터입니다. 반응형 미디어쿼리에서 이를 제거하고, 현재 실제
사용 중인 #unifiedPerformanceChart로 교체합니다.

https://claude.ai/code/session_01K5Xgh612Pm8ZQbYQ5witbN