### PR TITLE
fix(ci): 스케줄 cron 정각(:00) → :05로 변경하여 GitHub 스케줄러 재등록

### DIFF
--- a/.github/workflows/live-trading-domestic.yml
+++ b/.github/workflows/live-trading-domestic.yml
@@ -2,7 +2,7 @@ name: Live Trading - Domestic (KST 10:00)
 
 on:
   schedule:
-    - cron: '0 1 * * 1-5'   # UTC 01:00 = KST 10:00, 월~금
+    - cron: '5 1 * * 1-5'   # UTC 01:05 = KST 10:05, 월~금
   workflow_dispatch:
     inputs:
       skip_holiday_check:


### PR DESCRIPTION
$(cat <<'EOF'
## 문제

`live-trading-domestic.yml` 워크플로우가 스케줄(`0 1 * * 1-5`)로 등록되어 있지만 실행 이력이 없음.

## 원인

GitHub Actions의 알려진 동작:
1. **첫 실행 누락 버그**: 신규로 추가된 `schedule` 워크플로우는 워크플로우 파일에 변경이 없으면 GitHub 내부 스케줄러에 등록되지 않아 첫 실행이 누락됨 ([GitHub Community 다수 보고](https://github.com/orgs/community/discussions/27145))
2. **정각(:00) 고부하**: `0 1 * * 1-5`처럼 매시 정각에 실행되는 스케줄은 GitHub Actions 큐 혼잡으로 누락될 수 있음

## 수정

`0 1 * * 1-5` → `5 1 * * 1-5` (UTC 01:05 = KST 10:05)

- 워크플로우 파일 변경 → GitHub가 스케줄을 재등록 → 내일(화)부터 정상 실행
- 정각 회피로 큐 혼잡 문제 해소

## 즉시 확인 방법

이 PR 머지 전에도 지금 바로 확인하려면:
- GitHub Actions 탭 → `Live Trading - Domestic` → `Run workflow` 수동 실행
- `skip_holiday_check = true`로 실행하면 공휴일 체크 없이 봇 동작 확인 가능

https://claude.ai/code/session_0184QqDMbFgBVj4Co8UaMPhP
EOF
)