### PR TITLE
refactor: SpyEngine 정식 등록 및 별도 SPY 벤치마크 제거

### DIFF
--- a/docs/data/backtest/compare/engines.json
+++ b/docs/data/backtest/compare/engines.json
@@ -1,1 +1,1 @@
-["TradingEngine", "FullExposureEngine", "QldSHVEngine", "QldSchdEngine", "Asset5Engine"]
+["TradingEngine", "FullExposureEngine", "QldSHVEngine", "QldSchdEngine", "Asset5Engine", "SpyEngine"]

--- a/docs/data/backtest/compare/engines_meta.json
+++ b/docs/data/backtest/compare/engines_meta.json
@@ -1,1 +1,1 @@
-{"TradingEngine": {"color": "#1f77b4"}, "FullExposureEngine": {"color": "#2ca02c"}, "QldSHVEngine": {"color": "#ff7f0e"}, "QldSchdEngine": {"color": "#d62728"}, "Asset5Engine": {"color": "#9467bd"}}
+{"TradingEngine": {"color": "#1f77b4"}, "FullExposureEngine": {"color": "#2ca02c"}, "QldSHVEngine": {"color": "#ff7f0e"}, "QldSchdEngine": {"color": "#d62728"}, "Asset5Engine": {"color": "#9467bd"}, "SpyEngine": {"color": "#fd7e14"}}

--- a/docs/js/compare-charts.js
+++ b/docs/js/compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/compare-charts.js
 // 멀티 엔진 비교 전용 차트
 
-import { filterByDateRange, ENGINE_COLORS, SPY_COLOR } from './utils.js?v=2';
+import { filterByDateRange, ENGINE_COLORS } from './utils.js?v=2';
 
 let comparePerformanceChart = null;
 let compareStrategyChart = null;
@@ -61,20 +61,6 @@ export function renderComparePerformanceChart(enginesData, filteredSummaries) {
             tension: 0.1,
         });
     }
-
-    // SPY 벤치마크
-    const spyInitial = firstSummary[0].spy_price;
-    const spyData = firstSummary.map(d => (d.spy_price / spyInitial) * 100);
-    datasets.push({
-        label: 'SPY Benchmark',
-        data: spyData,
-        borderColor: SPY_COLOR,
-        borderWidth: 2,
-        borderDash: [5, 5],
-        pointRadius: 0,
-        fill: false,
-        tension: 0.1,
-    });
 
     // Regime 배경 박스
     const annotations = {};

--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -89,12 +89,9 @@ export function renderCompareOverview(enginesData) {
     }
 
     // 테이블 헤더
-    let headerCols = engineNames.map(name =>
+    const headerCols = engineNames.map(name =>
         `<th class="text-end pe-3">${colorDot(name)}${name}</th>`
     ).join('');
-
-    // SPY 열 추가
-    headerCols += `<th class="text-end pe-3"><span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#fd7e14;margin-right:6px;"></span>SPY</th>`;
 
     // 테이블 바디
     let rows = '';
@@ -114,34 +111,23 @@ export function renderCompareOverview(enginesData) {
             cells += `<td class="text-end pe-3 ${cls}">${fmt(value, format)}</td>`;
         });
 
-        // SPY 값
-        let spyValue;
-        if (key === 'finalValue') {
-            // SPY scaled final value
-            const s = firstEngine.summary;
-            const spyInitial = s[0]?.spy_price || 1;
-            const spyFinal = s[s.length - 1]?.spy_price || 1;
-            spyValue = (spyFinal / spyInitial) * (s[0]?.total_value || 10000);
-            cells += `<td class="text-end pe-3 text-muted">${fmt(spyValue, format)}</td>`;
-        } else if (key === 'beta') {
-            cells += `<td class="text-end pe-3 text-muted">1.00</td>`;
-        } else {
-            const spyMetric = engineMetrics[engineNames[0]].spy[key];
-            cells += `<td class="text-end pe-3 text-muted">${fmt(spyMetric, format)}</td>`;
-        }
-
         rows += `<tr><td class="ps-3">${label}</td>${cells}</tr>`;
     }
 
-    // Alpha 행
-    let alphaCells = '';
-    engineNames.forEach(name => {
-        const alpha = engineMetrics[name].portfolio.totalReturn - engineMetrics[name].spy.totalReturn;
-        const cls = alpha >= 0 ? 'text-success fw-bold' : 'text-danger fw-bold';
-        alphaCells += `<td class="text-end pe-3 ${cls}">${formatPercent(alpha)}</td>`;
-    });
-    alphaCells += `<td class="text-end pe-3 text-muted">-</td>`;
-    rows += `<tr class="table-light"><td class="ps-3 fw-bold">Alpha</td>${alphaCells}</tr>`;
+    // Alpha 행 (SpyEngine 기준)
+    const spyEngineName = engineNames.find(n => n === 'SpyEngine');
+    if (spyEngineName) {
+        const spyTotalReturn = engineMetrics[spyEngineName].portfolio.totalReturn;
+        let alphaCells = '';
+        engineNames.forEach(name => {
+            const alpha = engineMetrics[name].portfolio.totalReturn - spyTotalReturn;
+            const cls = name === spyEngineName ? 'text-muted' :
+                        alpha >= 0 ? 'text-success fw-bold' : 'text-danger fw-bold';
+            const label = name === spyEngineName ? '-' : formatPercent(alpha);
+            alphaCells += `<td class="text-end pe-3 ${cls}">${label}</td>`;
+        });
+        rows += `<tr class="table-light"><td class="ps-3 fw-bold">Alpha (vs SPY)</td>${alphaCells}</tr>`;
+    }
 
     container.innerHTML = `
         <!-- 백테스트 기간 배너 -->


### PR DESCRIPTION
## Summary
- SpyEngine이 새로 추가됨에 따라 하드코딩된 별도 SPY 벤치마크 계산 제거
- SpyEngine을 일반 엔진과 동일하게 비교 대상에 포함

## Changes
- `engines.json`: SpyEngine 추가 (5개 → 6개 엔진)
- `engines_meta.json`: SpyEngine 색상(`#fd7e14`, 오렌지) 등록
- `compare-ui.js`: 하드코딩된 SPY 열 제거, Alpha 행을 SpyEngine 포트폴리오 수익률 기준으로 변경
- `compare-charts.js`: `spy_price` 기반 "SPY Benchmark" 점선 라인 제거 (SpyEngine 라인으로 대체)

## Before / After
- **Before**: 메트릭 테이블에 SPY 열이 별도로 존재 (`spy_price` raw 데이터 계산), 차트에 점선 SPY 라인
- **After**: SpyEngine이 오렌지 실선으로 일반 엔진과 함께 표시, Alpha는 SpyEngine 대비 초과 수익률로 계산

## Test plan
- [ ] Backtest 모드(`?mode=backtest`) 접속 후 Overview 탭에서 SpyEngine 열 확인
- [ ] Performance 탭 차트에서 SpyEngine 라인(오렌지) 표시 확인
- [ ] Alpha (vs SPY) 행에서 SpyEngine 칸은 `-`, 나머지 엔진은 수익률 차이 표시 확인

https://claude.ai/code/session_01PgEF2oax6bFfHFz9sNd4gq