### PR TITLE
fix(ci): Google Drive 백업 워크플로우 수정 - rclone으로 교체

### DIFF
--- a/.github/workflows/gdrive-sync.yml
+++ b/.github/workflows/gdrive-sync.yml
@@ -10,19 +10,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 저장소 코드 불러오기
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: 코드를 ZIP 파일로 압축하기
-      # 파일명 자체를 업로드할 이름으로 지정하여 압축합니다.
       run: zip -r repo-StockAsset-latest-backup.zip . -x "*.git/*"
 
+    - name: rclone 설치
+      run: sudo apt-get install -y rclone
+
     - name: 구글 드라이브에 업로드하기 (OAuth 방식)
-      uses: logickoder/google-drive-upload@80e9dbe39d1136b6b0758781de3797364dc7135b # 1.0.1
-      with:
-        filename: repo-StockAsset-latest-backup.zip
-        folderId: ${{ secrets.GDRIVE_FOLDER_ID }}
-        clientId: ${{ secrets.GDRIVE_CLIENT_ID }}
-        clientSecret: ${{ secrets.GDRIVE_CLIENT_SECRET }}
-        refreshToken: ${{ secrets.GDRIVE_REFRESH_TOKEN }}
-        authType: oauth
-        overwrite: true
+      env:
+        GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
+        GDRIVE_CLIENT_SECRET: ${{ secrets.GDRIVE_CLIENT_SECRET }}
+        GDRIVE_REFRESH_TOKEN: ${{ secrets.GDRIVE_REFRESH_TOKEN }}
+        GDRIVE_FOLDER_ID: ${{ secrets.GDRIVE_FOLDER_ID }}
+      run: |
+        python3 -c "
+        import json, os
+        token = json.dumps({
+            'access_token': '',
+            'token_type': 'Bearer',
+            'refresh_token': os.environ['GDRIVE_REFRESH_TOKEN'],
+            'expiry': '0001-01-01T00:00:00Z'
+        })
+        config = '[gdrive]\ntype = drive\nclient_id = {}\nclient_secret = {}\ntoken = {}\n'.format(
+            os.environ['GDRIVE_CLIENT_ID'],
+            os.environ['GDRIVE_CLIENT_SECRET'],
+            token
+        )
+        os.makedirs(os.path.expanduser('~/.config/rclone'), exist_ok=True)
+        with open(os.path.expanduser('~/.config/rclone/rclone.conf'), 'w') as f:
+            f.write(config)
+        print('rclone 설정 완료')
+        "
+        rclone copy repo-StockAsset-latest-backup.zip gdrive: \
+          --drive-root-folder-id "$GDRIVE_FOLDER_ID" \
+          --verbose


### PR DESCRIPTION
## 문제

SHA 고정 커밋(`fcd1d0b`) 이후 Google Drive 백업 워크플로우가 실패함.

```
Error: Error: Input required and not supplied: credentials
```

`logickoder/google-drive-upload@80e9dbe39d1136b6b0758781de3797364dc7135b` (1.0.1) 버전이 기존 `@main`과 달리 `credentials` 입력을 추가로 요구하는 API로 변경되어, 기존에 설정한 OAuth 시크릿(`clientId`/`clientSecret`/`refreshToken`)과 호환되지 않음.

## 해결책

제3자 GitHub 액션(`logickoder/google-drive-upload`) 의존성을 제거하고, `rclone`을 직접 설치하여 Google Drive에 업로드.

- 기존 GitHub Secrets(`GDRIVE_CLIENT_ID`, `GDRIVE_CLIENT_SECRET`, `GDRIVE_REFRESH_TOKEN`, `GDRIVE_FOLDER_ID`) 그대로 재사용
- Python 스크립트로 rclone 설정 파일을 안전하게 생성 (시크릿 값이 JSON 특수문자를 포함하더라도 안전)
- `rclone copy` 명령어로 업로드 (동일 파일명 존재 시 덮어쓰기)

## 테스트 계획

- [ ] 워크플로우 수동 실행(`workflow_dispatch`)으로 Google Drive 업로드 동작 확인
- [ ] `repo-StockAsset-latest-backup.zip` 파일이 지정된 Google Drive 폴더에 업로드되는지 확인

https://claude.ai/code/session_01PaXcAk67qdmjdxtAWCiUWs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaXcAk67qdmjdxtAWCiUWs)_