### PR TITLE
Reduce regime exposure targets for QLD/QQQ/SHV strategy

### DIFF
--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -497,11 +497,11 @@ class QldQqqShvRegimeEngine(TradingEngine):
     - 자산군 C: [SHV]  (초단기 국채 ETF — 현금 대용)
 
     국면별 배분 전략:
-    - BULL:        QLD 27% + QQQ 63% + SHV 10%  → 실효 레버리지 1.17x
-    - SIDEWAYS:    QLD 40% + QQQ 40% + SHV 20%  → 실효 레버리지 1.20x
-    - BEAR_WEAK:   QLD 56% + QQQ 24% + SHV 20%  → 실효 레버리지 1.36x
-    - BEAR_STRONG: QLD 77% + QQQ  9% + SHV 15%  → 실효 레버리지 1.62x
-    - CRASH:       QLD 90% + QQQ  5% + SHV  5%  → 실효 레버리지 1.85x
+    - BULL:        QLD 21% + QQQ 49% + SHV 30%  → 실효 레버리지 0.91x
+    - SIDEWAYS:    QLD 30% + QQQ 30% + SHV 40%  → 실효 레버리지 0.90x
+    - BEAR_WEAK:   QLD 42% + QQQ 18% + SHV 40%  → 실효 레버리지 1.02x
+    - BEAR_STRONG: QLD 59% + QQQ  7% + SHV 35%  → 실효 레버리지 1.24x
+    - CRASH:       QLD 71% + QQQ  4% + SHV 25%  → 실효 레버리지 1.46x
     """
 
     ASSET_GROUPS: dict = {
@@ -523,11 +523,11 @@ class QldQqqShvRegimeEngine(TradingEngine):
 
     # 국면별 exposure (A+B 위험자산 비중): BULL→CRASH 순으로 증가
     REGIME_EXPOSURE_MAP: Dict[MarketRegime, float] = {
-        MarketRegime.BULL:        0.9,
-        MarketRegime.SIDEWAYS:    0.8,
-        MarketRegime.BEAR_WEAK:   0.8,
-        MarketRegime.BEAR_STRONG: 0.85,
-        MarketRegime.CRASH:       0.95,
+        MarketRegime.BULL:        0.7,
+        MarketRegime.SIDEWAYS:    0.6,
+        MarketRegime.BEAR_WEAK:   0.6,
+        MarketRegime.BEAR_STRONG: 0.65,
+        MarketRegime.CRASH:       0.75,
     }
 
     def analyze_strategy(

--- a/tests/test_qld_qqq_shv_regime_engine.py
+++ b/tests/test_qld_qqq_shv_regime_engine.py
@@ -200,11 +200,11 @@ def test_regime_engine_all_tickers():
 # ─────────────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("regime,expected_exposure", [
-    (MarketRegime.BULL, 0.9),
-    (MarketRegime.SIDEWAYS, 0.8),
-    (MarketRegime.BEAR_WEAK, 0.8),
-    (MarketRegime.BEAR_STRONG, 0.85),
-    (MarketRegime.CRASH, 0.95),
+    (MarketRegime.BULL, 0.7),
+    (MarketRegime.SIDEWAYS, 0.6),
+    (MarketRegime.BEAR_WEAK, 0.6),
+    (MarketRegime.BEAR_STRONG, 0.65),
+    (MarketRegime.CRASH, 0.75),
 ])
 def test_regime_engine_exposure_per_regime(regime, expected_exposure):
     """각 국면에서 REGIME_EXPOSURE_MAP에 따른 exposure가 반환된다."""
@@ -237,33 +237,33 @@ def test_regime_engine_does_not_call_targeter():
 # ─────────────────────────────────────────────────────────────────
 
 def test_regime_engine_end_to_end_bull():
-    """BULL 사이클: exposure=0.9가 rebalancer에 전달된다."""
+    """BULL 사이클: exposure=0.7이 rebalancer에 전달된다."""
     engine, mocks = _build_regime_engine(repo_last_reb=None)
     md = _make_market_data()
     mocks["calculator"].calculate.return_value = md
     mocks["analyzer"].analyze.return_value = MarketRegime.BULL
     engine.rebalancer = MagicMock()
-    engine.rebalancer.generate_signal.return_value = TradeSignal(0.9, [], "Hold")
+    engine.rebalancer.generate_signal.return_value = TradeSignal(0.7, [], "Hold")
 
     result = engine.run_one_cycle(mocks["data_provider"])
 
-    assert result.exposure == 0.9
+    assert result.exposure == 0.7
     call_args = engine.rebalancer.generate_signal.call_args
-    assert call_args[0][1] == 0.9  # exposure 인자
+    assert call_args[0][1] == 0.7  # exposure 인자
 
 
 def test_regime_engine_end_to_end_crash():
-    """CRASH 사이클: exposure=0.95로 공격적 리밸런싱."""
+    """CRASH 사이클: exposure=0.75로 리밸런싱."""
     engine, mocks = _build_regime_engine(repo_last_reb=None)
     md = _make_market_data(vix=38.0, mdd=-0.28)
     mocks["calculator"].calculate.return_value = md
     mocks["analyzer"].analyze.return_value = MarketRegime.CRASH
     engine.rebalancer = MagicMock()
-    engine.rebalancer.generate_signal.return_value = TradeSignal(0.95, [], "Max Leverage")
+    engine.rebalancer.generate_signal.return_value = TradeSignal(0.75, [], "Max Leverage")
 
     result = engine.run_one_cycle(mocks["data_provider"])
 
-    assert result.exposure == 0.95
+    assert result.exposure == 0.75
     assert result.is_rebalancing is True
 
 


### PR DESCRIPTION
## Summary
Adjusted the exposure allocation targets across all market regimes in the QLD/QQQ/SHV regime engine to reduce overall leverage and risk. This represents a shift toward a more conservative positioning strategy.

## Key Changes
- **BULL regime**: Reduced exposure from 0.9 to 0.7 (effective leverage 1.17x → 0.91x)
- **SIDEWAYS regime**: Reduced exposure from 0.8 to 0.6 (effective leverage 1.20x → 0.90x)
- **BEAR_WEAK regime**: Reduced exposure from 0.8 to 0.6 (effective leverage 1.36x → 1.02x)
- **BEAR_STRONG regime**: Reduced exposure from 0.85 to 0.65 (effective leverage 1.62x → 1.24x)
- **CRASH regime**: Reduced exposure from 0.95 to 0.75 (effective leverage 1.85x → 1.46x)

Updated corresponding asset allocation percentages across all regimes to reflect the new exposure targets while maintaining the strategic positioning relative to market conditions.

## Implementation Details
- Modified `REGIME_EXPOSURE_MAP` in `QldQqqShvRegimeEngine` class to use new exposure values
- Updated docstring comments showing the new allocation percentages and effective leverage ratios for each regime
- Updated all related test cases to validate the new exposure values across different market regimes

https://claude.ai/code/session_01AhYuCWPhKLNBKa1EtmvEyj