### PR TITLE
feat: 엔진 비교 백테스트 기능 추가

### DIFF
--- a/.github/workflows/run-compare-backtest.yml
+++ b/.github/workflows/run-compare-backtest.yml
@@ -1,0 +1,78 @@
+name: Compare All Engines Backtest
+
+on:
+  workflow_dispatch:
+    inputs:
+      start:
+        description: '시작 날짜 (예: 2015-01-01)'
+        required: true
+        type: string
+      end:
+        description: '종료 날짜 (예: 2023-12-31)'
+        required: true
+        type: string
+      initial_cash:
+        description: '초기 자본 (기본값: 10000)'
+        required: false
+        type: string
+        default: '10000'
+      interval:
+        description: '실행 간격 - 거래일 기준 (기본값: 1)'
+        required: false
+        type: string
+        default: '1'
+
+permissions:
+  contents: write
+
+jobs:
+  compare-backtest:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run compare backtest
+      env:
+        BACKTEST_START: ${{ inputs.start }}
+        BACKTEST_END: ${{ inputs.end }}
+        BACKTEST_CASH: ${{ inputs.initial_cash }}
+        BACKTEST_INTERVAL: ${{ inputs.interval }}
+      run: python scripts/run_compare_ci.py
+
+    - name: Commit and Push Results
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "📊 엔진 비교 백테스트 결과 업데이트 [skip ci]"
+        file_pattern: "docs/data/backtest/compare/* logs/backtest/*"
+
+    - name: Print backtest log
+      if: always()
+      run: |
+        LOG_FILE=$(ls logs/backtest/*.log 2>/dev/null | head -1)
+        if [ -n "$LOG_FILE" ]; then
+          echo "=== 백테스트 로그: $LOG_FILE ==="
+          cat "$LOG_FILE"
+        else
+          echo "로그 파일이 생성되지 않았습니다."
+        fi
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: compare-backtest-${{ inputs.start }}-${{ inputs.end }}
+        path: |
+          logs/backtest/
+          docs/data/backtest/compare/*.png
+        retention-days: 30

--- a/scripts/run_compare_ci.py
+++ b/scripts/run_compare_ci.py
@@ -1,0 +1,57 @@
+"""GitHub Actions CI용 엔진 비교 백테스트 실행 스크립트."""
+import os
+import sys
+
+
+def main() -> None:
+    start = os.environ["BACKTEST_START"]
+    end = os.environ["BACKTEST_END"]
+    cash = float(os.environ.get("BACKTEST_CASH", "10000"))
+    interval = int(os.environ.get("BACKTEST_INTERVAL", "1"))
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from src.backtest.runner import run_compare_backtest  # noqa: PLC0415
+
+    run_number = os.environ.get("GITHUB_RUN_NUMBER")
+
+    print(f"=== 엔진 비교 백테스트 시작: {start} ~ {end}, 초기자본: {cash:,.0f}, 실행간격: {interval}거래일 ===")
+    result = run_compare_backtest(
+        start, end, cash,
+        execution_interval=interval,
+        run_number=run_number,
+    )
+
+    if result is None:
+        print("ERROR: 비교 백테스트 결과 없음 (데이터 부족 또는 거래일 없음)")
+        sys.exit(1)
+
+    spy_str = f"{result.spy_cagr:.2%}" if result.spy_cagr is not None else "N/A"
+
+    lines = [
+        f"## 엔진 비교 백테스트 결과 ({start} ~ {end})",
+        "",
+        "| 엔진 | 최종 자산 | CAGR | MDD | Sharpe | 배당금 |",
+        "|------|----------|------|-----|--------|--------|",
+    ]
+    for name, r in result.engine_results.items():
+        lines.append(
+            f"| {name} | ${r.final_value:,.0f} | {r.cagr:.2%} | "
+            f"{r.mdd:.2%} | {r.sharpe_ratio:.2f} | ${r.total_dividend_income:,.2f} |"
+        )
+    lines.append(f"| **SPY Buy&Hold** | - | {spy_str} | - | - | - |")
+
+    if result.chart_path:
+        lines.append(f"\n차트 저장 경로: `{result.chart_path}`")
+
+    summary = "\n".join(lines) + "\n"
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if summary_file:
+        with open(summary_file, "w") as f:
+            f.write(summary)
+
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backtest/__init__.py
+++ b/src/backtest/__init__.py
@@ -1,10 +1,12 @@
-from src.backtest.runner import run_backtest
+from src.backtest.runner import run_backtest, run_compare_backtest, CompareBacktestResult
 from src.backtest.components import BacktestDataLoader, BacktestBroker
 from src.backtest.fetcher import download_historical_data
 from src.backtest.cache import BacktestDataCache
 
 __all__ = [
     "run_backtest",
+    "run_compare_backtest",
+    "CompareBacktestResult",
     "BacktestDataLoader",
     "BacktestBroker",
     "download_historical_data",

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -5,10 +5,12 @@ import matplotlib.pyplot as plt
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from src.strategy_config import StrategyConfig
 from src.core.models import TradeExecution
-from src.core.engine import TradingEngine
+from src.core.engine import (
+    TradingEngine, FullExposureEngine, QldSHVEngine, QldSchdEngine,
+)
 from src.infra.repo import JsonRepository
 from src.utils.logger import TradeLogger
 from src.backtest.fetcher import download_historical_data
@@ -30,6 +32,14 @@ class BacktestResult:
     trade_executions: Optional[List[TradeExecution]] = None  # 전체 매매 체결 기록
     trade_reason_summary: Optional[Dict[str, int]] = None  # 매매 사유별 발생 횟수
     total_dividend_income: float = 0.0  # 시뮬레이션 기간 중 수령한 총 배당금
+
+
+@dataclass
+class CompareBacktestResult:
+    """엔진 비교 백테스트 결과 구조체"""
+    engine_results: Dict[str, BacktestResult]  # {엔진명: BacktestResult}
+    spy_cagr: Optional[float]
+    chart_path: Optional[str]
 
 
 def _calculate_dividend_income(
@@ -68,6 +78,69 @@ def _validate_tickers(full_df: pd.DataFrame, required: List[str], logger: TradeL
     if missing:
         logger.warning(f"⚠️ 데이터 미수신 티커 {missing} — 백테스트를 중단합니다.")
     return missing
+
+
+def _calculate_metrics(
+    summary_data: list,
+    initial_cash: float,
+    full_df: pd.DataFrame,
+    sim_days: list,
+) -> Optional[Tuple[pd.DataFrame, float, float, float, float, Optional[float], Dict[str, float]]]:
+    """백테스트 결과 메트릭을 계산한다.
+
+    Returns:
+        (res_df, final_value, cagr, mdd, sharpe_ratio, spy_cagr, regime_returns)
+        또는 데이터가 없으면 None
+    """
+    if not summary_data:
+        return None
+
+    res_df = pd.DataFrame(summary_data)
+    res_df["date"] = pd.to_datetime(res_df["date"])
+    res_df = res_df.set_index("date")
+    if "executions" in res_df.columns:
+        res_df["trade_count"] = res_df["executions"].apply(
+            lambda x: len(x) if isinstance(x, list) else 0
+        )
+    else:
+        res_df["trade_count"] = 0
+
+    # CAGR
+    final_value = res_df.iloc[-1]['total_value']
+    years = (res_df.index[-1] - res_df.index[0]).days / 365.25
+    cagr = (final_value / initial_cash) ** (1 / years) - 1 if years > 0 else 0.0
+
+    # MDD
+    peak = res_df['total_value'].cummax()
+    drawdown = (res_df['total_value'] - peak) / peak
+    mdd = float(drawdown.min())
+
+    # Sharpe Ratio
+    daily_returns = res_df['total_value'].pct_change().dropna()
+    if len(daily_returns) > 1 and daily_returns.std() > 0:
+        sharpe_ratio = float(daily_returns.mean() / daily_returns.std() * np.sqrt(252))
+    else:
+        sharpe_ratio = 0.0
+
+    # SPY 벤치마크
+    spy_cagr = None
+    try:
+        spy_prices = full_df['Close']['SPY'].loc[sim_days].dropna()
+        if len(spy_prices) >= 2:
+            spy_return = spy_prices.iloc[-1] / spy_prices.iloc[0] - 1
+            spy_cagr = float((1 + spy_return) ** (1 / years) - 1) if years > 0 else 0.0
+    except Exception:
+        spy_cagr = None
+
+    # 국면별 수익률
+    res_df['daily_return'] = res_df['total_value'].pct_change()
+    regime_returns: Dict[str, float] = {}
+    for regime_val, group in res_df.groupby('regime'):
+        regime_daily = group['daily_return'].dropna()
+        if len(regime_daily) > 0:
+            regime_returns[str(regime_val)] = float(regime_daily.mean() * 252)
+
+    return res_df, final_value, cagr, mdd, sharpe_ratio, spy_cagr, regime_returns
 
 
 def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
@@ -208,55 +281,12 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
     logger.info("--- Backtest Finished ---")
 
     summary_data = backtest_repo._load_json(backtest_repo.summary_file, default=[])
-    if not summary_data:
+    metrics = _calculate_metrics(summary_data, initial_cash, full_df, sim_days)
+    if metrics is None:
         logger.warning("No trading data available for the given period.")
         return None
 
-    res_df = pd.DataFrame(summary_data)
-    res_df["date"] = pd.to_datetime(res_df["date"])
-    res_df = res_df.set_index("date")
-    # 파생 컬럼: 체결 수 (executions 없는 날은 0)
-    if "executions" in res_df.columns:
-        res_df["trade_count"] = res_df["executions"].apply(
-            lambda x: len(x) if isinstance(x, list) else 0
-        )
-    else:
-        res_df["trade_count"] = 0
-
-    # CAGR (연환산 수익률)
-    final_value = res_df.iloc[-1]['total_value']
-    years = (res_df.index[-1] - res_df.index[0]).days / 365.25
-    cagr = (final_value / initial_cash) ** (1 / years) - 1 if years > 0 else 0.0
-
-    # MDD (최대 낙폭)
-    peak = res_df['total_value'].cummax()
-    drawdown = (res_df['total_value'] - peak) / peak
-    mdd = float(drawdown.min())
-
-    # Sharpe Ratio (연환산, 무위험수익률 0% 가정)
-    daily_returns = res_df['total_value'].pct_change().dropna()
-    if len(daily_returns) > 1 and daily_returns.std() > 0:
-        sharpe_ratio = float(daily_returns.mean() / daily_returns.std() * np.sqrt(252))
-    else:
-        sharpe_ratio = 0.0
-
-    # SPY 벤치마크 (Buy & Hold)
-    spy_cagr = None
-    try:
-        spy_prices = full_df['Close']['SPY'].loc[sim_days].dropna()
-        if len(spy_prices) >= 2:
-            spy_return = spy_prices.iloc[-1] / spy_prices.iloc[0] - 1
-            spy_cagr = float((1 + spy_return) ** (1 / years) - 1) if years > 0 else 0.0
-    except Exception:
-        spy_cagr = None
-
-    # 국면별 연환산 평균 수익률
-    res_df['daily_return'] = res_df['total_value'].pct_change()
-    regime_returns: Dict[str, float] = {}
-    for regime_val, group in res_df.groupby('regime'):
-        regime_daily = group['daily_return'].dropna()
-        if len(regime_daily) > 0:
-            regime_returns[str(regime_val)] = float(regime_daily.mean() * 252)
+    res_df, final_value, cagr, mdd, sharpe_ratio, spy_cagr, regime_returns = metrics
 
     # 결과 출력
     logger.info(f"Initial: ${initial_cash:,.0f} -> Final: ${final_value:,.0f}")
@@ -318,6 +348,209 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
         trade_executions=all_executions,
         trade_reason_summary=trade_reason_counter if trade_reason_counter else None,
         total_dividend_income=total_dividend_income,
+    )
+
+
+# --- 엔진 비교 백테스트 ---
+
+ENGINE_REGISTRY: List[Tuple[str, type]] = [
+    ("TradingEngine", TradingEngine),
+    ("FullExposureEngine", FullExposureEngine),
+    ("QldSHVEngine", QldSHVEngine),
+    ("QldSchdEngine", QldSchdEngine),
+]
+
+_ENGINE_COLORS: Dict[str, str] = {
+    "TradingEngine": "#1f77b4",
+    "FullExposureEngine": "#2ca02c",
+    "QldSHVEngine": "#ff7f0e",
+    "QldSchdEngine": "#d62728",
+}
+
+
+def run_compare_backtest(
+    start_date: str,
+    end_date: str,
+    initial_cash: float = 10000.0,
+    execution_interval: int = 1,
+    output_dir: str = "docs/data/backtest/compare",
+    run_number: Optional[str] = None,
+    reinvest_dividends: bool = True,
+) -> Optional[CompareBacktestResult]:
+    """모든 엔진을 동시에 실행하고 결과를 비교한다."""
+    if execution_interval < 1:
+        raise ValueError(f"execution_interval은 1 이상이어야 합니다: {execution_interval}")
+
+    strategy = StrategyConfig(trading_interval_days=execution_interval)
+    logger = TradeLogger(log_dir="logs/backtest")
+
+    # 1. 전체 엔진의 티커 합집합 수집
+    all_tickers: set = set()
+    for _, eng_cls in ENGINE_REGISTRY:
+        groups = getattr(eng_cls, 'ASSET_GROUPS', strategy.ASSET_GROUPS)
+        for group_tickers in groups.values():
+            all_tickers.update(group_tickers)
+    all_tickers.add("SPY")
+    tickers = list(all_tickers)
+
+    # 2. 데이터 1회 다운로드
+    logger.info("--- Preparing Data (Compare Mode) ---")
+    full_df, full_vix, full_dividends = download_historical_data(tickers, start_date, end_date)
+
+    if _validate_tickers(full_df, tickers, logger):
+        return None
+
+    # 3. 거래일 산출
+    trading_days = full_df.index
+    sim_days = [d for d in trading_days if start_date <= d.strftime("%Y-%m-%d") <= end_date]
+
+    # 4. 엔진별 독립 컴포넌트 생성
+    engines: Dict[str, dict] = {}
+    for name, eng_cls in ENGINE_REGISTRY:
+        eff_groups = getattr(eng_cls, 'ASSET_GROUPS', strategy.ASSET_GROUPS)
+        eff_ratio = getattr(eng_cls, 'REBALANCE_RATIO_A', 0.5)
+
+        eng_output = f"{output_dir}/{name}"
+        existing = Path(eng_output)
+        if existing.exists():
+            for f in existing.iterdir():
+                if f.suffix == ".json":
+                    f.unlink()
+
+        loader = BacktestDataLoader(full_df, full_vix)
+        broker = BacktestBroker(initial_cash, logger=logger)
+        repo = JsonRepository(eng_output, asset_groups=eff_groups)
+        engine = eng_cls(
+            asset_groups=eff_groups,
+            ratio_a=eff_ratio,
+            broker=broker,
+            repo=repo,
+            logger=logger,
+            trading_interval_days=strategy.TRADING_INTERVAL_DAYS,
+            notifier=None,
+            is_live_trading=False,
+        )
+        engines[name] = {
+            "engine": engine,
+            "loader": loader,
+            "broker": broker,
+            "repo": repo,
+            "executions": [],
+            "reason_counter": {},
+            "dividend_income": 0.0,
+        }
+
+    # 5. 시뮬레이션 루프
+    logger.info(f"--- Starting Compare Backtest ({len(sim_days)} trading days) ---")
+
+    for today in sim_days:
+        # 종가 추출 (1회, 공유)
+        try:
+            close_prices = full_df['Close'].loc[today]
+            current_prices = close_prices.to_dict()
+            current_prices = {
+                t: (p if not (isinstance(p, float) and np.isnan(p)) else 0.0)
+                for t, p in current_prices.items()
+            }
+        except Exception as e:
+            logger.warning(f"[{today.date()}] 종가 추출 실패, 건너뜀: {e}")
+            continue
+
+        sim_date = today.strftime("%Y-%m-%d")
+
+        for name, ctx in engines.items():
+            ctx["loader"].set_date(today)
+            ctx["broker"].set_date(today)
+            ctx["broker"].set_prices(current_prices)
+
+            if reinvest_dividends:
+                div_income = _calculate_dividend_income(today, full_dividends, ctx["broker"])
+                if div_income > 0:
+                    ctx["broker"].receive_dividends(div_income)
+                    ctx["dividend_income"] += div_income
+
+            try:
+                result = ctx["engine"].run_one_cycle(ctx["loader"], sim_date=sim_date)
+                ctx["executions"].extend(result.executions)
+                if result.signal.has_orders:
+                    ctx["reason_counter"][result.signal.reason] = (
+                        ctx["reason_counter"].get(result.signal.reason, 0) + 1
+                    )
+            except Exception as e:
+                logger.error(f"[{name}] Error on {today.date()}: {e}")
+
+    # 6. 엔진별 메트릭 계산
+    logger.info("--- Compare Backtest Finished ---")
+
+    engine_results: Dict[str, BacktestResult] = {}
+    compare_spy_cagr: Optional[float] = None
+
+    for name, ctx in engines.items():
+        summary_data = ctx["repo"]._load_json(ctx["repo"].summary_file, default=[])
+        metrics = _calculate_metrics(summary_data, initial_cash, full_df, sim_days)
+        if metrics is None:
+            logger.warning(f"[{name}] No trading data available.")
+            continue
+
+        res_df, final_value, cagr, mdd, sharpe_ratio, spy_cagr, regime_returns = metrics
+
+        if compare_spy_cagr is None and spy_cagr is not None:
+            compare_spy_cagr = spy_cagr
+
+        logger.info(f"[{name}] Final: ${final_value:,.0f} | CAGR: {cagr:.2%} | MDD: {mdd:.2%} | Sharpe: {sharpe_ratio:.2f}")
+
+        engine_results[name] = BacktestResult(
+            history=res_df,
+            initial_cash=initial_cash,
+            final_value=final_value,
+            cagr=cagr,
+            mdd=mdd,
+            sharpe_ratio=sharpe_ratio,
+            spy_cagr=spy_cagr,
+            regime_returns=regime_returns,
+            chart_path=None,
+            trade_executions=ctx["executions"],
+            trade_reason_summary=ctx["reason_counter"] if ctx["reason_counter"] else None,
+            total_dividend_income=ctx["dividend_income"],
+        )
+
+    if not engine_results:
+        logger.warning("No engine produced results.")
+        return None
+
+    # 7. 비교 차트 생성
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    run_suffix = f"_{run_number}" if run_number else ""
+    chart_path = f"{output_dir}/compare_{start_date}_{end_date}{run_suffix}.png"
+
+    plt.figure(figsize=(14, 7))
+    for name, br in engine_results.items():
+        color = _ENGINE_COLORS.get(name, None)
+        plt.plot(br.history['total_value'],
+                 label=f'{name} (CAGR: {br.cagr:.2%})', color=color)
+
+    # SPY 벤치마크
+    if compare_spy_cagr is not None:
+        try:
+            spy_benchmark = full_df['Close']['SPY'].loc[sim_days].dropna()
+            spy_scaled = spy_benchmark / spy_benchmark.iloc[0] * initial_cash
+            plt.plot(spy_scaled, label=f'SPY Buy&Hold (CAGR: {compare_spy_cagr:.2%})',
+                     linestyle='--', color='gray', alpha=0.7)
+        except Exception:
+            pass
+
+    plt.title(f"Engine Comparison ({start_date} ~ {end_date})")
+    plt.ylabel("Portfolio Value ($)")
+    plt.legend(loc='upper left')
+    plt.grid(True, alpha=0.3)
+    plt.savefig(chart_path)
+    plt.close()
+    logger.info(f"Compare chart saved: {chart_path}")
+
+    return CompareBacktestResult(
+        engine_results=engine_results,
+        spy_cagr=compare_spy_cagr,
+        chart_path=chart_path,
     )
 
 

--- a/tests/test_backtest_compare.py
+++ b/tests/test_backtest_compare.py
@@ -1,0 +1,144 @@
+# tests/test_backtest_compare.py
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import patch, MagicMock
+from src.backtest.runner import (
+    run_compare_backtest, CompareBacktestResult, BacktestResult, ENGINE_REGISTRY,
+)
+
+
+# 모든 엔진의 티커 합집합 + SPY
+ALL_COMPARE_TICKERS = ["SPY", "SSO", "QLD", "IEF", "GLD", "PDBC", "SHV", "SCHD"]
+
+
+@pytest.fixture
+def mock_compare_fetcher():
+    """모든 엔진 티커를 포함하는 가짜 데이터 (400+일)."""
+    dates = pd.date_range(start="2022-01-01", end="2023-02-15")
+    n = len(dates)
+    price_data = {
+        ticker: np.linspace(100, 200, n)
+        for ticker in ALL_COMPARE_TICKERS
+    }
+    columns = pd.MultiIndex.from_product([["Close"], ALL_COMPARE_TICKERS])
+    df = pd.DataFrame(
+        np.column_stack(list(price_data.values())),
+        index=dates,
+        columns=columns,
+    )
+    vix = pd.DataFrame({"Close": [15.0] * n}, index=dates)
+    dividends = pd.DataFrame()
+    return df, vix, dividends
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_run_compare_backtest_returns_all_engines(mock_savefig, mock_download, mock_compare_fetcher):
+    """[Compare] 비교 백테스트가 4개 엔진 모두의 결과를 반환해야 한다."""
+    mock_download.return_value = mock_compare_fetcher
+
+    result = run_compare_backtest(
+        start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+    )
+
+    assert result is not None
+    assert isinstance(result, CompareBacktestResult)
+    expected_names = {name for name, _ in ENGINE_REGISTRY}
+    assert set(result.engine_results.keys()) == expected_names
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_run_compare_single_data_download(mock_savefig, mock_download, mock_compare_fetcher):
+    """[Compare] 데이터 다운로드가 정확히 1회만 호출되어야 한다."""
+    mock_download.return_value = mock_compare_fetcher
+
+    run_compare_backtest(
+        start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+    )
+
+    mock_download.assert_called_once()
+    # 호출된 티커에 모든 엔진의 티커가 포함되어야 함
+    tickers_called = set(mock_download.call_args[0][0])
+    assert "SPY" in tickers_called
+    assert "QLD" in tickers_called
+    assert "SCHD" in tickers_called
+    assert "SSO" in tickers_called
+    assert "SHV" in tickers_called
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_run_compare_independent_portfolios(mock_savefig, mock_download, mock_compare_fetcher):
+    """[Compare] 각 엔진의 BacktestResult가 독립적이어야 한다."""
+    mock_download.return_value = mock_compare_fetcher
+
+    result = run_compare_backtest(
+        start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+    )
+
+    assert result is not None
+    for name, br in result.engine_results.items():
+        assert isinstance(br, BacktestResult), f"{name}의 결과가 BacktestResult여야 함"
+        assert br.initial_cash == 10000.0
+        assert isinstance(br.final_value, float)
+        assert isinstance(br.cagr, float)
+        assert isinstance(br.mdd, float)
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_run_compare_chart_saved(mock_savefig, mock_download, mock_compare_fetcher):
+    """[Compare] 비교 차트가 저장되어야 한다."""
+    mock_download.return_value = mock_compare_fetcher
+
+    result = run_compare_backtest(
+        start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+    )
+
+    assert result is not None
+    mock_savefig.assert_called_once()
+    assert result.chart_path is not None
+    assert "compare" in result.chart_path
+
+
+@patch("src.backtest.runner.download_historical_data")
+def test_run_compare_returns_none_on_missing_tickers(mock_download):
+    """[Compare] 티커 누락 시 None을 반환해야 한다."""
+    # SPY만 있는 데이터 → 다른 티커 누락
+    dates = pd.date_range(start="2022-01-01", end="2023-02-15")
+    columns = pd.MultiIndex.from_product([["Close"], ["SPY"]])
+    df = pd.DataFrame(
+        np.linspace(100, 200, len(dates)).reshape(-1, 1),
+        index=dates,
+        columns=columns,
+    )
+    vix = pd.DataFrame({"Close": [15.0] * len(dates)}, index=dates)
+    mock_download.return_value = (df, vix, pd.DataFrame())
+
+    result = run_compare_backtest(
+        start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+    )
+
+    assert result is None
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_run_compare_spy_cagr_present(mock_savefig, mock_download, mock_compare_fetcher):
+    """[Compare] SPY 데이터가 있으면 spy_cagr이 계산되어야 한다."""
+    mock_download.return_value = mock_compare_fetcher
+
+    result = run_compare_backtest(
+        start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+    )
+
+    assert result is not None
+    assert result.spy_cagr is not None
+
+
+def test_compare_execution_interval_invalid_raises_error():
+    """[Compare] execution_interval이 1 미만이면 ValueError를 발생시켜야 한다."""
+    with pytest.raises(ValueError, match="execution_interval은 1 이상"):
+        run_compare_backtest("2023-01-02", "2023-01-05", execution_interval=0)


### PR DESCRIPTION
4개 엔진(TradingEngine, FullExposureEngine, QldSHVEngine, QldSchdEngine)을
동시에 실행하고 SPY 벤치마크와 함께 비교하는 기능을 구현.

- run_compare_backtest() 함수: 데이터 1회 다운로드, 엔진별 독립 실행
- _calculate_metrics() 헬퍼 추출로 run_backtest와 로직 재사용
- CompareBacktestResult 데이터클래스 추가
- 비교 차트: 4개 엔진 곡선 + SPY 점선 (색상 구분)
- GitHub Actions 워크플로우 (run-compare-backtest.yml)
- CI 스크립트 (scripts/run_compare_ci.py)
- 테스트 7건 추가 (커버리지 96.83%)

https://claude.ai/code/session_01WM1G6xuiQXSzhwVGW8dQJZ