### PR TITLE
feat: QldSchdShvEngine 추가 - QLD/SCHD/SHV 국면 적응형 엔진

### DIFF
--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -490,6 +490,79 @@ class Asset5Engine(FullExposureEngine):
     REBALANCE_RATIO_A: float = 0.4
 
 
+@register_engine(color="#e377c2")
+class QldSchdShvEngine(TradingEngine):
+    """QLD/SCHD/SHV 3-자산 국면 적응형 배당+레버리지 엔진.
+
+    SCHD(배당 성장)를 B그룹으로 활용하여 안정적 수익 기반을 확보하고,
+    국면에 따라 SHV(현금) 비중을 조절하여 하락장 방어력을 높인다.
+    - 자산군 A: [QLD]  (2x 레버리지 나스닥 ETF)
+    - 자산군 B: [SCHD] (배당 성장 ETF)
+    - 자산군 C: [SHV]  (초단기 국채 ETF — 현금 대용)
+
+    국면별 배분 전략 (QldSchdEngine 대비 방어력 강화):
+    - BULL:        QLD 27% + SCHD 63% + SHV 10%  → 공격적 배분
+    - SIDEWAYS:    QLD 21% + SCHD 49% + SHV 30%  → 현금 비중 확대
+    - BEAR_WEAK:   QLD 15% + SCHD 35% + SHV 50%  → 절반 현금화
+    - BEAR_STRONG: QLD  9% + SCHD 21% + SHV 70%  → 대부분 현금
+    - CRASH:       QLD  6% + SCHD 14% + SHV 80%  → 최소 투자
+    """
+
+    ASSET_GROUPS: dict = {
+        'A': ['QLD'],
+        'B': ['SCHD'],
+        'C': ['SHV'],
+    }
+
+    REBALANCE_RATIO_A: float = 0.3  # fallback (QldSchdEngine과 동일)
+
+    # 국면별 ratio_a (QLD vs SCHD 내 비중): 일관되게 0.3 유지
+    REGIME_RATIO_A_MAP: Dict[MarketRegime, float] = {
+        MarketRegime.BULL:        0.3,
+        MarketRegime.SIDEWAYS:    0.3,
+        MarketRegime.BEAR_WEAK:   0.3,
+        MarketRegime.BEAR_STRONG: 0.3,
+        MarketRegime.CRASH:       0.3,
+    }
+
+    # 국면별 exposure (A+B 위험자산 비중): 하락 시 공격적으로 축소
+    REGIME_EXPOSURE_MAP: Dict[MarketRegime, float] = {
+        MarketRegime.BULL:        0.9,
+        MarketRegime.SIDEWAYS:    0.7,
+        MarketRegime.BEAR_WEAK:   0.5,
+        MarketRegime.BEAR_STRONG: 0.3,
+        MarketRegime.CRASH:       0.2,
+    }
+
+    def analyze_strategy(
+        self, market_data: MarketData
+    ) -> Tuple[MarketRegime, float, List[str]]:
+        """Step 3 오버라이드: 국면별 고정 exposure 매핑 사용."""
+        nan_fields = market_data.nan_fields()
+        prev_regime = self.analyzer._prev_regime
+
+        if nan_fields:
+            self.logger.error(
+                f"NaN detected in: {', '.join(nan_fields)}. Treating as CRASH."
+            )
+            regime = MarketRegime.CRASH
+            exposure = 0.0
+        else:
+            regime = self.analyzer.analyze(market_data)
+            exposure = self.REGIME_EXPOSURE_MAP.get(regime, 0.8)
+
+        # 국면 변화 로그
+        if prev_regime is not None and regime != prev_regime:
+            self.logger.info(
+                f"Regime Change: {prev_regime.value} → {regime.value} "
+                f"(Price={market_data.spy_price:.2f}, MA180={market_data.spy_ma180:.2f}, "
+                f"Momentum={market_data.spy_momentum:.4f}, "
+                f"VIX={market_data.vix:.1f}, MDD={market_data.spy_mdd:.2%})"
+            )
+
+        return regime, exposure, nan_fields
+
+
 @register_engine(color="#8c564b")
 class QldQqqShvRegimeEngine(TradingEngine):
     """QLD/QQQ/SHV 3-자산 국면 적응형 레버리지 엔진.


### PR DESCRIPTION
QldSchdEngine의 변동성을 줄이기 위해 SHV(현금)를 C그룹으로 추가하고
국면별 exposure를 조절하는 새 엔진을 구현.

- BULL: 90% 투자 (QLD 27% + SCHD 63% + SHV 10%)
- BEAR_STRONG: 30% 투자 (QLD 9% + SCHD 21% + SHV 70%)
- CRASH: 20% 투자 (QLD 6% + SCHD 14% + SHV 80%)

https://claude.ai/code/session_0148BUudHLKziNjFzh8gxupK