### PR TITLE
fix: 포트폴리오 현금 조회를 D+2 예수금(prvs_rcdl_excc_amt)으로 변경

### DIFF
--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -99,7 +99,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
             output2_list = data.get('output2', [])
             summary = output2_list[0] if output2_list else {}
-            total_cash = float(summary.get('dnca_tot_amt', 0) or 0)
+            total_cash = float(summary.get('prvs_rcdl_excc_amt', 0) or 0)
 
             for item in data.get('output1', []):
                 qty = int(item.get('hldg_qty', 0) or 0)

--- a/tests/test_infra_broker_kis_domestic.py
+++ b/tests/test_infra_broker_kis_domestic.py
@@ -148,7 +148,7 @@ def test_domestic_get_portfolio_success(domestic_paper_broker, mock_requests):
             {'pdno': '005930', 'hldg_qty': '10', 'prpr': '72000'},
             {'pdno': '000660', 'hldg_qty': '5', 'prpr': '185000'},
         ],
-        'output2': [{'dnca_tot_amt': '5000000'}]
+        'output2': [{'prvs_rcdl_excc_amt': '5000000'}]
     }
     mock_requests.get.return_value = portfolio_response
 
@@ -185,7 +185,7 @@ def test_domestic_get_portfolio_zero_qty_excluded(domestic_paper_broker, mock_re
             {'pdno': '005930', 'hldg_qty': '10', 'prpr': '72000'},
             {'pdno': '000660', 'hldg_qty': '0', 'prpr': '185000'},
         ],
-        'output2': [{'dnca_tot_amt': '3000000'}]
+        'output2': [{'prvs_rcdl_excc_amt': '3000000'}]
     }
     mock_requests.get.return_value = portfolio_response
 
@@ -504,7 +504,7 @@ def test_domestic_execute_orders_sell_then_buy(domestic_paper_broker, mock_reque
     portfolio_response.json.return_value = {
         'rt_cd': '0',
         'output1': [],
-        'output2': [{'dnca_tot_amt': '1000000'}]
+        'output2': [{'prvs_rcdl_excc_amt': '1000000'}]
     }
     # 체결내역 (매수)
     buy_fill_response = MagicMock()
@@ -634,7 +634,7 @@ def test_get_portfolio_returns_ks_keys(domestic_paper_broker, mock_requests):
         'output1': [
             {'pdno': '069500', 'hldg_qty': '100', 'prpr': '13500'},
         ],
-        'output2': [{'dnca_tot_amt': '2000000'}]
+        'output2': [{'prvs_rcdl_excc_amt': '2000000'}]
     }
     mock_requests.get.return_value = portfolio_response
 


### PR DESCRIPTION
## Summary
- `kis_domestic.py`의 `get_portfolio()`에서 현금 조회 필드를 `dnca_tot_amt` → `prvs_rcdl_excc_amt`로 변경
- `dnca_tot_amt`(예수금 총액)는 미결제 금액을 포함하여 실제 매수 가능 금액보다 클 수 있음
- `prvs_rcdl_excc_amt`(D+2 예수금)는 결제 완료된 실제 사용 가능 현금을 반영

## Test plan
- [ ] `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/` 통과 확인
- [ ] KIS 브로커 라이브 테스트로 반환값 확인

https://claude.ai/code/session_013cjnXvqwGBg3c5Xs4CL93a