### PR TITLE
Add stock splits data handling to download-data workflow

### DIFF
--- a/.github/workflows/download-data.yml
+++ b/.github/workflows/download-data.yml
@@ -48,7 +48,7 @@ jobs:
         tickers = ['SSO', 'QLD', 'IEF', 'GLD', 'PDBC', 'SHV', 'SCHD', 'SPY', 'VOO', 'IEMG', 'EMB']
 
         cache = BacktestDataCache(logger=TradeLogger())
-        ohlcv, vix, dividends = cache.get_data(tickers, real_start_str, end_date)
+        ohlcv, vix, dividends, splits = cache.get_data(tickers, real_start_str, end_date)
 
         print(f'OHLCV shape: {ohlcv.shape}')
         print(f'OHLCV range: {ohlcv.index.min()} ~ {ohlcv.index.max()}')
@@ -66,6 +66,12 @@ jobs:
             print(dividends[dividends.any(axis=1)].head(10))
         else:
             print('Dividends: empty')
+        print(f'Splits shape: {splits.shape}')
+        if not splits.empty:
+            print(f'Splits range: {splits.index.min()} ~ {splits.index.max()}')
+            print(splits[splits.any(axis=1)].head(10))
+        else:
+            print('Splits: empty')
 
         print('')
         print('=== NaN 진단 (Close 기준) ===')


### PR DESCRIPTION
## Summary
Updated the data download workflow to handle stock splits data in addition to the existing OHLCV, VIX, and dividends data.

## Key Changes
- Modified `cache.get_data()` call to unpack an additional `splits` return value
- Added diagnostic output for splits data including:
  - Shape of the splits DataFrame
  - Date range of splits data (min/max index)
  - Sample of non-empty splits records (first 10 rows)
  - Empty state indicator when no splits data exists

## Implementation Details
The changes follow the same pattern as the existing dividends data handling, providing consistent diagnostic output for all data types retrieved from the cache. This allows for better visibility into the completeness and range of stock splits data being downloaded.

https://claude.ai/code/session_017LBb4i432Me4mbtXiKpWMw