### PR TITLE
fix: _is_due()에서 stale last_rebalancing_date로 인한 리밸런싱 미실행 버그 수정

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -1,4 +1,5 @@
 # src/backtest/runner.py
+import shutil
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -411,11 +412,9 @@ def run_compare_backtest(
         eff_ratio = getattr(eng_cls, 'REBALANCE_RATIO_A', 0.5)
 
         eng_output = f"{output_dir}/{name}"
-        existing = Path(eng_output)
-        if existing.exists():
-            for f in existing.iterdir():
-                if f.suffix == ".json":
-                    f.unlink()
+        eng_path = Path(eng_output)
+        if eng_path.exists():
+            shutil.rmtree(eng_path)
 
         loader = BacktestDataLoader(full_df, full_vix)
         broker = BacktestBroker(initial_cash, logger=logger)

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -281,7 +281,11 @@ class TradingEngine:
         try:
             last = pd.Timestamp(last_str)
             today = pd.Timestamp(sim_date) if sim_date else pd.Timestamp.today().normalize()
-            return (today - last).days >= self.trading_interval_days
+            diff_days = (today - last).days
+            # sim_date가 last_rebalancing_date보다 과거이면 stale 데이터 → 리밸런싱 실행
+            if diff_days < 0:
+                return True
+            return diff_days >= self.trading_interval_days
         except Exception:
             return True  # 파싱 실패 시 안전하게 리밸런싱 실행
 

--- a/tests/test_backtest_compare.py
+++ b/tests/test_backtest_compare.py
@@ -142,3 +142,40 @@ def test_compare_execution_interval_invalid_raises_error():
     """[Compare] execution_interval이 1 미만이면 ValueError를 발생시켜야 한다."""
     with pytest.raises(ValueError, match="execution_interval은 1 이상"):
         run_compare_backtest("2023-01-02", "2023-01-05", execution_interval=0)
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_stale_status_json_does_not_block_rebalancing(mock_savefig, mock_download, mock_compare_fetcher, tmp_path):
+    """[Compare] 이전 실행의 stale status.json이 남아있어도 리밸런싱이 정상 실행되어야 한다."""
+    import json, os
+    mock_download.return_value = mock_compare_fetcher
+
+    output_dir = str(tmp_path / "compare")
+
+    # 엔진별 디렉토리에 stale status.json 미리 생성
+    for name, _ in ENGINE_REGISTRY:
+        eng_dir = os.path.join(output_dir, name)
+        os.makedirs(eng_dir, exist_ok=True)
+        stale_status = {
+            "last_rebalancing_date": "2025-12-30",
+            "last_updated": "2025-12-30",
+            "strategy": {"regime": "Bull"},
+            "portfolio": {"total_value": 10000.0},
+        }
+        with open(os.path.join(eng_dir, "status.json"), "w") as f:
+            json.dump(stale_status, f)
+
+    result = run_compare_backtest(
+        start_date="2023-01-02",
+        end_date="2023-01-05",
+        initial_cash=10000.0,
+        output_dir=output_dir,
+    )
+
+    assert result is not None
+    for name, br in result.engine_results.items():
+        # 가격이 선형 증가(100->200)하므로 total_value는 10000과 달라야 함
+        assert br.final_value != br.initial_cash, (
+            f"{name}: final_value가 initial_cash와 같음 — 리밸런싱이 실행되지 않았음"
+        )

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -367,6 +367,13 @@ def test_is_due_invalid_date_returns_true():
     assert engine._is_due(None) is True
 
 
+def test_is_due_stale_future_date_returns_true():
+    """이전 실행의 last_rebalancing_date가 sim_date보다 미래 → stale 데이터이므로 True."""
+    engine, mocks = _make_engine(repo_last_reb="2025-12-30", trading_interval_days=5)
+    # sim_date가 last_rebalancing_date보다 ~1094일 이전
+    assert engine._is_due("2023-01-02") is True
+
+
 # ─────────────────────────────────────────────────────────────────
 # rebalancing_date 전달 검증
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
이전 백테스트의 status.json에 미래 날짜(last_rebalancing_date)가 남아있을 때
_is_due()가 항상 False를 반환하여 엔진이 모니터링 모드에 갇히는 문제 수정.
- _is_due(): 음수 일수 차이 시 True 반환 (stale 데이터 처리)
- run_compare_backtest(): shutil.rmtree로 엔진별 디렉토리 완전 삭제
- 테스트 추가: stale status.json 시나리오 검증

https://claude.ai/code/session_01LnTU4p5pbt3xcJUJEhJaSH