### PR TITLE
fix: 국내주식 포트폴리오 현금 계산에서 CMA 제거

### DIFF
--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -99,9 +99,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
             output2_list = data.get('output2', [])
             summary = output2_list[0] if output2_list else {}
-            dnca = float(summary.get('dnca_tot_amt', 0) or 0)
-            cma = float(summary.get('cma_evlu_amt', 0) or 0)
-            total_cash = dnca + cma
+            total_cash = float(summary.get('dnca_tot_amt', 0) or 0)
 
             for item in data.get('output1', []):
                 qty = int(item.get('hldg_qty', 0) or 0)


### PR DESCRIPTION
## Summary

- `get_portfolio()`에서 `cma_evlu_amt`(CMA 평가금액)를 `dnca_tot_amt`(예수금)에 더하던 코드 제거
- `dnca_tot_amt`와 `cma_evlu_amt`는 KIS API에서 별개 필드이나, 사용 계좌에 CMA가 없으므로 불필요
- 3줄 → 1줄로 단순화

## Test plan

- [ ] 기존 `test_domestic_get_portfolio_*` 테스트 통과 확인 (mock 데이터에 `cma_evlu_amt` 미포함 → 동작 동일)

https://claude.ai/code/session_01BnpTpF66g794dEQwuF76Y1