### PR TITLE
fix(ci): rclone 토큰 인식 오류 수정 - root_folder_id를 설정 파일에 포함

### DIFF
--- a/.github/workflows/gdrive-sync.yml
+++ b/.github/workflows/gdrive-sync.yml
@@ -32,17 +32,16 @@ jobs:
             'token_type': 'Bearer',
             'refresh_token': os.environ['GDRIVE_REFRESH_TOKEN'],
             'expiry': '0001-01-01T00:00:00Z'
-        })
-        config = '[gdrive]\ntype = drive\nclient_id = {}\nclient_secret = {}\ntoken = {}\n'.format(
+        }, separators=(',', ':'))
+        config = '[gdrive]\ntype = drive\nclient_id = {}\nclient_secret = {}\ntoken = {}\nroot_folder_id = {}\n'.format(
             os.environ['GDRIVE_CLIENT_ID'],
             os.environ['GDRIVE_CLIENT_SECRET'],
-            token
+            token,
+            os.environ['GDRIVE_FOLDER_ID']
         )
         os.makedirs(os.path.expanduser('~/.config/rclone'), exist_ok=True)
         with open(os.path.expanduser('~/.config/rclone/rclone.conf'), 'w') as f:
             f.write(config)
         print('rclone 설정 완료')
         "
-        rclone copy repo-StockAsset-latest-backup.zip gdrive: \
-          --drive-root-folder-id "$GDRIVE_FOLDER_ID" \
-          --verbose
+        rclone copy repo-StockAsset-latest-backup.zip gdrive: --verbose


### PR DESCRIPTION
## 문제

PR #280 머지 후에도 `"there's no refresh token"` 오류가 계속 발생.

```
ERROR : Fatal error received - not attempting retries
Failed to copy: couldn't list directory: ... token expired and there's no refresh token
- manually refresh with "rclone config reconnect gdrive{SM3Vg}:"
```

## 원인

`--drive-root-folder-id`를 커맨드라인 플래그로 사용하면 rclone이 기존 `[gdrive]` 설정을 기반으로 `gdrive{임시ID}` 라는 동적 백엔드를 새로 생성합니다. 이 동적 백엔드가 설정 파일의 `token`(refresh_token 포함)을 제대로 상속받지 못해 인증 실패.

## 수정

- `root_folder_id`를 `rclone.conf`에 직접 포함
- `rclone copy` 명령에서 `--drive-root-folder-id` 플래그 제거
- `json.dumps(..., separators=(',', ':'))` 적용하여 compact JSON 형식 사용

## 테스트 계획

- [ ] `workflow_dispatch`로 수동 실행하여 Google Drive 업로드 정상 동작 확인

https://claude.ai/code/session_01PaXcAk67qdmjdxtAWCiUWs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaXcAk67qdmjdxtAWCiUWs)_