### PR TITLE
feat: register_engine 데코레이터로 엔진 자동 등록 자동화

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -21,6 +21,8 @@ import {
     renderTradeHistory
 } from './ui.js?v=2';
 
+import { loadEngineMeta } from './utils.js?v=2';
+
 import {
     renderCompareOverview,
     renderCompareTradesTab,
@@ -118,6 +120,9 @@ async function loadLiveMode() {
 async function loadCompareMode() {
     const basePath = 'data/backtest/compare/';
     const cacheBust = `v=${Date.now()}`;
+
+    // 0. 엔진 색상 메타 로드 (ENGINE_COLORS 런타임 주입)
+    await loadEngineMeta(basePath);
 
     // 1. 엔진 목록 로드
     const enginesRes = await fetch(`${basePath}engines.json?${cacheBust}`);

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -226,15 +226,27 @@ export function computeAdvancedMetrics(summaryData, initialCash = null) {
 }
 
 /**
- * 엔진별 고유 색상 팔레트
+ * 엔진별 고유 색상 팔레트 (런타임에 loadEngineMeta()로 채워짐)
  */
-export const ENGINE_COLORS = {
-    TradingEngine: '#0d6efd',
-    FullExposureEngine: '#dc3545',
-    QldSHVEngine: '#198754',
-    QldSchdEngine: '#6f42c1',
-    '자산5분법': '#9467bd'
-};
+export const ENGINE_COLORS = {};
+
+/**
+ * engines_meta.json을 fetch하여 ENGINE_COLORS를 채운다.
+ * loadCompareMode() 시작 시 반드시 먼저 호출해야 한다.
+ * @param {string} basePath - engines_meta.json이 있는 경로 (예: 'data/backtest/compare/')
+ */
+export async function loadEngineMeta(basePath) {
+    try {
+        const res = await fetch(`${basePath}engines_meta.json?v=${Date.now()}`);
+        if (!res.ok) return;
+        const meta = await res.json();
+        for (const [name, info] of Object.entries(meta)) {
+            ENGINE_COLORS[name] = info.color;
+        }
+    } catch (e) {
+        console.warn('engines_meta.json 로드 실패 — 폴백 색상(#6c757d) 사용');
+    }
+}
 
 export const SPY_COLOR = '#fd7e14';
 

--- a/scripts/run_compare_ci.py
+++ b/scripts/run_compare_ci.py
@@ -11,7 +11,7 @@ def main() -> None:
     interval = int(os.environ.get("BACKTEST_INTERVAL", "1"))
 
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-    from src.backtest.runner import run_compare_backtest, ENGINE_REGISTRY  # noqa: PLC0415
+    from src.backtest.runner import run_compare_backtest, ENGINE_REGISTRY, _ENGINE_COLORS  # noqa: PLC0415
 
     run_number = os.environ.get("GITHUB_RUN_NUMBER")
 
@@ -21,6 +21,14 @@ def main() -> None:
     engine_names = [name for name, _ in ENGINE_REGISTRY]
     with open(os.path.join(output_dir, "engines.json"), "w") as f:
         json.dump(engine_names, f)
+
+    # 엔진 메타 (색상 포함) 생성 — JS가 런타임에 읽어 ENGINE_COLORS 대체
+    engines_meta = {
+        name: {"color": _ENGINE_COLORS.get(name, "#6c757d")}
+        for name in engine_names
+    }
+    with open(os.path.join(output_dir, "engines_meta.json"), "w") as f:
+        json.dump(engines_meta, f)
 
     print(f"=== 엔진 비교 백테스트 시작: {start} ~ {end}, 초기자본: {cash:,.0f}, 실행간격: {interval}거래일 ===")
     result = run_compare_backtest(

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -11,6 +11,8 @@ from src.strategy_config import StrategyConfig
 from src.core.models import TradeExecution
 from src.core.engine import (
     TradingEngine, FullExposureEngine, QldSHVEngine, QldSchdEngine, Asset5Engine,
+    _ENGINE_REGISTRY as ENGINE_REGISTRY,
+    _ENGINE_COLORS,
 )
 from src.infra.repo import JsonRepository
 from src.utils.logger import TradeLogger
@@ -353,22 +355,7 @@ def run_backtest(start_date: str, end_date: str, initial_cash: float = 10000.0,
 
 
 # --- 엔진 비교 백테스트 ---
-
-ENGINE_REGISTRY: List[Tuple[str, type]] = [
-    ("TradingEngine", TradingEngine),
-    ("FullExposureEngine", FullExposureEngine),
-    ("QldSHVEngine", QldSHVEngine),
-    ("QldSchdEngine", QldSchdEngine),
-    ("자산5분법", Asset5Engine),
-]
-
-_ENGINE_COLORS: Dict[str, str] = {
-    "TradingEngine": "#1f77b4",
-    "FullExposureEngine": "#2ca02c",
-    "QldSHVEngine": "#ff7f0e",
-    "QldSchdEngine": "#d62728",
-    "자산5분법": "#9467bd",
-}
+# ENGINE_REGISTRY, _ENGINE_COLORS는 src.core.engine에서 import (자동 등록)
 
 
 def run_compare_backtest(

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -1,6 +1,6 @@
 # src/core/engine.py
 import time
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -11,7 +11,27 @@ from src.core.models import (
 from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
 from src.utils.calculator import IndicatorCalculator
 
+# 엔진 자동 등록 레지스트리
+_ENGINE_REGISTRY: List[Tuple[str, type]] = []
+_ENGINE_COLORS: Dict[str, str] = {}
 
+
+def register_engine(name: str = None, color: str = "#6c757d"):
+    """엔진 클래스를 레지스트리에 자동 등록하는 데코레이터.
+
+    Args:
+        name: 레지스트리에 등록할 이름. 기본값은 클래스명(__name__).
+        color: 대시보드 차트 색상 (hex). 기본값은 회색(#6c757d).
+    """
+    def decorator(cls):
+        key = name or cls.__name__
+        _ENGINE_REGISTRY.append((key, cls))
+        _ENGINE_COLORS[key] = color
+        return cls
+    return decorator
+
+
+@register_engine(color="#1f77b4")
 class TradingEngine:
     """핵심 트레이딩 사이클 엔진 (Template Method 패턴).
 
@@ -320,6 +340,7 @@ class TradingEngine:
             self.notifier.send_alert(msg)
 
 
+@register_engine(color="#2ca02c")
 class FullExposureEngine(TradingEngine):
     """항상 exposure=1.0을 유지하는 전략 엔진.
 
@@ -358,6 +379,7 @@ class FullExposureEngine(TradingEngine):
         return regime, exposure, nan_fields
 
 
+@register_engine(color="#ff7f0e")
 class QldSHVEngine(FullExposureEngine):
     """QLD(A그룹) + SHV(B그룹)만으로 구성된 Full Exposure 전략 엔진.
 
@@ -374,6 +396,7 @@ class QldSHVEngine(FullExposureEngine):
 
 
 
+@register_engine(color="#d62728")
 class QldSchdEngine(FullExposureEngine):
     """QLD(A그룹) + SCHD(B그룹)으로 구성된 Full Exposure 전략 엔진.
 
@@ -390,6 +413,7 @@ class QldSchdEngine(FullExposureEngine):
     REBALANCE_RATIO_A: float = 0.3
 
 
+@register_engine(color="#9467bd")
 class Asset5Engine(FullExposureEngine):
     """자산5분법 — VOO/IEMG(A그룹) + TLT/EMB/GLD(B그룹) Full Exposure 전략 엔진.
 


### PR DESCRIPTION
- engine.py에 register_engine 데코레이터 추가, 모든 엔진 클래스에 적용
- 자산5분법 → Asset5Engine 이름 통일 (클래스명 그대로 사용)
- runner.py ENGINE_REGISTRY/_ENGINE_COLORS 수동 정의 제거, engine.py import로 대체
- run_compare_ci.py에서 engines_meta.json(색상 포함) 자동 생성
- utils.js ENGINE_COLORS 하드코딩 제거, loadEngineMeta()로 런타임 주입
- main.js loadCompareMode() 시작 시 loadEngineMeta() 호출

새 엔진 추가 시 engine.py 한 곳만 수정하면 모든 레이어에 자동 반영

https://claude.ai/code/session_01E5W5QwEHZwmqUcvoscTT69