### PR TITLE
Replace VOO ticker with SPY across codebase

### DIFF
--- a/docs/data/backtest/compare/Asset5Engine/asset_groups.json
+++ b/docs/data/backtest/compare/Asset5Engine/asset_groups.json
@@ -1,7 +1,7 @@
 {
     "A": {
         "tickers": [
-            "VOO",
+            "SPY",
             "EEM"
         ],
         "label": "Growth",

--- a/docs/data/backtest/compare/Asset5Engine/history.json
+++ b/docs/data/backtest/compare/Asset5Engine/history.json
@@ -7,7 +7,7 @@
         "reason": "첫 투자: 40:60 비율로 진입",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 10,
                 "price": 191.16,

--- a/docs/data/backtest/compare/Asset5Engine/status.json
+++ b/docs/data/backtest/compare/Asset5Engine/status.json
@@ -19,7 +19,7 @@
         "cash_balance": 432.3931707317072,
         "holdings": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "qty": 10,
                 "price": 190.0,
                 "value": 1900.0

--- a/docs/data/backtest/compare/자산5분법/asset_groups.json
+++ b/docs/data/backtest/compare/자산5분법/asset_groups.json
@@ -1,7 +1,7 @@
 {
     "A": {
         "tickers": [
-            "VOO",
+            "SPY",
             "IEMG"
         ],
         "label": "Growth",

--- a/docs/data/backtest/compare/자산5분법/history.json
+++ b/docs/data/backtest/compare/자산5분법/history.json
@@ -7,7 +7,7 @@
         "reason": "첫 투자: 40:60 비율로 진입",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 12,
                 "price": 157.13,
@@ -86,7 +86,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 147.58,
@@ -232,7 +232,7 @@
         "reason": "비율 재조정: 상대이탈 2.5% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 169.96,
@@ -417,7 +417,7 @@
         "reason": "비율 유지, exposure 조정으로 주문 발생",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 217.16,
@@ -486,7 +486,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 210.96,
@@ -769,7 +769,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 252.2,
@@ -818,7 +818,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 202.72,
@@ -857,7 +857,7 @@
         "reason": "비율 재조정: 상대이탈 5.9% > 임계치 5.0%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 211.72,
@@ -926,7 +926,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 195.46,
@@ -955,7 +955,7 @@
         "reason": "비율 재조정: 상대이탈 5.9% > 임계치 5.0%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 229.04,
@@ -1004,7 +1004,7 @@
         "reason": "비율 재조정: 상대이탈 6.4% > 임계치 5.0%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 260.94,
@@ -1063,7 +1063,7 @@
         "reason": "비율 재조정: 상대이탈 28.1% > 임계치 7.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 2,
                 "price": 284.35,
@@ -1112,7 +1112,7 @@
         "reason": "비율 유지, exposure 조정으로 주문 발생",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 2,
                 "price": 288.87,
@@ -1161,7 +1161,7 @@
         "reason": "비율 재조정: 상대이탈 9.1% > 임계치 7.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 322.91,
@@ -1220,7 +1220,7 @@
         "reason": "비율 유지, exposure 조정으로 주문 발생",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 348.78,
@@ -1377,7 +1377,7 @@
         "reason": "비율 유지, exposure 조정으로 주문 발생",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 371.25,
@@ -1456,7 +1456,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 367.57,
@@ -1485,7 +1485,7 @@
         "reason": "비율 재조정: 상대이탈 4.1% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 389.22,
@@ -1564,7 +1564,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 345.2,
@@ -1603,7 +1603,7 @@
         "reason": "비율 재조정: 상대이탈 3.9% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 369.63,
@@ -1642,7 +1642,7 @@
         "reason": "비율 재조정: 상대이탈 24.6% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 2,
                 "price": 370.46,
@@ -1691,7 +1691,7 @@
         "reason": "비율 재조정: 상대이탈 6.1% > 임계치 5.0%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 2,
                 "price": 372.73,
@@ -1760,7 +1760,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 337.92,
@@ -1838,7 +1838,7 @@
         "reason": "비율 재조정: 상대이탈 2.9% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 362.75,
@@ -1916,7 +1916,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 363.09,
@@ -1945,7 +1945,7 @@
         "reason": "비율 재조정: 상대이탈 3.0% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 364.19,
@@ -2013,7 +2013,7 @@
         "reason": "비율 재조정: 상대이탈 3.1% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 364.82,
@@ -2042,7 +2042,7 @@
         "reason": "비율 재조정: 상대이탈 2.8% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 363.87,
@@ -2120,7 +2120,7 @@
         "reason": "비율 유지, exposure 조정으로 주문 발생",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 456.83,
@@ -2189,7 +2189,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 458.62,
@@ -2228,7 +2228,7 @@
         "reason": "비율 유지, exposure 조정으로 주문 발생",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 483.2,
@@ -2414,7 +2414,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 514.74,
@@ -2541,7 +2541,7 @@
         "reason": "비율 재조정: 상대이탈 5.2% > 임계치 2.5%",
         "executions": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "SELL",
                 "quantity": 1,
                 "price": 530.04,
@@ -2600,7 +2600,7 @@
                 "reason": ""
             },
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "action": "BUY",
                 "quantity": 1,
                 "price": 536.41,

--- a/docs/data/backtest/compare/자산5분법/status.json
+++ b/docs/data/backtest/compare/자산5분법/status.json
@@ -19,7 +19,7 @@
         "cash_balance": 1016.8197623256297,
         "holdings": [
             {
-                "ticker": "VOO",
+                "ticker": "SPY",
                 "qty": 9,
                 "price": 631.719970703125,
                 "value": 5685.479736328125

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -475,16 +475,16 @@ class QqqEngine(FullExposureEngine):
 
 @register_engine(color="#9467bd")
 class Asset5Engine(FullExposureEngine):
-    """자산5분법 — VOO/IEMG(A그룹) + TLT/EMB/GLD(B그룹) Full Exposure 전략 엔진.
+    """자산5분법 — SPY/IEMG(A그룹) + TLT/EMB/GLD(B그룹) Full Exposure 전략 엔진.
 
-    - 자산군 A: [VOO, IEMG]  (미국/신흥국 주식 ETF)
+    - 자산군 A: [SPY, IEMG]  (미국/신흥국 주식 ETF)
     - 자산군 B: [TLT, EMB, GLD] (장기국채, 신흥국채권, 금 ETF)
     - exposure=1.0 항상 유지 (FullExposureEngine 상속)
     - A:B 비율 = 0.4:0.6 (안전자산 비중 강조)
     """
 
     ASSET_GROUPS: dict = {
-        'A': ['VOO', 'EEM'],
+        'A': ['SPY', 'EEM'],
         'B': ['TLT', 'EMB', 'GLD'],
     }
     REBALANCE_RATIO_A: float = 0.4

--- a/tests/test_backtest_compare.py
+++ b/tests/test_backtest_compare.py
@@ -9,7 +9,7 @@ from src.backtest.runner import (
 
 
 # 모든 엔진의 티커 합집합 + SPY
-ALL_COMPARE_TICKERS = ["SPY", "SSO", "QLD", "IEF", "GLD", "DBC", "SHV", "SDY", "QQQ", "VOO", "EEM", "TLT", "EMB"]
+ALL_COMPARE_TICKERS = ["SPY", "SSO", "QLD", "IEF", "GLD", "DBC", "SHV", "SDY", "QQQ", "EEM", "TLT", "EMB"]
 
 
 @pytest.fixture

--- a/tests/test_new_engines.py
+++ b/tests/test_new_engines.py
@@ -634,8 +634,8 @@ def test_qqq_schd_a_group_differs_from_qld_schd():
 # ─────────────────────────────────────────────────────────────────
 
 def test_asset5_asset_groups_A():
-    """Asset5Engine의 A그룹은 [VOO, EEM]."""
-    assert Asset5Engine.ASSET_GROUPS['A'] == ['VOO', 'EEM']
+    """Asset5Engine의 A그룹은 [SPY, EEM]."""
+    assert Asset5Engine.ASSET_GROUPS['A'] == ['SPY', 'EEM']
 
 
 def test_asset5_asset_groups_B():
@@ -708,7 +708,7 @@ def test_asset5_all_tickers():
         MockAnalyzer.return_value._prev_regime = None
         engine = Asset5Engine(broker=broker, repo=repo, logger=logger)
 
-    assert set(engine.all_tickers) == {'VOO', 'EEM', 'TLT', 'EMB', 'GLD'}
+    assert set(engine.all_tickers) == {'SPY', 'EEM', 'TLT', 'EMB', 'GLD'}
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -726,8 +726,8 @@ def _build_asset5_engine(repo_last_reb=None, notifier=None):
     repo.load_last_regime.return_value = None
     broker.get_portfolio.return_value = Portfolio(
         total_cash=50000.0,
-        holdings={'VOO': 50},
-        current_prices={'VOO': 400.0, 'EEM': 50.0, 'TLT': 95.0, 'EMB': 90.0, 'GLD': 180.0},
+        holdings={'SPY': 50},
+        current_prices={'SPY': 400.0, 'EEM': 50.0, 'TLT': 95.0, 'EMB': 90.0, 'GLD': 180.0},
     )
     broker.fetch_current_prices.return_value = {}
 


### PR DESCRIPTION
- src/core/engine.py: Asset5Engine ASSET_GROUPS A그룹 VOO → SPY, docstring 업데이트
- tests/test_new_engines.py: 관련 테스트 assertions 및 mock 데이터 VOO → SPY
- tests/test_backtest_compare.py: ALL_COMPARE_TICKERS에서 중복 제거 (SPY 이미 포함)
- docs/data/backtest/compare/: Asset5Engine, 자산5분법 JSON 데이터 VOO → SPY

https://claude.ai/code/session_015ePGZ8ho7S36eQmRdc7dav