### PR TITLE
feat: 백테스트 Performance 탭에 배당금 그래프 추가

### DIFF
--- a/docs/js/compare-charts.js
+++ b/docs/js/compare-charts.js
@@ -5,6 +5,8 @@ import { filterByDateRange, ENGINE_COLORS } from './utils.js?v=2';
 
 let comparePerformanceChart = null;
 let compareStrategyChart = null;
+let compareCumulativeDividendChart = null;
+let compareYearlyDividendChart = null;
 
 function getRegimeColor(regimeStr) {
     if (!regimeStr) return 'transparent';
@@ -194,6 +196,161 @@ export function renderCompareStrategyChart(enginesData) {
 }
 
 /**
+ * 멀티 엔진 누적 배당금 비교 차트 (오버레이 라인)
+ * @param {Map<string, Object>} enginesData
+ */
+export function renderCompareCumulativeDividendChart(enginesData) {
+    const canvas = document.getElementById('compareCumulativeDividendChart');
+    if (!canvas) return;
+
+    if (compareCumulativeDividendChart) compareCumulativeDividendChart.destroy();
+
+    const engineNames = [...enginesData.keys()];
+    const datasets = [];
+
+    // 전체 날짜 범위를 첫 번째 엔진 기준으로 설정
+    const firstSummary = enginesData.get(engineNames[0]).summary;
+    if (!firstSummary || firstSummary.length === 0) return;
+
+    for (const name of engineNames) {
+        const summary = enginesData.get(name).summary;
+        if (!summary) continue;
+
+        let cumulative = 0;
+        const dateMap = new Map();
+        summary.forEach(d => {
+            const div = d.daily_dividend || 0;
+            if (div > 0) {
+                cumulative += div;
+            }
+            dateMap.set(d.date, parseFloat(cumulative.toFixed(2)));
+        });
+
+        // 전체 날짜 기준으로 정렬된 데이터 생성
+        const data = firstSummary.map(d => dateMap.get(d.date) ?? null);
+        const hasDividend = data.some(v => v !== null && v > 0);
+
+        datasets.push({
+            label: name,
+            data: hasDividend ? data : firstSummary.map(() => 0),
+            borderColor: ENGINE_COLORS[name] || '#6c757d',
+            borderWidth: 2,
+            pointRadius: 0,
+            fill: false,
+            tension: 0.1,
+        });
+    }
+
+    const labels = firstSummary.map(d => d.date);
+
+    compareCumulativeDividendChart = new Chart(canvas, {
+        type: 'line',
+        data: { labels, datasets },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            scales: {
+                x: { grid: { display: false } },
+                y: {
+                    beginAtZero: true,
+                    title: { display: true, text: 'Cumulative Dividend ($)' },
+                    ticks: {
+                        callback: v => '$' + v.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 }),
+                    },
+                },
+            },
+            plugins: {
+                legend: { display: true, position: 'bottom', labels: { usePointStyle: true, padding: 15 } },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => `${ctx.dataset.label}: $${ctx.parsed.y.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+                    },
+                },
+            },
+        },
+    });
+}
+
+/**
+ * 멀티 엔진 월별 배당금 비교 바 차트 (최근 1년)
+ * @param {Map<string, Object>} enginesData
+ */
+export function renderCompareYearlyDividendChart(enginesData) {
+    const canvas = document.getElementById('compareYearlyDividendChart');
+    if (!canvas) return;
+
+    if (compareYearlyDividendChart) compareYearlyDividendChart.destroy();
+
+    // 최근 12개월 레이블 생성
+    const months = [];
+    const now = new Date();
+    for (let i = 11; i >= 0; i--) {
+        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`);
+    }
+    const labels = months.map(m => {
+        const [y, mo] = m.split('-');
+        return `${y}.${mo}`;
+    });
+
+    const oneYearAgo = new Date();
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+    const engineNames = [...enginesData.keys()];
+    const datasets = [];
+
+    for (const name of engineNames) {
+        const summary = enginesData.get(name).summary;
+        if (!summary) continue;
+
+        const monthlyMap = {};
+        summary.filter(d => new Date(d.date) >= oneYearAgo).forEach(d => {
+            const div = d.daily_dividend || 0;
+            if (div > 0) {
+                const month = d.date.slice(0, 7);
+                monthlyMap[month] = (monthlyMap[month] || 0) + div;
+            }
+        });
+
+        datasets.push({
+            label: name,
+            data: months.map(m => parseFloat((monthlyMap[m] || 0).toFixed(2))),
+            backgroundColor: ENGINE_COLORS[name] ? ENGINE_COLORS[name].replace(')', ', 0.65)').replace('rgb', 'rgba') : 'rgba(108,117,125,0.65)',
+            borderColor: ENGINE_COLORS[name] || '#6c757d',
+            borderWidth: 1,
+            borderRadius: 3,
+        });
+    }
+
+    compareYearlyDividendChart = new Chart(canvas, {
+        type: 'bar',
+        data: { labels, datasets },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            scales: {
+                x: { grid: { display: false } },
+                y: {
+                    beginAtZero: true,
+                    title: { display: true, text: 'Dividend ($)' },
+                    ticks: { callback: v => '$' + v.toFixed(0) },
+                },
+            },
+            plugins: {
+                legend: { display: true, position: 'bottom', labels: { usePointStyle: true, padding: 15 } },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => `${ctx.dataset.label}: $${ctx.parsed.y.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+                    },
+                },
+            },
+        },
+    });
+}
+
+/**
  * 시간 범위에 따라 비교 성과 차트 재렌더링
  */
 export function updateCompareChartRange(enginesData, range) {
@@ -208,7 +365,7 @@ export function updateCompareChartRange(enginesData, range) {
  * 비교 차트 리사이즈
  */
 export function resizeCompareCharts() {
-    [comparePerformanceChart, compareStrategyChart].forEach(chart => {
+    [comparePerformanceChart, compareStrategyChart, compareCumulativeDividendChart, compareYearlyDividendChart].forEach(chart => {
         if (chart) chart.resize();
     });
 }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -33,6 +33,8 @@ import {
 import {
     renderComparePerformanceChart,
     renderCompareStrategyChart,
+    renderCompareCumulativeDividendChart,
+    renderCompareYearlyDividendChart,
     updateCompareChartRange,
     resizeCompareCharts,
 } from './compare-charts.js?v=2';
@@ -164,6 +166,8 @@ async function loadCompareMode() {
         setupComparePerformanceHTML();
         renderComparePerformanceChart(enginesData);
         renderCompareStrategyChart(enginesData);
+        renderCompareCumulativeDividendChart(enginesData);
+        renderCompareYearlyDividendChart(enginesData);
         setupCompareTimeRangeSelector(enginesData);
         perfRendered = true;
     }
@@ -226,6 +230,29 @@ function setupComparePerformanceHTML() {
             <div class="card-body">
                 <div style="height: 300px;">
                     <canvas id="compareStrategyChart"></canvas>
+                </div>
+            </div>
+        </div>
+
+        <!-- Dividend Charts -->
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-header bg-white py-3">
+                <h5 class="mb-0"><i class="fas fa-hand-holding-usd me-2"></i>Cumulative Dividend Comparison</h5>
+            </div>
+            <div class="card-body">
+                <div style="height: 280px;">
+                    <canvas id="compareCumulativeDividendChart"></canvas>
+                </div>
+            </div>
+        </div>
+
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-header bg-white py-3">
+                <h5 class="mb-0"><i class="fas fa-calendar-alt me-2"></i>Monthly Dividend Comparison (Last 12M)</h5>
+            </div>
+            <div class="card-body">
+                <div style="height: 280px;">
+                    <canvas id="compareYearlyDividendChart"></canvas>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- compare-charts.js: renderCompareCumulativeDividendChart, renderCompareYearlyDividendChart 함수 추가
  - 전 엔진 누적 배당금 오버레이 라인 차트
  - 최근 12개월 엔진별 월별 배당금 비교 바 차트
  - resizeCompareCharts에 새 차트 인스턴스 포함
- main.js: 백테스트 Performance 탭 HTML에 배당금 차트 카드 2개 추가
  - compareCumulativeDividendChart, compareYearlyDividendChart 캔버스 삽입
  - renderPerformanceTab에서 두 배당금 함수 호출

https://claude.ai/code/session_014Srk2Ur51edk3hoFKfGbUr