### PR TITLE
ci(live): 라이브 봇 스텝에 SLACK_BOT_TOKEN/SLACK_CHANNEL_ID 매핑 추가

### DIFF
--- a/.github/workflows/live-trading-domestic.yml
+++ b/.github/workflows/live-trading-domestic.yml
@@ -84,6 +84,9 @@ jobs:
         MY_TEST_KIS_ACC_NO: ${{ secrets.MY_TEST_KIS_ACC_NO }}
         # 공용
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_LIVE }}
+        # Slack Bot Token(스레드 댓글로 상세 로그 전송). 없으면 위 웹후크로 요약만 전송.
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
         PYTHONUNBUFFERED: "1"
         # 향후 계정 추가 시:
         # {NEW_PREFIX}_KIS_APP_KEY: ${{ secrets.{NEW_PREFIX}_KIS_APP_KEY }}


### PR DESCRIPTION
## 문제

PR #276에서 추가한 슬랙 스레드 댓글(상세 로그) 기능이, GitHub Actions 라이브 실행 시 동작하지 않고 **기존처럼 요약만** 전송되는 현상.

## 원인

`live-trading-domestic.yml`의 "Run live trading bot" 스텝 `env:`에 `SLACK_WEBHOOK_URL`만 매핑돼 있고 `SLACK_BOT_TOKEN`/`SLACK_CHANNEL_ID`가 빠져 있었습니다. GitHub Secret을 등록해도 워크플로우 `env:`에서 명시적으로 꺼내주지 않으면 `os.getenv("SLACK_BOT_TOKEN", "")`가 빈 문자열을 받습니다. 그 결과 `SlackNotifier`가 봇 토큰 경로를 건너뛰고 Webhook 폴백(요약만)으로 빠집니다.

## 변경

라이브 실행 스텝 `env:`에 두 환경변수를 매핑:

```yaml
SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
```

## 사용자 확인 필요

- GitHub 저장소 Secrets에 **`SLACK_BOT_TOKEN`**(`xoxb-...`), **`SLACK_CHANNEL_ID`**(`C...`)가 **이 이름 그대로** 등록돼 있어야 합니다. 다른 이름으로 등록했다면 `secrets.XXX` 참조를 맞춰 주세요.
- 봇이 대상 채널에 초대돼 있어야 하며(`/invite @앱`), `chat:write` 스코프가 필요합니다.

https://claude.ai/code/session_014iNufK9SQ22uPuYi18i7Rr

---
_Generated by [Claude Code](https://claude.ai/code/session_014iNufK9SQ22uPuYi18i7Rr)_