### PR TITLE
fix(dashboard): Live 탭 데이터 로드 실패 오류 수정

### DIFF
--- a/docs/data/accounts.json
+++ b/docs/data/accounts.json
@@ -1,3 +1,3 @@
 [
-  "test_acc"
+  "my_test"
 ]

--- a/docs/data/accounts_meta.json
+++ b/docs/data/accounts_meta.json
@@ -1,7 +1,7 @@
 {
   "my_test": {
     "market_type": "domestic",
-    "engine_name": "DomesticAsset5Engine",
+    "engine_name": "DomesticAsset5RealEngine",
     "color": "#fd7e14",
     "is_live": true
   }

--- a/docs/data/accounts_meta.json
+++ b/docs/data/accounts_meta.json
@@ -1,8 +1,8 @@
 {
-  "test_acc": {
-    "market_type": "overseas",
-    "engine_name": "SpyEngine",
+  "my_test": {
+    "market_type": "domestic",
+    "engine_name": "DomesticAsset5Engine",
     "color": "#fd7e14",
-    "is_live": false
+    "is_live": true
   }
 }


### PR DESCRIPTION
## 문제
GitHub Pages Live 탭 접속 시 "데이터(data/) 로드 실패. 파일 생성을 기다려주세요." 오류 발생.

## 원인
`docs/data/accounts.json`이 `test_acc` 계정 ID를 참조하고 있었으나, 실제 데이터 파일은 `docs/data/my_test/` 디렉토리에 존재. 프론트엔드가 `data/test_acc/summary.json` 등을 fetch하면 404로 실패하여 catch 블록의 오류 메시지가 표시됨.

## 수정 내용
- `accounts.json`: `["test_acc"]` → `["my_test"]`
- `accounts_meta.json`: 키를 `my_test`로 변경, `market_type`을 `domestic`, `is_live`를 `true`로 실제 계정 정보에 맞게 수정

## 테스트 계획
- [ ] GitHub Pages Live 탭에서 데이터가 정상 로드되는지 확인
- [ ] Overview, Performance, Trades 탭 데이터 표시 확인

https://claude.ai/code/session_01KJa1AE3YFA4sLiY5pD92Te