### PR TITLE
feat: QqqSchdEngine 추가 (QQQ/SCHD, ratio_a=0.3)

### DIFF
--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -413,6 +413,23 @@ class QldSchdEngine(FullExposureEngine):
     REBALANCE_RATIO_A: float = 0.3
 
 
+@register_engine(color="#1f77b4")
+class QqqSchdEngine(FullExposureEngine):
+    """QQQ(A그룹) + SCHD(B그룹)으로 구성된 Full Exposure 전략 엔진.
+
+    - 자산군 A: [QQQ]  (나스닥 100 ETF)
+    - 자산군 B: [SCHD] (배당 성장 ETF)
+    - exposure=1.0 항상 유지 (FullExposureEngine 상속)
+    - A:B 비율 = 0.3:0.7 (성장보다 배당 비중 강조)
+    """
+
+    ASSET_GROUPS: dict = {
+        'A': ['QQQ'],
+        'B': ['SCHD'],
+    }
+    REBALANCE_RATIO_A: float = 0.3
+
+
 @register_engine(color="#fd7e14")
 class SpyEngine(FullExposureEngine):
     """SPY Buy&Hold 벤치마크 시뮬레이션 엔진.

--- a/tests/test_new_engines.py
+++ b/tests/test_new_engines.py
@@ -11,7 +11,7 @@ import math
 import pytest
 from unittest.mock import MagicMock, patch
 
-from src.core.engine import QldSHVEngine, QldSchdEngine, Asset5Engine
+from src.core.engine import QldSHVEngine, QldSchdEngine, Asset5Engine, QqqSchdEngine
 from src.core.logic import Rebalancer
 from src.core.models import (
     MarketData, MarketRegime, Portfolio, TradeSignal,
@@ -442,6 +442,191 @@ def test_engines_asset_groups_differ():
     """두 엔진의 B그룹 자산이 다르다 (SHV vs SCHD)."""
     assert QldSHVEngine.ASSET_GROUPS['B'] != QldSchdEngine.ASSET_GROUPS['B']
     assert QldSHVEngine.ASSET_GROUPS['A'] == QldSchdEngine.ASSET_GROUPS['A']
+
+
+# ─────────────────────────────────────────────────────────────────
+# QqqSchdEngine — 클래스 상수 검증
+# ─────────────────────────────────────────────────────────────────
+
+def test_qqq_schd_asset_groups_A():
+    """QqqSchdEngine의 A그룹은 [QQQ]."""
+    assert QqqSchdEngine.ASSET_GROUPS['A'] == ['QQQ']
+
+
+def test_qqq_schd_asset_groups_B():
+    """QqqSchdEngine의 B그룹은 [SCHD]."""
+    assert QqqSchdEngine.ASSET_GROUPS['B'] == ['SCHD']
+
+
+def test_qqq_schd_no_C_group():
+    """QqqSchdEngine에는 C그룹(현금)이 없다."""
+    assert 'C' not in QqqSchdEngine.ASSET_GROUPS
+
+
+def test_qqq_schd_rebalance_ratio_a_class_constant():
+    """REBALANCE_RATIO_A 클래스 상수가 0.3이다."""
+    assert QqqSchdEngine.REBALANCE_RATIO_A == 0.3
+
+
+# ─────────────────────────────────────────────────────────────────
+# QqqSchdEngine — 기본 Rebalancer 자동 생성
+# ─────────────────────────────────────────────────────────────────
+
+def _build_qqq_schd_engine(repo_last_reb=None, notifier=None):
+    """QqqSchdEngine을 Mock 의존성으로 조립."""
+    broker = MagicMock()
+    repo = MagicMock()
+    logger = MagicMock()
+    data_provider = MagicMock()
+
+    repo.get_last_rebalancing_date.return_value = repo_last_reb
+    repo.load_last_regime.return_value = None
+    broker.get_portfolio.return_value = _make_portfolio()
+    broker.fetch_current_prices.return_value = {}
+
+    with patch('src.core.engine.IndicatorCalculator') as MockCalc, \
+         patch('src.core.engine.RegimeAnalyzer') as MockAnalyzer, \
+         patch('src.core.engine.VolatilityTargeter') as MockTargeter, \
+         patch('src.core.engine.Rebalancer') as MockRebalancer:
+
+        calculator = MockCalc.return_value
+        analyzer = MockAnalyzer.return_value
+        analyzer._prev_regime = None
+        targeter = MockTargeter.return_value
+        rebalancer = MockRebalancer.return_value
+
+        engine = QqqSchdEngine(
+            broker=broker,
+            repo=repo,
+            logger=logger,
+            trading_interval_days=5,
+            notifier=notifier,
+        )
+
+    return engine, {
+        "calculator": calculator,
+        "analyzer": analyzer,
+        "targeter": targeter,
+        "rebalancer": rebalancer,
+        "broker": broker,
+        "repo": repo,
+        "logger": logger,
+        "data_provider": data_provider,
+    }
+
+
+def test_qqq_schd_default_rebalancer_groups():
+    """rebalancer가 클래스 ASSET_GROUPS로 자동 생성된다."""
+    broker, repo, logger = _make_base_deps()
+    with patch('src.core.engine.IndicatorCalculator'), \
+         patch('src.core.engine.RegimeAnalyzer'), \
+         patch('src.core.engine.VolatilityTargeter'):
+        engine = QqqSchdEngine(broker=broker, repo=repo, logger=logger)
+    assert engine.rebalancer.groups == QqqSchdEngine.ASSET_GROUPS
+
+
+def test_qqq_schd_default_rebalancer_ratio_a():
+    """rebalancer ratio_a=0.3으로 생성된다."""
+    broker, repo, logger = _make_base_deps()
+    with patch('src.core.engine.IndicatorCalculator'), \
+         patch('src.core.engine.RegimeAnalyzer'), \
+         patch('src.core.engine.VolatilityTargeter'):
+        engine = QqqSchdEngine(broker=broker, repo=repo, logger=logger)
+    assert engine.rebalancer.ratio_a == 0.3
+
+
+def test_qqq_schd_default_rebalancer_ratio_b():
+    """ratio_b = 1 - ratio_a = 0.7."""
+    broker, repo, logger = _make_base_deps()
+    with patch('src.core.engine.IndicatorCalculator'), \
+         patch('src.core.engine.RegimeAnalyzer'), \
+         patch('src.core.engine.VolatilityTargeter'):
+        engine = QqqSchdEngine(broker=broker, repo=repo, logger=logger)
+    assert abs(engine.rebalancer.ratio_b - 0.7) < 1e-9
+
+
+def test_qqq_schd_all_tickers():
+    """all_tickers는 QQQ + SCHD 조합이다."""
+    engine, _ = _build_qqq_schd_engine()
+    assert set(engine.all_tickers) == {"QQQ", "SCHD"}
+
+
+# ─────────────────────────────────────────────────────────────────
+# QqqSchdEngine — analyze_strategy (FullExposureEngine 상속)
+# ─────────────────────────────────────────────────────────────────
+
+def test_qqq_schd_bull_exposure_1():
+    """BULL 국면에서 exposure=1.0."""
+    engine, mocks = _build_qqq_schd_engine()
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    _, exposure, nan_fields = engine.analyze_strategy(_make_market_data())
+    assert exposure == 1.0
+    assert nan_fields == []
+
+
+def test_qqq_schd_crash_exposure_1():
+    """CRASH 국면에서도 exposure=1.0 (NaN 아닐 때)."""
+    engine, mocks = _build_qqq_schd_engine()
+    mocks["analyzer"].analyze.return_value = MarketRegime.CRASH
+    _, exposure, _ = engine.analyze_strategy(_make_market_data(vix=40.0, mdd=-0.30))
+    assert exposure == 1.0
+
+
+def test_qqq_schd_nan_exposure_zero():
+    """NaN 데이터 시 exposure=0.0 (안전장치)."""
+    engine, mocks = _build_qqq_schd_engine()
+    _, exposure, nan_fields = engine.analyze_strategy(_make_market_data(nan_vol=True))
+    assert exposure == 0.0
+    assert "spy_volatility" in nan_fields
+    mocks["analyzer"].analyze.assert_not_called()
+
+
+def test_qqq_schd_does_not_call_targeter():
+    """FullExposureEngine처럼 targeter를 호출하지 않는다."""
+    engine, mocks = _build_qqq_schd_engine()
+    mocks["analyzer"].analyze.return_value = MarketRegime.BEAR_WEAK
+    engine.analyze_strategy(_make_market_data())
+    mocks["targeter"].calculate_exposure.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────
+# QqqSchdEngine — end-to-end 사이클
+# ─────────────────────────────────────────────────────────────────
+
+def test_qqq_schd_end_to_end_rebalancing():
+    """전체 사이클: exposure=1.0이 rebalancer에 전달된다."""
+    engine, mocks = _build_qqq_schd_engine(repo_last_reb=None)
+    md = _make_market_data()
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["rebalancer"] = MagicMock()
+    engine.rebalancer = mocks["rebalancer"]
+    engine.rebalancer.generate_signal.return_value = TradeSignal(1.0, [], "Hold")
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    assert result.exposure == 1.0
+    call_args = engine.rebalancer.generate_signal.call_args
+    assert call_args[0][1] == 1.0
+
+
+def test_qqq_schd_end_to_end_nan_no_trade():
+    """NaN 시 전체 사이클: 매매 없이 종료."""
+    engine, mocks = _build_qqq_schd_engine(repo_last_reb=None)
+    md = _make_market_data(nan_vol=True)
+    mocks["calculator"].calculate.return_value = md
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    assert result.exposure == 0.0
+    assert result.is_rebalancing is False
+    assert result.executions == []
+
+
+def test_qqq_schd_a_group_differs_from_qld_schd():
+    """QqqSchdEngine과 QldSchdEngine의 A그룹이 다르다 (QQQ vs QLD)."""
+    assert QqqSchdEngine.ASSET_GROUPS['A'] != QldSchdEngine.ASSET_GROUPS['A']
+    assert QqqSchdEngine.ASSET_GROUPS['B'] == QldSchdEngine.ASSET_GROUPS['B']
 
 
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- FullExposureEngine 상속, A그룹=[QQQ], B그룹=[SCHD], REBALANCE_RATIO_A=0.3
- test_new_engines.py에 QqqSchdEngine 단위 테스트 추가 (상수/Rebalancer/analyze_strategy/e2e)

https://claude.ai/code/session_01LSS8fYvCWjrggag5E8dvrF