### PR TITLE
feat: 자산 배분 테이블에 포트폴리오 비율(%) 컬럼 추가

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,6 +181,7 @@
                                                 <th class="text-end">Qty</th>
                                                 <th class="text-end">Price</th>
                                                 <th class="text-end">Value</th>
+                                                <th class="text-end">Ratio</th>
                                             </tr>
                                         </thead>
                                         <tbody id="holdings-table-body">

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -127,6 +127,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
     const tbody = document.getElementById('holdings-table-body');
     const holdings = statusData.portfolio.holdings;
     const cash = statusData.portfolio.cash_balance;
+    const totalValue = statusData.portfolio.total_value;
 
     // 그룹별 정렬
     const sorted = [...holdings].sort((a, b) => {
@@ -139,6 +140,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
     sorted.forEach(h => {
         if (h.value <= 0 && h.qty <= 0) return; // 보유량 0인 항목 제외
         const g = getAssetGroup(h.ticker, groupConfig);
+        const ratio = totalValue > 0 ? Math.round(h.value / totalValue * 100) : 0;
         rows += `
             <tr>
                 <td><span class="badge" style="background-color: ${g.color}">${g.group}: ${g.label}</span></td>
@@ -146,6 +148,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
                 <td class="text-end">${h.qty}</td>
                 <td class="text-end">${formatAmount(h.price, marketType)}</td>
                 <td class="text-end">${formatAmount(h.value, marketType)}</td>
+                <td class="text-end">${ratio}%</td>
             </tr>
         `;
     });
@@ -153,6 +156,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
     // Cash 행 추가
     if (cash > 0) {
         const cashLabel = marketType === 'domestic' ? 'KRW' : 'USD';
+        const cashRatio = totalValue > 0 ? Math.round(cash / totalValue * 100) : 0;
         rows += `
             <tr class="table-light">
                 <td><span class="badge bg-secondary">Cash</span></td>
@@ -160,11 +164,12 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
                 <td class="text-end">-</td>
                 <td class="text-end">-</td>
                 <td class="text-end">${formatAmount(cash, marketType)}</td>
+                <td class="text-end">${cashRatio}%</td>
             </tr>
         `;
     }
 
-    tbody.innerHTML = rows || '<tr><td colspan="5" class="text-center text-muted">No holdings</td></tr>';
+    tbody.innerHTML = rows || '<tr><td colspan="6" class="text-center text-muted">No holdings</td></tr>';
 }
 
 /**

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -127,7 +127,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
     const tbody = document.getElementById('holdings-table-body');
     const holdings = statusData.portfolio.holdings;
     const cash = statusData.portfolio.cash_balance;
-    const totalValue = statusData.portfolio.total_value;
+    const totalValue = statusData.portfolio.total_value || (holdings.reduce((sum, h) => sum + (h.value || 0), 0) + (cash || 0));
 
     // 그룹별 정렬
     const sorted = [...holdings].sort((a, b) => {
@@ -140,7 +140,7 @@ export function renderHoldingsTable(statusData, groupConfig, marketType = 'overs
     sorted.forEach(h => {
         if (h.value <= 0 && h.qty <= 0) return; // 보유량 0인 항목 제외
         const g = getAssetGroup(h.ticker, groupConfig);
-        const ratio = totalValue > 0 ? Math.round(h.value / totalValue * 100) : 0;
+        const ratio = totalValue > 0 ? Math.round((h.value || 0) / totalValue * 100) : 0;
         rows += `
             <tr>
                 <td><span class="badge" style="background-color: ${g.color}">${g.group}: ${g.label}</span></td>


### PR DESCRIPTION
## Summary
- 단일계좌 대시보드의 Asset Allocation 테이블에 `Ratio` 컬럼 추가
- 각 종목의 전체 포트폴리오 대비 비율을 정수 `%` 형태로 표시 (예: `18%`)
- Cash 행에도 동일하게 비율 표시
- `total_value`(holdings + cash 합산)를 기준으로 계산하므로 전체 합계 = 100%

## Changes
- `docs/index.html`: 테이블 헤더에 `Ratio` 컬럼 추가
- `docs/js/ui.js`: `renderHoldingsTable` 함수에 비율 계산 및 렌더링 추가, "No holdings" fallback colspan 5→6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rR7qaf9Tr5JKyfWxAXibz

---
_Generated by [Claude Code](https://claude.ai/code/session_011rR7qaf9Tr5JKyfWxAXibz)_