### PR TITLE
feat: 월별 배당금 그래프를 연간 배당금 (전체 기간) 으로 변경

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -279,12 +279,12 @@
                             </div>
                         </div>
                     </div>
-                    <!-- Yearly Dividend (Monthly Bar) -->
+                    <!-- Yearly Dividend (Annual Bar) -->
                     <div class="col-lg-6">
                         <div class="card border-0 shadow-sm h-100">
                             <div class="card-header bg-white py-3">
-                                <h5 class="mb-0"><i class="fas fa-calendar-alt me-2 text-success"></i>최근 1년 월별 배당금</h5>
-                                <div class="text-muted small mt-1">최근 12개월 월별 수령 배당금</div>
+                                <h5 class="mb-0"><i class="fas fa-calendar-alt me-2 text-success"></i>연간 배당금</h5>
+                                <div class="text-muted small mt-1">전체 기간 연도별 수령 배당금</div>
                             </div>
                             <div class="card-body">
                                 <div style="height: 250px;">

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -262,51 +262,40 @@ export function renderCumulativeDividendChart(summaryData) {
 }
 
 /**
- * 최근 1년 월별 배당금 바 차트
+ * 전체 기간 연간 배당금 바 차트
  */
 export function renderYearlyDividendChart(summaryData) {
     const canvas = document.getElementById('yearlyDividendChart');
     if (!canvas) return;
 
-    // 최근 1년치 데이터 필터
-    const oneYearAgo = new Date();
-    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-
-    const recentData = summaryData.filter(d => new Date(d.date) >= oneYearAgo);
-
-    // 월별 집계
-    const monthlyMap = {};
-    recentData.forEach(d => {
+    // 전체 기간 연도별 집계
+    const yearlyMap = {};
+    summaryData.forEach(d => {
         const div = d.daily_dividend || 0;
         if (div > 0) {
-            const month = d.date.slice(0, 7); // "YYYY-MM"
-            monthlyMap[month] = (monthlyMap[month] || 0) + div;
+            const year = d.date.slice(0, 4); // "YYYY"
+            yearlyMap[year] = (yearlyMap[year] || 0) + div;
         }
     });
 
-    // 최근 12개월 레이블 생성 (배당이 없는 달도 0으로 표시)
-    const months = [];
-    const now = new Date();
-    for (let i = 11; i >= 0; i--) {
-        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-        const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-        months.push(key);
+    // 데이터 범위 내 연도 레이블 생성
+    const years = Object.keys(yearlyMap).sort();
+    if (years.length === 0 && summaryData.length > 0) {
+        const firstYear = summaryData[0].date.slice(0, 4);
+        const lastYear = summaryData[summaryData.length - 1].date.slice(0, 4);
+        for (let y = parseInt(firstYear); y <= parseInt(lastYear); y++) years.push(String(y));
     }
 
-    const labels = months.map(m => {
-        const [y, mo] = m.split('-');
-        return `${y}.${mo}`;
-    });
-    const barData = months.map(m => parseFloat((monthlyMap[m] || 0).toFixed(2)));
+    const barData = years.map(y => parseFloat((yearlyMap[y] || 0).toFixed(2)));
 
     if (yearlyDividendChart) yearlyDividendChart.destroy();
 
     yearlyDividendChart = new Chart(canvas, {
         type: 'bar',
         data: {
-            labels,
+            labels: years,
             datasets: [{
-                label: '월별 배당금 ($)',
+                label: '연간 배당금 ($)',
                 data: barData,
                 backgroundColor: barData.map(v =>
                     v > 0 ? 'rgba(25, 135, 84, 0.75)' : 'rgba(200, 200, 200, 0.3)'
@@ -325,7 +314,7 @@ export function renderYearlyDividendChart(summaryData) {
                 x: { grid: { display: false } },
                 y: {
                     beginAtZero: true,
-                    title: { display: true, text: 'Dividend ($)' },
+                    title: { display: true, text: 'Annual Dividend ($)' },
                     ticks: {
                         callback: v => '$' + v.toFixed(0)
                     }
@@ -335,7 +324,7 @@ export function renderYearlyDividendChart(summaryData) {
                 legend: { display: false },
                 tooltip: {
                     callbacks: {
-                        label: ctx => `배당금: $${ctx.parsed.y.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+                        label: ctx => `연간 배당금: $${ctx.parsed.y.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
                     }
                 }
             }

--- a/docs/js/compare-charts.js
+++ b/docs/js/compare-charts.js
@@ -273,7 +273,7 @@ export function renderCompareCumulativeDividendChart(enginesData) {
 }
 
 /**
- * 멀티 엔진 월별 배당금 비교 바 차트 (최근 1년)
+ * 멀티 엔진 연간 배당금 비교 바 차트 (전체 기간)
  * @param {Map<string, Object>} enginesData
  */
 export function renderCompareYearlyDividendChart(enginesData) {
@@ -282,40 +282,36 @@ export function renderCompareYearlyDividendChart(enginesData) {
 
     if (compareYearlyDividendChart) compareYearlyDividendChart.destroy();
 
-    // 최근 12개월 레이블 생성
-    const months = [];
-    const now = new Date();
-    for (let i = 11; i >= 0; i--) {
-        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-        months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`);
-    }
-    const labels = months.map(m => {
-        const [y, mo] = m.split('-');
-        return `${y}.${mo}`;
-    });
-
-    const oneYearAgo = new Date();
-    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-
     const engineNames = [...enginesData.keys()];
-    const datasets = [];
 
+    // 전체 기간의 연도 범위 수집
+    const yearSet = new Set();
+    for (const name of engineNames) {
+        const summary = enginesData.get(name).summary;
+        if (!summary) continue;
+        summary.forEach(d => {
+            if ((d.daily_dividend || 0) > 0) yearSet.add(d.date.slice(0, 4));
+        });
+    }
+    const years = [...yearSet].sort();
+
+    const datasets = [];
     for (const name of engineNames) {
         const summary = enginesData.get(name).summary;
         if (!summary) continue;
 
-        const monthlyMap = {};
-        summary.filter(d => new Date(d.date) >= oneYearAgo).forEach(d => {
+        const yearlyMap = {};
+        summary.forEach(d => {
             const div = d.daily_dividend || 0;
             if (div > 0) {
-                const month = d.date.slice(0, 7);
-                monthlyMap[month] = (monthlyMap[month] || 0) + div;
+                const year = d.date.slice(0, 4);
+                yearlyMap[year] = (yearlyMap[year] || 0) + div;
             }
         });
 
         datasets.push({
             label: name,
-            data: months.map(m => parseFloat((monthlyMap[m] || 0).toFixed(2))),
+            data: years.map(y => parseFloat((yearlyMap[y] || 0).toFixed(2))),
             backgroundColor: ENGINE_COLORS[name] ? ENGINE_COLORS[name].replace(')', ', 0.65)').replace('rgb', 'rgba') : 'rgba(108,117,125,0.65)',
             borderColor: ENGINE_COLORS[name] || '#6c757d',
             borderWidth: 1,
@@ -325,7 +321,7 @@ export function renderCompareYearlyDividendChart(enginesData) {
 
     compareYearlyDividendChart = new Chart(canvas, {
         type: 'bar',
-        data: { labels, datasets },
+        data: { labels: years, datasets },
         options: {
             responsive: true,
             maintainAspectRatio: false,
@@ -334,12 +330,22 @@ export function renderCompareYearlyDividendChart(enginesData) {
                 x: { grid: { display: false } },
                 y: {
                     beginAtZero: true,
-                    title: { display: true, text: 'Dividend ($)' },
+                    title: { display: true, text: 'Annual Dividend ($)' },
                     ticks: { callback: v => '$' + v.toFixed(0) },
                 },
             },
             plugins: {
-                legend: { display: true, position: 'bottom', labels: { usePointStyle: true, padding: 15 } },
+                legend: {
+                    display: true,
+                    position: 'bottom',
+                    labels: { usePointStyle: true, padding: 15 },
+                    onClick: (e, legendItem, legend) => {
+                        const index = legendItem.datasetIndex;
+                        const meta = legend.chart.getDatasetMeta(index);
+                        meta.hidden = !meta.hidden;
+                        legend.chart.update();
+                    },
+                },
                 tooltip: {
                     callbacks: {
                         label: ctx => `${ctx.dataset.label}: $${ctx.parsed.y.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -248,7 +248,7 @@ function setupComparePerformanceHTML() {
 
         <div class="card border-0 shadow-sm mb-4">
             <div class="card-header bg-white py-3">
-                <h5 class="mb-0"><i class="fas fa-calendar-alt me-2"></i>Monthly Dividend Comparison (Last 12M)</h5>
+                <h5 class="mb-0"><i class="fas fa-calendar-alt me-2"></i>Annual Dividend Comparison (Full Period)</h5>
             </div>
             <div class="card-body">
                 <div style="height: 280px;">


### PR DESCRIPTION
- charts.js: renderYearlyDividendChart - 최근 12개월 월별 집계 → 전체 기간 연도별 집계
- compare-charts.js: renderCompareYearlyDividendChart - 동일하게 연간 집계로 변경, 엔진 범례 클릭으로 보여주기/숨기기 지원
- main.js: 카드 타이틀 'Monthly Dividend Comparison (Last 12M)' → 'Annual Dividend Comparison (Full Period)'
- index.html: 카드 타이틀 '최근 1년 월별 배당금' → '연간 배당금', 부제 업데이트

https://claude.ai/code/session_012SzvnXQcnqQ6pD4Vq5xsqj