### PR TITLE
fix: download-data.yml에 TradeLogger 추가로 cache.py 동작 로그 출력

### DIFF
--- a/.github/workflows/download-data.yml
+++ b/.github/workflows/download-data.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         python -c "
         from src.backtest.cache import BacktestDataCache
+        from src.utils.logger import TradeLogger
         from datetime import datetime, timedelta
 
         start_date = '${{ inputs.start_date }}'
@@ -46,7 +47,7 @@ jobs:
 
         tickers = ['SSO', 'QLD', 'IEF', 'GLD', 'PDBC', 'SHV', 'SCHD', 'SPY', 'VOO', 'IEMG', 'EMB']
 
-        cache = BacktestDataCache()
+        cache = BacktestDataCache(logger=TradeLogger())
         ohlcv, vix, dividends = cache.get_data(tickers, real_start_str, end_date)
 
         print(f'OHLCV shape: {ohlcv.shape}')


### PR DESCRIPTION
BacktestDataCache()를 로거 없이 생성하면 _NullLogger가 사용되어
전체 다운로드, NaN ffill, 상장일 조정 등 모든 동작 로그가 무시됨.
TradeLogger를 주입하여 GitHub Actions 콘솔에 로그가 출력되도록 수정.

https://claude.ai/code/session_01RQpjv79x2bJPCFDseaRLMg