### PR TITLE
refactor(logs): CI 로그 가독성/정보량 개선

### DIFF
--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -267,11 +267,12 @@ class TradingEngine:
 
                 total = len(signal.orders)
                 filled = sum(1 for e in executions if e.status == ExecutionStatus.FILLED)
+                partial = sum(1 for e in executions if e.status == ExecutionStatus.PARTIAL)
                 ordered = sum(1 for e in executions if e.status == ExecutionStatus.ORDERED)
                 rejected = sum(1 for e in executions if e.status == ExecutionStatus.REJECTED)
                 failed = total - len(executions)
                 self.logger.info(
-                    f"Order Summary: total={total} filled={filled} "
+                    f"Order Summary: total={total} filled={filled} partial={partial} "
                     f"ordered={ordered} rejected={rejected} failed={failed}"
                 )
 

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -6,7 +6,8 @@ import pandas as pd
 
 from src.core.interfaces import IDataProvider, IBrokerAdapter, IRepository, ILogger, INotifier
 from src.core.models import (
-    MarketData, MarketRegime, Portfolio, TradeSignal, TradeExecution, DayResult
+    MarketData, MarketRegime, Portfolio, TradeSignal, TradeExecution, DayResult,
+    ExecutionStatus,
 )
 from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
 from src.utils.calculator import IndicatorCalculator
@@ -99,8 +100,8 @@ class TradingEngine:
         self.logger.info(">>> Step 2: Indicator Calculation")
         market_data = self.calculate_indicators(spy_df, vix)
         self.logger.info(
-            f"Market Data: Price={market_data.spy_price}, "
-            f"VIX={market_data.vix}, MDD={market_data.spy_mdd:.2%}"
+            f"Market Data: Price={market_data.spy_price:.2f}, "
+            f"VIX={market_data.vix:.2f}, MDD={market_data.spy_mdd:.2%}"
         )
 
         # Step 3: 국면 분석
@@ -124,6 +125,10 @@ class TradingEngine:
         # Step 6: 저장
         self.logger.info(">>> Step 6: Archiving Data")
         self.persist(market_data, signal, executions, final_pf, regime, exposure, is_rebalancing, sim_date, daily_dividend)
+        self.logger.info(
+            f"Cycle Completed: regime={regime.value} exposure={exposure:.2f} "
+            f"orders={len(signal.orders)} executions={len(executions)}"
+        )
 
         return DayResult(
             market_data=market_data,
@@ -257,9 +262,18 @@ class TradingEngine:
                 self._notify_alert(crash_msg)
 
             if signal.has_orders:
-                self.logger.info(f"Signal Generated: {signal.reason}")
-                self.logger.info(f"Executing {len(signal.orders)} orders...")
+                self.logger.info(f"Executing {len(signal.orders)} orders ({signal.reason})")
                 executions = self.broker.execute_orders(signal.orders)
+
+                total = len(signal.orders)
+                filled = sum(1 for e in executions if e.status == ExecutionStatus.FILLED)
+                ordered = sum(1 for e in executions if e.status == ExecutionStatus.ORDERED)
+                rejected = sum(1 for e in executions if e.status == ExecutionStatus.REJECTED)
+                failed = total - len(executions)
+                self.logger.info(
+                    f"Order Summary: total={total} filled={filled} "
+                    f"ordered={ordered} rejected={rejected} failed={failed}"
+                )
 
                 if executions:
                     self._notify_message(f"✅ Orders Executed. Count: {len(executions)}")

--- a/src/core/logic/rebalancer.py
+++ b/src/core/logic/rebalancer.py
@@ -235,9 +235,6 @@ class Rebalancer:
                     portfolio: Portfolio, eff_a: float) -> None:
         if not self._logger:
             return
-        self._logger.info("═" * 48)
-        self._logger.info(" Rebalancer.generate_signal 시작")
-        self._logger.info("═" * 48)
         self._logger.info(
             f"[입력] Regime={regime.value} | TargetExposure={target_exposure:.2f} "
             f"| TotalValue=${portfolio.total_value:,.2f} | Cash=${portfolio.total_cash:,.2f}"
@@ -306,4 +303,3 @@ class Rebalancer:
         else:
             self._logger.info("[최종 주문] 주문 없음")
         self._logger.info(f"[결정 사유] {reason}")
-        self._logger.info("═" * 48)

--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -52,7 +52,6 @@ class KisBrokerCommon(IBrokerAdapter):
             self.token_expires_at = datetime.fromisoformat(cached["expires_at"])
             return cached["access_token"]
 
-        self.logger.info("[KisBroker] 새 토큰 발급 중...")
         url = f"{self.base_url}/oauth2/tokenP"
         payload = {
             "grant_type": "client_credentials",
@@ -69,6 +68,9 @@ class KisBrokerCommon(IBrokerAdapter):
             self.token_expires_at = datetime.now() + timedelta(seconds=expires_in)
             token = data['access_token']
             self._save_token_to_cache(token, self.token_expires_at)
+            self.logger.info(
+                f"[KisBroker] 새 토큰 발급 완료 (expires_at={self.token_expires_at:%Y-%m-%d %H:%M:%S})"
+            )
             return token
         except Exception as e:
             self.logger.error(f"[KisBroker] Auth Error: {e}")
@@ -152,11 +154,15 @@ class KisBrokerCommon(IBrokerAdapter):
                 time.sleep(2)  # 정산 대기
 
             # === 3. 매수 실행 (주문 + 체결 대기 통합) ===
+            prev_cash: Optional[float] = None
             for order in buy_orders:
                 # 매수 주문마다 증권사 API로 실제 가용 금액 조회
                 pf = self.get_portfolio()
                 current_cash = pf.total_cash
-                self.logger.info(f"[KisBroker] Available Cash for BUY: {current_cash:,.0f}")
+                # 현금 변동이 있을 때만 로깅(동일 값 반복 노이즈 방지)
+                if prev_cash is None or current_cash != prev_cash:
+                    self.logger.info(f"[KisBroker] Available Cash for BUY: {current_cash:,.0f}")
+                    prev_cash = current_cash
 
                 # 안전 마진 (98%)
                 SAFE_MARGIN = 0.98

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -159,7 +159,10 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             resp_data = res.json()
 
             if resp_data['rt_cd'] != '0':
-                self.logger.error(f"[KisDomestic] Order Failed: {resp_data.get('msg1')}")
+                self.logger.error(
+                    f"[KisDomestic] Order Failed: {order.action} {order.ticker} "
+                    f"qty={order.quantity} @ {order_price} — {resp_data.get('msg1')}"
+                )
                 return None
 
             odno = resp_data.get('output', {}).get('ODNO', '')

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -144,7 +144,10 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             resp_data = res.json()
 
             if resp_data['rt_cd'] != '0':
-                self.logger.error(f"[KisBroker] Order Failed: {resp_data.get('msg1')}")
+                self.logger.error(
+                    f"[KisBroker] Order Failed: {order.action} {order.ticker} "
+                    f"qty={order.quantity} @ {order_price} — {resp_data.get('msg1')}"
+                )
                 return None
 
             self.logger.info(f"[KisBroker] Order Sent: {order.action} {order.ticker} {order.quantity} @ {order_price}")
@@ -211,7 +214,10 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             resp_data = res.json()
 
             if resp_data['rt_cd'] != '0':
-                self.logger.error(f"[KisBroker] Order Failed: {resp_data.get('msg1')}")
+                self.logger.error(
+                    f"[KisBroker] Order Failed: {order.action} {order.ticker} "
+                    f"qty={order.quantity} @ {order_price} — {resp_data.get('msg1')}"
+                )
                 return None
 
             odno = resp_data.get('output', {}).get('ODNO', '')

--- a/src/infra/broker/kis_token_cache.py
+++ b/src/infra/broker/kis_token_cache.py
@@ -24,7 +24,7 @@ def load_token_from_cache(app_key: str, logger) -> Optional[dict]:
             return None
         expires_at = datetime.fromisoformat(entry["expires_at"])
         if datetime.now() >= expires_at - timedelta(seconds=60):
-            logger.info("[KisBroker] 캐시 토큰 만료됨, 재발급 필요")
+            logger.debug("[KisBroker] 캐시 토큰 만료됨, 재발급 필요")
             return None
         return entry
     except Exception as e:
@@ -45,6 +45,6 @@ def save_token_to_cache(app_key: str, token: str, expires_at: datetime, logger) 
         }
         with open(KIS_TOKEN_CACHE_PATH, "w", encoding="utf-8") as f:
             json.dump(cache, f, ensure_ascii=False, indent=2)
-        logger.info(f"[KisBroker] 토큰 캐시 저장: {KIS_TOKEN_CACHE_PATH}")
+        logger.debug(f"[KisBroker] 토큰 캐시 저장: {KIS_TOKEN_CACHE_PATH}")
     except Exception as e:
         logger.warning(f"[KisBroker] 토큰 캐시 저장 실패 (무시): {e}")

--- a/src/infra/data.py
+++ b/src/infra/data.py
@@ -27,23 +27,21 @@ class YFinanceLoader(IDataProvider):
             
             return df
         except Exception as e:
-            self.logger.error(f"[Data] ❌ Error fetching OHLCV: {e}")
+            self.logger.error(f"[Data] Error fetching OHLCV: {e}")
             raise e
 
     def fetch_vix(self) -> float:
         """
         VIX 지수 조회 (안전장치 포함)
         """
-        self.logger.info("[Data] 🔍 Fetching VIX data from Yahoo Finance...")
-
         try:
             vix_df = yf.download("^VIX", period="5d", auto_adjust=False, progress=False)
 
             # 1. 데이터가 비어있는 경우
             if vix_df is None or vix_df.empty:
-                self.logger.warning("[Data] ⚠️ VIX DataFrame is empty! Returning safety default: 20.0")
+                self.logger.warning("[Data] VIX DataFrame is empty — fallback to 20.0")
                 return 20.0
-            
+
             # 2. 값 추출 (MultiIndex 대응)
             if isinstance(vix_df.columns, pd.MultiIndex):
                 close_series = vix_df.xs('Close', axis=1, level=0)
@@ -53,14 +51,14 @@ class YFinanceLoader(IDataProvider):
                     val = close_series.iloc[-1]
             else:
                 val = vix_df['Close'].iloc[-1]
-                
+
             vix_value = float(val)
-            self.logger.info(f"[Data] ✅ VIX successfully fetched: {vix_value:.2f}")
+            self.logger.info(f"[Data] VIX fetched: {vix_value:.2f}")
             return vix_value
 
         except Exception as e:
             # 3. 에러 발생 시
-            self.logger.error(f"[Data] ❌ Error fetching VIX: {e}. Returning safety default: 20.0")
+            self.logger.error(f"[Data] Error fetching VIX: {e} — fallback to 20.0")
             return 20.0
 
     def fetch_daily_dividends(self, tickers: List[str]) -> Dict[str, float]:
@@ -86,5 +84,5 @@ class YFinanceLoader(IDataProvider):
             row = divs.loc[today_ts]
             return {t: float(v) for t, v in row.items() if float(v) > 0}
         except Exception as e:
-            self.logger.error(f"[Data] ❌ Error fetching dividends: {e}. Returning empty.")
+            self.logger.error(f"[Data] Error fetching dividends: {e} — returning empty")
             return {}

--- a/tests/test_core_logic.py
+++ b/tests/test_core_logic.py
@@ -1259,7 +1259,7 @@ def test_create_group_orders_no_log_without_logger(create_portfolio):
 
 
 def test_generate_signal_logs_entry_context(create_portfolio):
-    """generate_signal은 시작 시 구분선, regime, exposure, total_value를 로깅해야 한다."""
+    """generate_signal은 시작 시 regime, exposure, total_value를 로깅해야 한다."""
     mock_logger = MagicMock()
     rebalancer = Rebalancer({'A': ['SPY'], 'B': ['IEF']}, logger=mock_logger)
     pf = create_portfolio(
@@ -1270,8 +1270,8 @@ def test_generate_signal_logs_entry_context(create_portfolio):
     rebalancer.generate_signal(pf, target_exposure=0.8, regime=MarketRegime.BULL)
 
     info_calls = [call.args[0] for call in mock_logger.info.call_args_list]
-    # 구분선 출력 확인
-    assert any('═' in msg or '====' in msg for msg in info_calls)
+    # 입력 컨텍스트 헤더 출력 확인
+    assert any('[입력]' in msg for msg in info_calls)
     # regime 로깅
     assert any('Bull' in msg or 'Regime' in msg for msg in info_calls)
     # exposure 로깅
@@ -1368,7 +1368,7 @@ def test_generate_signal_no_log_without_logger(create_portfolio):
 
 
 def test_generate_signal_logs_crash_rebalancing(create_portfolio):
-    """CRASH 시에도 구분선, 입력 정보, 주문 결과가 로깅되어야 한다."""
+    """CRASH 시에도 입력 정보, 주문 결과가 로깅되어야 한다."""
     mock_logger = MagicMock()
     rebalancer = Rebalancer({'A': ['SPY'], 'B': ['IEF'], 'C': ['SHV']}, logger=mock_logger)
     pf = create_portfolio(holdings={'SPY': 10}, prices={'SPY': 100.0, 'IEF': 100.0, 'SHV': 100.0})
@@ -1376,8 +1376,8 @@ def test_generate_signal_logs_crash_rebalancing(create_portfolio):
     signal = rebalancer.generate_signal(pf, target_exposure=0.0, regime=MarketRegime.CRASH)
 
     info_calls = [call.args[0] for call in mock_logger.info.call_args_list]
-    # 구분선과 입력 정보가 로깅되어야 함
-    assert any('Rebalancer' in msg or '═' in msg for msg in info_calls)
+    # 입력 정보가 로깅되어야 함
+    assert any('[입력]' in msg for msg in info_calls)
     # CRASH에서도 주문이 생성됨 (exposure=0 → 매도)
     assert signal.has_orders is True
 

--- a/tests/test_infra_data.py
+++ b/tests/test_infra_data.py
@@ -138,7 +138,7 @@ def test_fetch_vix_multiindex_structure(mock_yf_download, mock_logger):
     # 2. 검증
     assert vix == 25.5
     # 성공 로그가 찍혔는지 확인
-    mock_logger.info.assert_any_call("[Data] 🔍 Fetching VIX data from Yahoo Finance...")
+    mock_logger.info.assert_any_call("[Data] VIX fetched: 25.50")
 
 def test_fetch_vix_return_type_float(mock_yf_download, mock_logger):
     """


### PR DESCRIPTION
## Summary
`logs/ci/2026-04-22.log` 분석 결과 발견된 **정보 부족 로그**와 **중복·노이즈 로그**를 순차적으로 정리했습니다.

### 정보 부족 수정
- **Order Failed**에 주문 식별자(action/ticker/quantity/price) 추가 → 동일 에러 4건 발생 시에도 어떤 주문이 실패했는지 즉시 식별 가능 (`kis_domestic.py`, `kis_overseas.py` 2곳)
- **Market Data** 숫자 포맷 통일: `Price=704.0800170898438` → `Price=704.08`, `VIX=19.159999...` → `VIX=19.16`
- Step 6 직후 `Order Summary`(filled/ordered/rejected/failed)와 `Cycle Completed` 요약 추가 → 실행 결과 추적 가능

### 노이즈 축소
- 매수마다 찍히던 `Available Cash for BUY` → 현금 변동 시에만 로깅
- 토큰 발급 3줄(만료 안내/발급 중/캐시 저장) → 한 줄 `새 토큰 발급 완료 (expires_at=...)` 로 통합, 나머지는 DEBUG 강등
- `Signal Generated` + `[결정 사유]` 중복 제거 → `Executing N orders (reason)` 한 줄로 통합
- Rebalancer 구분선(═) 3줄 및 `Rebalancer.generate_signal 시작` 헤더 삭제 (Step 5 헤더와 중복)
- VIX/OHLCV/배당 로그 이모지(🔍 ✅ ⚠️ ❌) 제거, "Fetching VIX..." 시작 로그 제거 (완료 로그 하나면 충분)

## Test plan
- [x] `pytest --cov=src --cov-fail-under=80 tests/` — 602 passed, 4 skipped, 커버리지 94.13%
- [x] 변경된 로그 포맷을 검증하는 테스트 3건 업데이트
  - `test_generate_signal_logs_entry_context` (구분선 → `[입력]`)
  - `test_generate_signal_logs_crash_rebalancing` (구분선 → `[입력]`)
  - `test_fetch_vix_multiindex_structure` (`🔍 Fetching VIX` → `VIX fetched: 25.50`)

https://claude.ai/code/session_01LYa7XckBWoJd4YUN4iz9Dr