### PR TITLE
feat: 단일 계좌 대시보드 티커 → 한글 alias 매핑

### DIFF
--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -4,6 +4,7 @@
 import {
     filterByDateRange,
     getAssetGroup,
+    getTickerAlias,
     formatCurrency,
     formatAmount,
     computeMonthlyReturns,
@@ -939,7 +940,7 @@ export function renderMonthlyTradeFrequencyChart(historyData) {
 /**
  * 티커별 거래 기여 가로 바 차트
  */
-export function renderTickerContributionChart(historyData, marketType = 'overseas') {
+export function renderTickerContributionChart(historyData, marketType = 'overseas', groupConfig = null) {
     const canvas = document.getElementById('tickerContributionChart');
     if (!canvas) return;
     if (tickerContributionChart) tickerContributionChart.destroy();
@@ -948,7 +949,7 @@ export function renderTickerContributionChart(historyData, marketType = 'oversea
     if (data.length === 0) return;
 
     const currSymbol = marketType === 'domestic' ? '₩' : '$';
-    const labels = data.map(d => d.ticker);
+    const labels = data.map(d => getTickerAlias(d.ticker, groupConfig));
     const volumes = data.map(d => d.totalVolume);
 
     tickerContributionChart = new Chart(canvas, {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -188,9 +188,9 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
     updateSummaryCards(statusData, summaryData, marketType);
     renderGroupBarChart(statusData, groupConfig, marketType);
     renderHoldingsTable(statusData, groupConfig, marketType);
-    renderTodayActivity(historyData, statusData, marketType);
+    renderTodayActivity(historyData, statusData, marketType, groupConfig);
     updateDecisionLogic(summaryData[summaryData.length - 1]);
-    renderFailedOrderAlert(historyData);
+    renderFailedOrderAlert(historyData, groupConfig);
     renderStatusFreshnessBadge(statusData);
 
     let perfRendered = false;
@@ -229,14 +229,14 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
         renderFeeImpactCard(historyData, summaryData);
         renderTradeReasonPie(historyData);
         renderMonthlyTradeFrequencyChart(historyData);
-        renderTickerContributionChart(historyData, marketType);
-        renderTradeHistory(historyData, undefined, marketType);
+        renderTickerContributionChart(historyData, marketType, groupConfig);
+        renderTradeHistory(historyData, undefined, marketType, groupConfig);
         tradesRendered = true;
     }
 
     function renderOperationsTab() {
         if (opsRendered) return;
-        renderOperationsPanel(statusData, historyData, summaryData);
+        renderOperationsPanel(statusData, historyData, summaryData, groupConfig);
         opsRendered = true;
     }
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -540,7 +540,7 @@ export function renderFailedOrderAlert(historyData, groupConfig = null) {
 /**
  * Operations 탭 - 모든 카드/테이블 통합 렌더링
  */
-export function renderOperationsPanel(statusData, historyData, summaryData) {
+export function renderOperationsPanel(statusData, historyData, summaryData, groupConfig = null) {
     // [1] 마지막 실행 시각 카드
     const lastRunLabel = document.getElementById('ops-last-run-label');
     const lastRunTime = document.getElementById('ops-last-run-time');
@@ -596,7 +596,7 @@ export function renderOperationsPanel(statusData, historyData, summaryData) {
             failedTableBody.innerHTML = failed.slice().reverse().map(f => `
                 <tr>
                     <td class="ps-3 small text-muted">${f.date}</td>
-                    <td class="fw-bold">${f.ticker}</td>
+                    <td class="fw-bold">${getTickerAlias(f.ticker, groupConfig)}</td>
                     <td><span class="badge ${f.action === 'BUY' ? 'bg-success' : 'bg-danger'}">${f.action}</span></td>
                     <td class="text-end">${f.quantity}</td>
                     <td><span class="badge bg-warning text-dark">${f.status}</span></td>

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -170,7 +170,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
 /**
  * 오늘의 활동 영역 렌더링
  */
-export function renderTodayActivity(historyData, statusData, marketType = 'overseas') {
+export function renderTodayActivity(historyData, statusData, marketType = 'overseas', groupConfig = null) {
     const container = document.getElementById('today-activity');
     if (!historyData || historyData.length === 0) {
         container.innerHTML = `
@@ -189,7 +189,7 @@ export function renderTodayActivity(historyData, statusData, marketType = 'overs
     // 체결 종목 배지 생성
     let actionsHtml = lastTrade.executions.map(ex => `
         <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
-            ${ex.action} ${ex.ticker} (${ex.quantity})
+            ${ex.action} ${getTickerAlias(ex.ticker, groupConfig)} (${ex.quantity})
         </span>
     `).join('');
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -324,13 +324,17 @@ let currentPage = 1;
 const TRADES_PER_PAGE = 10;
 let cachedHistoryData = [];
 let cachedMarketType = 'overseas';
+let cachedGroupConfig = null;
 
 /**
  * 매매 기록 테이블 렌더링 (페이지네이션 지원)
  */
-export function renderTradeHistory(historyData, page = undefined, marketType = 'overseas') {
+export function renderTradeHistory(historyData, page = undefined, marketType = 'overseas', groupConfig = null) {
     cachedHistoryData = historyData;
     cachedMarketType = marketType;
+    if (groupConfig !== null) {
+        cachedGroupConfig = groupConfig;
+    }
     if (page !== undefined) currentPage = page;
 
     const tbody = document.getElementById('history-table-body');
@@ -357,7 +361,7 @@ export function renderTradeHistory(historyData, page = undefined, marketType = '
         // 체결 종목 배지 생성
         let actionsHtml = tx.executions.map(ex => `
             <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
-                ${ex.action} ${ex.ticker} (${ex.quantity})
+                ${ex.action} ${getTickerAlias(ex.ticker, cachedGroupConfig)} (${ex.quantity})
             </span>
         `).join('');
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -522,7 +522,7 @@ export function renderStatusFreshnessBadge(statusData) {
 /**
  * Overview 탭 - 미체결/실패 주문 상단 알림
  */
-export function renderFailedOrderAlert(historyData) {
+export function renderFailedOrderAlert(historyData, groupConfig = null) {
     const alert = document.getElementById('failed-order-alert');
     const text = document.getElementById('failed-order-alert-text');
     if (!alert || !text) return;
@@ -533,7 +533,7 @@ export function renderFailedOrderAlert(historyData) {
     }
     alert.classList.remove('d-none');
     const recent = failed.slice(-3).reverse();
-    const summary = recent.map(f => `${f.date} ${f.ticker} ${f.action} [${f.status}]`).join(', ');
+    const summary = recent.map(f => `${f.date} ${getTickerAlias(f.ticker, groupConfig)} ${f.action} [${f.status}]`).join(', ');
     text.innerHTML = ` ${failed.length}건 감지 — 최근: ${summary}`;
 }
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -5,6 +5,7 @@ import {
     getRegimeColorClass,
     getRegimeBannerClass,
     getAssetGroup,
+    getTickerAlias,
     formatCurrency,
     formatAmount,
     formatPercent,
@@ -141,7 +142,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
         rows += `
             <tr>
                 <td><span class="badge" style="background-color: ${g.color}">${g.group}: ${g.label}</span></td>
-                <td class="fw-bold">${h.ticker}</td>
+                <td class="fw-bold">${getTickerAlias(h.ticker, groupConfig)}</td>
                 <td class="text-end">${h.qty}</td>
                 <td class="text-end">${formatAmount(h.price, marketType)}</td>
                 <td class="text-end">${formatAmount(h.value, marketType)}</td>

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -645,3 +645,17 @@ export function getStatusFreshness(lastUpdatedISO, now = new Date()) {
     }
     return { label, colorClass, ageHours };
 }
+
+/**
+ * groupConfig.aliases에서 티커의 한글명(alias)을 반환.
+ * alias가 없으면 raw ticker를 그대로 반환.
+ * @param {string} ticker
+ * @param {Object|null} groupConfig - asset_groups.json 내용
+ * @returns {string}
+ */
+export function getTickerAlias(ticker, groupConfig) {
+    if (groupConfig && groupConfig.aliases && groupConfig.aliases[ticker]) {
+        return groupConfig.aliases[ticker];
+    }
+    return ticker;
+}

--- a/docs/plans/2026-06-19-ticker-alias-mapping.md
+++ b/docs/plans/2026-06-19-ticker-alias-mapping.md
@@ -1,0 +1,453 @@
+# Ticker Alias Mapping Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 단일 계좌 대시보드의 모든 티커 표시를 `asset_groups.json`의 `aliases`에 정의된 한글명으로 대체한다.
+
+**Architecture:** `utils.js`에 `getTickerAlias(ticker, groupConfig)` 헬퍼를 추가하고, `ui.js`와 `charts.js`의 티커 표시 함수들에 `groupConfig` 파라미터를 추가하여 alias를 적용한다. 기존 함수 시그니처는 선택적 파라미터로 하위 호환성을 유지한다.
+
+**Tech Stack:** Vanilla JavaScript (ES Modules), Browser-side rendering only (no Python changes)
+
+---
+
+## 배경 및 현황
+
+`asset_groups.json`의 `aliases` 필드 예시:
+```json
+{
+  "aliases": {
+    "226490.KS": "KODEX 코스피",
+    "133690.KS": "TIGER 미국나스닥100",
+    ...
+  }
+}
+```
+
+티커가 raw code로 표시되는 위치 목록:
+| 파일 | 함수 | 위치 | 표시 예 |
+|------|------|------|---------|
+| `ui.js` | `renderHoldingsTable` | 보유 종목 테이블 Ticker 컬럼 | `226490.KS` |
+| `ui.js` | `renderTodayActivity` | Today's Activity 배지 | `BUY 226490.KS (3)` |
+| `ui.js` | `renderTradeHistory` | Trade History 테이블 Actions 배지 | `BUY 226490.KS (3)` |
+| `ui.js` | `renderFailedOrderAlert` | 상단 미체결 알림 텍스트 | `226490.KS BUY` |
+| `ui.js` | `renderOperationsPanel` | Operations 탭 미체결 테이블 Ticker 컬럼 | `226490.KS` |
+| `charts.js` | `renderTickerContributionChart` | 종목별 거래 기여 차트 라벨 | `226490.KS` |
+
+---
+
+## Task 1: `getTickerAlias` 헬퍼 추가
+
+**Files:**
+- Modify: `docs/js/utils.js` (끝에 추가)
+
+**Step 1: 함수 추가**
+
+`docs/js/utils.js` 파일 끝에 아래 함수를 추가한다:
+
+```javascript
+/**
+ * groupConfig.aliases에서 티커의 한글명(alias)을 반환.
+ * alias가 없으면 raw ticker를 그대로 반환.
+ * @param {string} ticker
+ * @param {Object|null} groupConfig - asset_groups.json 내용
+ * @returns {string}
+ */
+export function getTickerAlias(ticker, groupConfig) {
+    if (groupConfig && groupConfig.aliases && groupConfig.aliases[ticker]) {
+        return groupConfig.aliases[ticker];
+    }
+    return ticker;
+}
+```
+
+**Step 2: 수동 검증**
+
+브라우저 콘솔에서:
+```javascript
+// groupConfig 예시
+const gc = { aliases: { "226490.KS": "KODEX 코스피" } };
+// 예상: "KODEX 코스피"
+// alias 없는 경우: "SSO" → "SSO"
+```
+
+**Step 3: Commit**
+
+```bash
+git add docs/js/utils.js
+git commit -m "feat(dashboard): add getTickerAlias helper to utils.js"
+```
+
+---
+
+## Task 2: `ui.js` - `renderHoldingsTable` 보유 종목 테이블
+
+**Files:**
+- Modify: `docs/js/ui.js`
+
+현재 코드 (line ~5):
+```javascript
+import {
+    ...
+} from './utils.js?v=3';
+```
+
+현재 코드 (line ~144):
+```javascript
+<td class="fw-bold">${h.ticker}</td>
+```
+
+**Step 1: import에 `getTickerAlias` 추가**
+
+`docs/js/ui.js` 상단 import에 `getTickerAlias` 추가:
+```javascript
+import {
+    getRegimeColorClass,
+    getRegimeBannerClass,
+    getAssetGroup,
+    getTickerAlias,          // ← 추가
+    formatCurrency,
+    ...
+} from './utils.js?v=3';
+```
+
+**Step 2: Ticker 컬럼을 alias로 교체**
+
+`renderHoldingsTable` 함수 내 (line ~144):
+```javascript
+// before:
+<td class="fw-bold">${h.ticker}</td>
+
+// after:
+<td class="fw-bold">${getTickerAlias(h.ticker, groupConfig)}</td>
+```
+
+**Step 3: 수동 검증 (브라우저 확인)**
+- Overview 탭 → Asset Allocation 테이블 → Ticker 컬럼에 `KODEX 코스피` 등 한글명 표시 확인
+- 해외 계좌(SSO, QLD 등)는 alias 없으므로 raw ticker 그대로 표시
+
+**Step 4: Commit**
+
+```bash
+git add docs/js/ui.js
+git commit -m "feat(dashboard): show ticker alias in holdings table"
+```
+
+---
+
+## Task 3: `ui.js` - `renderTodayActivity` Today's Activity 배지
+
+**Files:**
+- Modify: `docs/js/ui.js`
+- Modify: `docs/js/main.js` (call site 업데이트)
+
+**Step 1: 함수 시그니처에 groupConfig 추가**
+
+`renderTodayActivity` 함수 선언 변경:
+```javascript
+// before:
+export function renderTodayActivity(historyData, statusData, marketType = 'overseas') {
+
+// after:
+export function renderTodayActivity(historyData, statusData, marketType = 'overseas', groupConfig = null) {
+```
+
+**Step 2: 배지 내 ticker를 alias로 교체**
+
+같은 함수 내 (line ~191):
+```javascript
+// before:
+let actionsHtml = lastTrade.executions.map(ex => `
+    <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
+        ${ex.action} ${ex.ticker} (${ex.quantity})
+    </span>
+`).join('');
+
+// after:
+let actionsHtml = lastTrade.executions.map(ex => `
+    <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
+        ${ex.action} ${getTickerAlias(ex.ticker, groupConfig)} (${ex.quantity})
+    </span>
+`).join('');
+```
+
+**Step 3: `main.js` call site 업데이트**
+
+`docs/js/main.js`의 `_renderSingleAccount` 함수 내:
+```javascript
+// before:
+renderTodayActivity(historyData, statusData, marketType);
+
+// after:
+renderTodayActivity(historyData, statusData, marketType, groupConfig);
+```
+
+**Step 4: 수동 검증**
+- Overview 탭 → Today's Activity 배지에 `BUY KODEX 코스피 (3)` 형태로 표시
+
+**Step 5: Commit**
+
+```bash
+git add docs/js/ui.js docs/js/main.js
+git commit -m "feat(dashboard): show ticker alias in today's activity badges"
+```
+
+---
+
+## Task 4: `ui.js` - `renderTradeHistory` Trade History 배지
+
+**Files:**
+- Modify: `docs/js/ui.js`
+- Modify: `docs/js/main.js`
+
+**Step 1: 모듈 레벨 캐시 변수 추가**
+
+`renderTradeHistory` 위에 있는 모듈 레벨 변수들:
+```javascript
+// before:
+let cachedHistoryData = [];
+let cachedMarketType = 'overseas';
+
+// after:
+let cachedHistoryData = [];
+let cachedMarketType = 'overseas';
+let cachedGroupConfig = null;
+```
+
+**Step 2: 함수 시그니처에 groupConfig 추가 + 캐시 저장**
+
+```javascript
+// before:
+export function renderTradeHistory(historyData, page = undefined, marketType = 'overseas') {
+    cachedHistoryData = historyData;
+    cachedMarketType = marketType;
+
+// after:
+export function renderTradeHistory(historyData, page = undefined, marketType = 'overseas', groupConfig = null) {
+    cachedHistoryData = historyData;
+    cachedMarketType = marketType;
+    cachedGroupConfig = groupConfig;
+```
+
+**Step 3: 배지 내 ticker를 alias로 교체 (line ~359)**
+
+```javascript
+// before:
+let actionsHtml = tx.executions.map(ex => `
+    <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
+        ${ex.action} ${ex.ticker} (${ex.quantity})
+    </span>
+`).join('');
+
+// after:
+let actionsHtml = tx.executions.map(ex => `
+    <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
+        ${ex.action} ${getTickerAlias(ex.ticker, cachedGroupConfig)} (${ex.quantity})
+    </span>
+`).join('');
+```
+
+**Step 4: `main.js` call site 업데이트**
+
+`docs/js/main.js`의 `renderTradesTab` 내:
+```javascript
+// before:
+renderTradeHistory(historyData, undefined, marketType);
+
+// after:
+renderTradeHistory(historyData, undefined, marketType, groupConfig);
+```
+
+**Step 5: 수동 검증**
+- Trades 탭 → Trade History 테이블의 Actions 컬럼에 한글명 표시 확인
+- 페이지 이동 후에도 alias가 유지되는지 확인 (cachedGroupConfig 동작 검증)
+
+**Step 6: Commit**
+
+```bash
+git add docs/js/ui.js docs/js/main.js
+git commit -m "feat(dashboard): show ticker alias in trade history table"
+```
+
+---
+
+## Task 5: `ui.js` - `renderFailedOrderAlert` 미체결 알림
+
+**Files:**
+- Modify: `docs/js/ui.js`
+- Modify: `docs/js/main.js`
+
+**Step 1: 함수 시그니처에 groupConfig 추가**
+
+```javascript
+// before:
+export function renderFailedOrderAlert(historyData) {
+
+// after:
+export function renderFailedOrderAlert(historyData, groupConfig = null) {
+```
+
+**Step 2: 알림 텍스트 내 ticker를 alias로 교체 (line ~531)**
+
+```javascript
+// before:
+const summary = recent.map(f => `${f.date} ${f.ticker} ${f.action} [${f.status}]`).join(', ');
+
+// after:
+const summary = recent.map(f => `${f.date} ${getTickerAlias(f.ticker, groupConfig)} ${f.action} [${f.status}]`).join(', ');
+```
+
+**Step 3: `main.js` call site 업데이트**
+
+```javascript
+// before:
+renderFailedOrderAlert(historyData);
+
+// after:
+renderFailedOrderAlert(historyData, groupConfig);
+```
+
+**Step 4: Commit**
+
+```bash
+git add docs/js/ui.js docs/js/main.js
+git commit -m "feat(dashboard): show ticker alias in failed order alert"
+```
+
+---
+
+## Task 6: `ui.js` - `renderOperationsPanel` 미체결 주문 테이블
+
+**Files:**
+- Modify: `docs/js/ui.js`
+- Modify: `docs/js/main.js`
+
+**Step 1: 함수 시그니처에 groupConfig 추가**
+
+```javascript
+// before:
+export function renderOperationsPanel(statusData, historyData, summaryData) {
+
+// after:
+export function renderOperationsPanel(statusData, historyData, summaryData, groupConfig = null) {
+```
+
+**Step 2: 미체결 테이블 Ticker 컬럼을 alias로 교체 (line ~594)**
+
+```javascript
+// before:
+<td class="fw-bold">${f.ticker}</td>
+
+// after:
+<td class="fw-bold">${getTickerAlias(f.ticker, groupConfig)}</td>
+```
+
+**Step 3: `main.js` call site 업데이트**
+
+`renderOperationsTab` 내:
+```javascript
+// before:
+renderOperationsPanel(statusData, historyData, summaryData);
+
+// after:
+renderOperationsPanel(statusData, historyData, summaryData, groupConfig);
+```
+
+**Step 4: 수동 검증**
+- Operations 탭 → 미체결/실패 주문 상세 테이블 → Ticker 컬럼에 한글명 표시
+
+**Step 5: Commit**
+
+```bash
+git add docs/js/ui.js docs/js/main.js
+git commit -m "feat(dashboard): show ticker alias in operations panel"
+```
+
+---
+
+## Task 7: `charts.js` - `renderTickerContributionChart` 차트 라벨
+
+**Files:**
+- Modify: `docs/js/charts.js`
+
+**Step 1: import에 `getTickerAlias` 추가**
+
+`docs/js/charts.js` 상단 import:
+```javascript
+import {
+    getAssetGroup,
+    getTickerAlias,          // ← 추가
+    computeTickerContribution,
+    ...
+} from './utils.js?v=3';
+```
+
+**Step 2: 함수 시그니처에 groupConfig 추가 (line ~942)**
+
+```javascript
+// before:
+export function renderTickerContributionChart(historyData, marketType = 'overseas') {
+
+// after:
+export function renderTickerContributionChart(historyData, marketType = 'overseas', groupConfig = null) {
+```
+
+**Step 3: 차트 라벨을 alias로 교체 (line ~951)**
+
+```javascript
+// before:
+const labels = data.map(d => d.ticker);
+
+// after:
+const labels = data.map(d => getTickerAlias(d.ticker, groupConfig));
+```
+
+**Step 4: `main.js` call site 업데이트**
+
+`renderTradesTab` 내:
+```javascript
+// before:
+renderTickerContributionChart(historyData, marketType);
+
+// after:
+renderTickerContributionChart(historyData, marketType, groupConfig);
+```
+
+**Step 5: 수동 검증**
+- Trades 탭 → 종목별 거래 기여 차트 → Y축 라벨에 `KODEX 코스피` 등 한글명 표시
+
+**Step 6: Commit**
+
+```bash
+git add docs/js/charts.js docs/js/main.js
+git commit -m "feat(dashboard): show ticker alias in contribution chart labels"
+```
+
+---
+
+## Task 8: 최종 통합 검증 및 PR 생성
+
+**Step 1: `utils.js` 버전 캐시 확인**
+
+`ui.js`와 `charts.js`의 import에서 `utils.js?v=3` 버전 태그가 일치하는지 확인.
+`main.js`의 import에서도 `ui.js?v=3`, `charts.js?v=3` 등 버전이 일치하는지 확인.
+
+**Step 2: 전체 시나리오 수동 테스트 체크리스트**
+
+국내 계좌(domestic) 시나리오:
+- [ ] Overview 탭 → Asset Allocation 테이블 Ticker 컬럼: `226490.KS` → `KODEX 코스피`
+- [ ] Overview 탭 → Today's Activity 배지: `BUY 226490.KS` → `BUY KODEX 코스피`
+- [ ] Trades 탭 → Trade History Actions 배지: alias 적용 확인
+- [ ] Trades 탭 → 종목별 거래 기여 차트 라벨: alias 적용 확인
+- [ ] Trades 탭 → 페이지 이동 후에도 alias 유지 확인
+- [ ] Operations 탭 → 미체결 테이블 Ticker 컬럼: alias 적용 확인
+
+해외 계좌(overseas) 시나리오 (alias 없는 경우):
+- [ ] `SSO`, `QLD`, `IEF` 등 overseas 티커는 raw ticker 그대로 표시 확인
+
+**Step 3: PR 생성**
+
+```bash
+git push -u origin claude/ticker-alias-mapping-avco4p
+```
+
+그런 다음 GitHub MCP로 PR 생성.

--- a/docs/plans/2026-06-19-ticker-alias-mapping.md
+++ b/docs/plans/2026-06-19-ticker-alias-mapping.md
@@ -215,6 +215,9 @@ let cachedGroupConfig = null;
 
 **Step 2: 함수 시그니처에 groupConfig 추가 + 캐시 저장**
 
+페이지네이션 시 `groupConfig` 없이 호출되면 `null`로 덮어써 alias가 사라지는 버그를 방지하기 위해,
+`groupConfig`가 명시적으로 전달된 경우에만 캐시를 업데이트한다.
+
 ```javascript
 // before:
 export function renderTradeHistory(historyData, page = undefined, marketType = 'overseas') {
@@ -225,7 +228,9 @@ export function renderTradeHistory(historyData, page = undefined, marketType = '
 export function renderTradeHistory(historyData, page = undefined, marketType = 'overseas', groupConfig = null) {
     cachedHistoryData = historyData;
     cachedMarketType = marketType;
-    cachedGroupConfig = groupConfig;
+    if (groupConfig !== null) {
+        cachedGroupConfig = groupConfig;
+    }
 ```
 
 **Step 3: 배지 내 ticker를 alias로 교체 (line ~359)**


### PR DESCRIPTION
## Summary

- `asset_groups.json`의 `aliases` 필드를 활용해 국내 종목 번호 티커(`226490.KS` 등)를 한글명(`KODEX 코스피`)으로 표시
- `utils.js`에 `getTickerAlias(ticker, groupConfig)` 헬퍼 추가 (alias 없으면 raw ticker 폴백)
- 티커가 표시되는 모든 위치에 적용: 보유 종목 테이블, Today's Activity, Trade History, 미체결 알림, Operations 탭, 종목별 거래 기여 차트

## 변경 대상 파일

- `docs/js/utils.js` — `getTickerAlias()` 추가
- `docs/js/ui.js` — 5개 함수에 `groupConfig` 파라미터 추가 및 alias 적용
- `docs/js/charts.js` — `renderTickerContributionChart`에 alias 적용
- `docs/js/main.js` — 모든 call site에 `groupConfig` 전달

## Test plan

- [ ] 국내 계좌(domestic): Overview → Asset Allocation 테이블 Ticker 컬럼에 `KODEX 코스피` 등 한글명 표시
- [ ] Today's Activity 배지: `BUY KODEX 코스피 (3)` 형태 확인
- [ ] Trades 탭 → Trade History Actions 배지 + 페이지 이동 후에도 alias 유지
- [ ] Trades 탭 → 종목별 거래 기여 차트 라벨에 한글명 표시
- [ ] Operations 탭 → 미체결 테이블 Ticker 컬럼에 한글명 표시
- [ ] 해외 계좌(overseas): alias 없는 `SSO`, `QLD` 등은 raw ticker 그대로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1raorfGjWP5nk5Gb9N9zs

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1raorfGjWP5nk5Gb9N9zs)_