### PR TITLE
feat: 국내 계정 라이브 실거래용 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/live-trading-domestic.yml
+++ b/.github/workflows/live-trading-domestic.yml
@@ -1,0 +1,117 @@
+name: Live Trading - Domestic (KST 10:00)
+
+on:
+  schedule:
+    - cron: '0 1 * * 1-5'   # UTC 01:00 = KST 10:00, 월~금
+  workflow_dispatch:
+    inputs:
+      skip_holiday_check:
+        description: '한국 공휴일 체크를 건너뛰고 강제 실행 (수동 디버그용)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  live-domestic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: live-trading-domestic
+      cancel-in-progress: false   # 진행 중 주문 사이클을 중단시키지 않음
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: pip
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Check Korean holiday
+      id: holiday
+      if: ${{ inputs.skip_holiday_check != true }}
+      run: |
+        python - <<'PY'
+        import os, datetime, holidays
+        kr = holidays.country_holidays('KR')
+        # GitHub runner는 UTC → KST(UTC+9)로 변환하여 오늘 날짜 판정
+        today_kst = (datetime.datetime.utcnow() + datetime.timedelta(hours=9)).date()
+        is_holiday = today_kst in kr
+        name = kr.get(today_kst, "")
+        print(f"KST today={today_kst}, holiday={is_holiday}, name={name}")
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f"is_holiday={'true' if is_holiday else 'false'}\n")
+            f.write(f"kst_date={today_kst.isoformat()}\n")
+        PY
+
+    - name: Skip if holiday
+      if: ${{ steps.holiday.outputs.is_holiday == 'true' }}
+      run: |
+        echo "::notice title=Holiday Skip::${{ steps.holiday.outputs.kst_date }} 는 한국 공휴일입니다. 실행을 건너뜁니다."
+        exit 0
+
+    - name: Restore KIS token cache
+      if: ${{ steps.holiday.outputs.is_holiday != 'true' }}
+      id: token-cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: .kis_token_cache.json
+        key: kis-token-domestic-${{ github.run_id }}
+        restore-keys: |
+          kis-token-domestic-
+
+    - name: Run live trading bot (domestic)
+      if: ${{ steps.holiday.outputs.is_holiday != 'true' }}
+      env:
+        # 계정: MY_TEST (accounts.yaml의 kis_env_prefix: MY_TEST)
+        MY_TEST_KIS_APP_KEY: ${{ secrets.MY_TEST_KIS_APP_KEY }}
+        MY_TEST_KIS_APP_SECRET: ${{ secrets.MY_TEST_KIS_APP_SECRET }}
+        MY_TEST_KIS_ACC_NO: ${{ secrets.MY_TEST_KIS_ACC_NO }}
+        # 공용
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        PYTHONUNBUFFERED: "1"
+        # 향후 계정 추가 시:
+        # {NEW_PREFIX}_KIS_APP_KEY: ${{ secrets.{NEW_PREFIX}_KIS_APP_KEY }}
+        # {NEW_PREFIX}_KIS_APP_SECRET: ${{ secrets.{NEW_PREFIX}_KIS_APP_SECRET }}
+        # {NEW_PREFIX}_KIS_ACC_NO: ${{ secrets.{NEW_PREFIX}_KIS_ACC_NO }}
+      run: python src/main.py
+
+    - name: Save KIS token cache
+      if: ${{ always() && steps.holiday.outputs.is_holiday != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: .kis_token_cache.json
+        key: kis-token-domestic-${{ github.run_id }}
+
+    - name: Commit and push updated dashboard data
+      if: ${{ success() && steps.holiday.outputs.is_holiday != 'true' }}
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "chore(live): update domestic trading data [skip ci]"
+        file_pattern: "docs/data/**/*.json"
+        commit_user_name: "github-actions[bot]"
+        commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Notify Slack on failure
+      if: ${{ failure() && steps.holiday.outputs.is_holiday != 'true' }}
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      run: |
+        if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+          echo "SLACK_WEBHOOK_URL not set, skipping Slack notification"
+          exit 0
+        fi
+        RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\":rotating_light: Live Trading (Domestic) FAILED\n<${RUN_URL}|Run #${{ github.run_id }}>\"}" \
+          "$SLACK_WEBHOOK_URL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,17 +65,19 @@ accounts.yaml            # 멀티 계정 설정 (accounts.yaml.example 참고)
 - `kis_env_prefix` - 환경변수 prefix (예: "ACC1" → `ACC1_KIS_APP_KEY`)
 
 ## CI/CD
-GitHub Actions 워크플로우 5개:
+GitHub Actions 워크플로우 6개:
 - `python-test.yml` - main 브랜치 Push/PR 시 단위 테스트 (80% 커버리지 필수)
 - `broker-live-test.yml` - 수동 실행: KIS 브로커 라이브 API 테스트
 - `download-data.yml` - 수동 실행: 백테스트용 시장 데이터 다운로드
 - `gdrive-sync.yml` - main Push 또는 수동: Google Drive 백업
 - `run-compare-backtest.yml` - 수동 실행: 전략 엔진 비교 백테스트
+- `live-trading-domestic.yml` - 평일 KST 10:00 스케줄 + 수동 실행: 국내 계정 라이브 실거래. 한국 공휴일 자동 스킵, 실행 후 docs/data/**/*.json 자동 커밋
 
 테스트 시 `test_infra_broker_kis_domestic_live.py`는 CI에서 제외됨.
 
 ## 주의사항
-- .env 파일과 accounts.yaml은 절대 커밋하지 않을 것 (accounts.yaml.example 참고)
+- .env 파일은 절대 커밋하지 않을 것
+- accounts.yaml에는 민감 정보를 넣지 말 것 (KIS 키/계좌번호는 GitHub Secrets의 `{PREFIX}_KIS_*` 환경변수로만 주입)
 - 실거래 여부는 accounts.yaml의 `is_live` 필드로 계정별 설정
 - 매도 주문을 먼저 실행한 후 매수 진행 (자금 부족 방지)
 - YFinance API 실패 시 VIX 기본값 20.0 적용

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 matplotlib
 pytest-cov
 PyYAML
+holidays


### PR DESCRIPTION
평일 KST 10:00 (UTC 01:00) cron 스케줄 + 수동 실행 지원.
holidays 패키지로 한국 공휴일 자동 스킵, KIS 토큰 캐시,
실행 후 docs/data/**/*.json 자동 커밋, 실패 시 Slack 알림.

https://claude.ai/code/session_016UFWDn9kBmEKUBTKy5Z9NW