### PR TITLE
fix: 백테스트 Overview total_return 계산 오류 수정

### DIFF
--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -17,10 +17,11 @@ export function renderCompareOverview(enginesData) {
     const container = document.getElementById('overview');
     if (!container) return;
 
-    // 각 엔진 metrics 계산
+    // 각 엔진 metrics 계산 (status.json의 initial_cash로 정확한 totalReturn 계산)
     const engineMetrics = {};
     for (const [name, data] of enginesData) {
-        engineMetrics[name] = computeAdvancedMetrics(data.summary);
+        const initialCash = data.status?.initial_cash ?? null;
+        engineMetrics[name] = computeAdvancedMetrics(data.summary, initialCash);
     }
 
     const engineNames = [...enginesData.keys()];

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -140,9 +140,10 @@ export function getAssetGroup(ticker, groupConfig) {
 /**
  * 포트폴리오 & SPY 벤치마크 고급 지표 계산
  * @param {Array} summaryData - summary 배열 (total_value, spy_price 포함)
+ * @param {number|null} initialCash - 실제 초기 자본 (status.json의 initial_cash). 없으면 summary 첫 값 사용.
  * @returns {{portfolio: Object, spy: Object}} 양쪽 지표 객체
  */
-export function computeAdvancedMetrics(summaryData) {
+export function computeAdvancedMetrics(summaryData, initialCash = null) {
     const empty = { totalReturn: 0, cagr: 0, mdd: 0, volatility: 0, sharpe: 0, sortino: 0, calmar: 0, beta: 1.0 };
     if (!summaryData || summaryData.length < 2) {
         return { portfolio: { ...empty }, spy: { ...empty, beta: 1.0 } };
@@ -164,8 +165,8 @@ export function computeAdvancedMetrics(summaryData) {
         spyReturns.push(summaryData[i].spy_price / summaryData[i - 1].spy_price - 1);
     }
 
-    function calcMetrics(values, dailyReturns) {
-        const firstVal = values[0];
+    function calcMetrics(values, dailyReturns, baseValue = null) {
+        const firstVal = baseValue !== null ? baseValue : values[0];
         const lastVal = values[values.length - 1];
         const totalReturn = (lastVal / firstVal - 1) * 100;
         const cagr = (Math.pow(lastVal / firstVal, 1 / years) - 1) * 100;
@@ -205,7 +206,7 @@ export function computeAdvancedMetrics(summaryData) {
     const portValues = summaryData.map(d => d.total_value);
     const spyValues = summaryData.map(d => d.spy_price);
 
-    const portMetrics = calcMetrics(portValues, portReturns);
+    const portMetrics = calcMetrics(portValues, portReturns, initialCash);
     const spyMetrics = calcMetrics(spyValues, spyReturns);
 
     // Beta = Cov(port, spy) / Var(spy)

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -498,6 +498,13 @@ def run_compare_backtest(
 
         logger.info(f"[{name}] Final: ${final_value:,.0f} | CAGR: {cagr:.2%} | MDD: {mdd:.2%} | Sharpe: {sharpe_ratio:.2f}")
 
+        # status.json에 initial_cash와 backtest_start_date 저장 (JS 정확한 totalReturn 계산용)
+        status_path = ctx["repo"].status_file
+        status_data = ctx["repo"]._load_json(status_path, default={})
+        status_data["initial_cash"] = initial_cash
+        status_data["backtest_start_date"] = start_date
+        ctx["repo"]._save_json(status_path, status_data)
+
         engine_results[name] = BacktestResult(
             history=res_df,
             initial_cash=initial_cash,


### PR DESCRIPTION
max_summary_records=2000으로 summary.json이 잘려 JS가 첫 레코드를
실제 초기자본으로 오인해 totalReturn이 잘못 계산되는 버그 수정.

- runner.py: 비교 백테스트 완료 후 status.json에 initial_cash,
  backtest_start_date 저장
- utils.js: computeAdvancedMetrics에 initialCash 파라미터 추가,
  포트폴리오 totalReturn/CAGR을 실제 초기자본 기준으로 계산
- compare-ui.js: status.initial_cash를 computeAdvancedMetrics에 전달

https://claude.ai/code/session_01ThaTjZP2dbx2PBJPeYnHUj