### PR TITLE
fix: 분산 계산을 모분산(N)에서 표본분산(N-1)으로 변경

### DIFF
--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -182,7 +182,7 @@ export function computeAdvancedMetrics(summaryData) {
 
         // Volatility (연환산)
         const meanRet = dailyReturns.reduce((s, r) => s + r, 0) / dailyReturns.length;
-        const variance = dailyReturns.reduce((s, r) => s + Math.pow(r - meanRet, 2), 0) / dailyReturns.length;
+        const variance = dailyReturns.reduce((s, r) => s + Math.pow(r - meanRet, 2), 0) / (dailyReturns.length - 1);
         const volatility = Math.sqrt(variance) * Math.sqrt(252) * 100;
 
         // Sharpe Ratio (무위험 수익률 0 가정)
@@ -191,7 +191,7 @@ export function computeAdvancedMetrics(summaryData) {
         // Sortino Ratio (하방 변동성만)
         const downsideReturns = dailyReturns.filter(r => r < 0);
         const downsideVariance = downsideReturns.length > 0
-            ? downsideReturns.reduce((s, r) => s + Math.pow(r, 2), 0) / dailyReturns.length
+            ? downsideReturns.reduce((s, r) => s + Math.pow(r, 2), 0) / (dailyReturns.length - 1)
             : 0;
         const downsideStd = Math.sqrt(downsideVariance);
         const sortino = downsideStd !== 0 ? (meanRet / downsideStd) * Math.sqrt(252) : 0;


### PR DESCRIPTION
computeAdvancedMetrics의 volatility 및 Sortino ratio 계산에서
모분산(population variance, /N) 대신 표본분산(sample variance, /N-1)을
사용하도록 수정. 통계적으로 더 정확한 불편 추정량(unbiased estimator)을 적용.

https://claude.ai/code/session_01Lp9hLEjDBBxjXPg1hk7Fty