### PR TITLE
feat: Performance 탭 국면별 성과 분석 테이블 추가 (#295)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -238,6 +238,33 @@
                     </div>
                 </div>
 
+                <!-- Regime Performance Analysis Table -->
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white py-3">
+                        <h5 class="mb-0"><i class="fas fa-table me-2"></i>국면별 성과 분석</h5>
+                        <div class="text-muted small mt-1">각 시장 국면에서의 수익률 및 리스크 — 핵심 가설(Bear/Crash 낙폭 축소) 수치 검증</div>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0 align-middle">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th class="ps-3">국면</th>
+                                        <th class="text-end">일수</th>
+                                        <th class="text-end">누적 수익률</th>
+                                        <th class="text-end">연환산 수익률</th>
+                                        <th class="text-end">국면 내 MDD</th>
+                                        <th class="text-end pe-3">전체 비율</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="regime-performance-table-body">
+                                    <tr><td class="ps-3 text-muted" colspan="6">Loading...</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Rolling Returns + DD/Calmar Cards -->
                 <div class="row g-3 mb-4">
                     <div class="col-6 col-md-4 col-lg-2">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -36,7 +36,8 @@ import {
     renderFeeImpactCard,
     renderStatusFreshnessBadge,
     renderFailedOrderAlert,
-    renderOperationsPanel
+    renderOperationsPanel,
+    renderRegimePerformanceTable
 } from './ui.js?v=3';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=4';
@@ -201,6 +202,7 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
     function renderPerformanceTab() {
         if (perfRendered) return;
         renderPerformanceSummaryCards(summaryData);
+        renderRegimePerformanceTable(summaryData);
         renderRollingReturnCards(summaryData);
         renderCurrentDrawdownCard(summaryData);
         renderCalmarCard(summaryData);

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -18,7 +18,8 @@ import {
     computeCurrentRegimeStreak,
     computeFailedExecutions,
     inferNextRebalanceDate,
-    getStatusFreshness
+    getStatusFreshness,
+    computeRegimePerformance
 } from './utils.js?v=3';
 
 /**
@@ -627,4 +628,45 @@ export function renderOperationsPanel(statusData, historyData, summaryData, grou
     setText('ops-target-exposure', statusData.strategy ? (statusData.strategy.target_exposure * 100).toFixed(0) + '%' : '-');
     setText('ops-trigger-reason', (statusData.strategy && statusData.strategy.trigger_reason) || '-');
     setText('ops-total-trades', (historyData || []).length + '건');
+}
+
+/**
+ * Performance 탭 - 국면별 성과 분석 테이블 렌더링
+ */
+export function renderRegimePerformanceTable(summaryData) {
+    const tbody = document.getElementById('regime-performance-table-body');
+    if (!tbody) return;
+
+    const rows = computeRegimePerformance(summaryData);
+    if (rows.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">데이터 없음</td></tr>';
+        return;
+    }
+
+    // 국면 표시 순서 정의
+    const ORDER = ['Bull', 'Sideways', 'Bear_Weak', 'Bear_Strong', 'Crash', 'Unknown'];
+    rows.sort((a, b) => {
+        const ai = ORDER.indexOf(a.regime);
+        const bi = ORDER.indexOf(b.regime);
+        return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
+    });
+
+    tbody.innerHTML = rows.map(row => {
+        const colorClass = getRegimeColorClass(row.regime);
+        const cumClass = row.cumulativeReturn >= 0 ? 'text-success' : 'text-danger';
+        const annClass = row.annualized >= 0 ? 'text-success' : 'text-danger';
+        const mddClass = row.mdd < -5 ? 'text-danger' : 'text-muted';
+        const regimeLabel = row.regime.replace('_', ' ');
+
+        return `
+            <tr>
+                <td class="ps-3 fw-bold"><span class="${colorClass}">${regimeLabel}</span></td>
+                <td class="text-end">${row.days.toLocaleString()}</td>
+                <td class="text-end fw-bold ${cumClass}">${row.cumulativeReturn >= 0 ? '+' : ''}${row.cumulativeReturn.toFixed(2)}%</td>
+                <td class="text-end ${annClass}">${row.annualized >= 0 ? '+' : ''}${row.annualized.toFixed(1)}%</td>
+                <td class="text-end ${mddClass}">${row.mdd.toFixed(2)}%</td>
+                <td class="text-end pe-3 text-muted">${row.periodPct.toFixed(1)}%</td>
+            </tr>
+        `;
+    }).join('');
 }

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -647,6 +647,55 @@ export function getStatusFreshness(lastUpdatedISO, now = new Date()) {
 }
 
 /**
+ * 국면별 성과 분석 (일간 복리 합산 방식)
+ * @param {Array} summaryData - summary 배열 (regime, total_value 필드 필요)
+ * @returns {Array<{regime, days, cumulativeReturn, annualized, mdd, periodPct}>}
+ */
+export function computeRegimePerformance(summaryData) {
+    if (!summaryData || summaryData.length < 2) return [];
+
+    const totalDays = summaryData.length;
+
+    // 국면별 일간 수익률 및 자산가 버킷 수집
+    const buckets = {};
+    for (let i = 1; i < summaryData.length; i++) {
+        const regime = summaryData[i].regime || 'Unknown';
+        const r = summaryData[i - 1].total_value > 0
+            ? summaryData[i].total_value / summaryData[i - 1].total_value - 1
+            : 0;
+        if (!buckets[regime]) buckets[regime] = { returns: [], values: [summaryData[i - 1].total_value] };
+        buckets[regime].returns.push(r);
+        buckets[regime].values.push(summaryData[i].total_value);
+    }
+
+    return Object.entries(buckets).map(([regime, { returns, values }]) => {
+        const days = returns.length;
+
+        // 누적 수익률 (복리)
+        const cumulativeReturn = (returns.reduce((acc, r) => acc * (1 + r), 1) - 1) * 100;
+
+        // 연환산 수익률 (평균 일간 수익률 기준)
+        const avgDaily = returns.reduce((s, r) => s + r, 0) / days;
+        const annualized = (Math.pow(1 + avgDaily, 252) - 1) * 100;
+
+        // 국면 내 MDD
+        let peak = -Infinity;
+        let mdd = 0;
+        values.forEach(v => {
+            if (v > peak) peak = v;
+            const dd = peak > 0 ? (v - peak) / peak : 0;
+            if (dd < mdd) mdd = dd;
+        });
+        mdd = mdd * 100;
+
+        // 전체 기간 비율
+        const periodPct = (days / totalDays) * 100;
+
+        return { regime, days, cumulativeReturn, annualized, mdd, periodPct };
+    });
+}
+
+/**
  * groupConfig.aliases에서 티커의 한글명(alias)을 반환.
  * alias가 없으면 raw ticker를 그대로 반환.
  * @param {string} ticker

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -654,21 +654,21 @@ export function getStatusFreshness(lastUpdatedISO, now = new Date()) {
 export function computeRegimePerformance(summaryData) {
     if (!summaryData || summaryData.length < 2) return [];
 
-    const totalDays = summaryData.length;
+    // 분모를 수익률 일수(n-1)로 설정해야 전체 비율 합이 100%가 됨
+    const totalActiveDays = summaryData.length - 1;
 
-    // 국면별 일간 수익률 및 자산가 버킷 수집
+    // 국면별 일간 수익률만 수집 (절대 자산가 미사용 — 비연속 국면 MDD 오류 방지)
     const buckets = {};
     for (let i = 1; i < summaryData.length; i++) {
         const regime = summaryData[i].regime || 'Unknown';
         const r = summaryData[i - 1].total_value > 0
             ? summaryData[i].total_value / summaryData[i - 1].total_value - 1
             : 0;
-        if (!buckets[regime]) buckets[regime] = { returns: [], values: [summaryData[i - 1].total_value] };
-        buckets[regime].returns.push(r);
-        buckets[regime].values.push(summaryData[i].total_value);
+        if (!buckets[regime]) buckets[regime] = [];
+        buckets[regime].push(r);
     }
 
-    return Object.entries(buckets).map(([regime, { returns, values }]) => {
+    return Object.entries(buckets).map(([regime, returns]) => {
         const days = returns.length;
 
         // 누적 수익률 (복리)
@@ -678,18 +678,20 @@ export function computeRegimePerformance(summaryData) {
         const avgDaily = returns.reduce((s, r) => s + r, 0) / days;
         const annualized = (Math.pow(1 + avgDaily, 252) - 1) * 100;
 
-        // 국면 내 MDD
-        let peak = -Infinity;
+        // 국면 내 MDD: 복리 누적 곡선 기준으로 계산 (비연속 국면에서도 정확)
+        let peak = 1;
+        let current = 1;
         let mdd = 0;
-        values.forEach(v => {
-            if (v > peak) peak = v;
-            const dd = peak > 0 ? (v - peak) / peak : 0;
+        returns.forEach(r => {
+            current = current * (1 + r);
+            if (current > peak) peak = current;
+            const dd = (current - peak) / peak;
             if (dd < mdd) mdd = dd;
         });
         mdd = mdd * 100;
 
-        // 전체 기간 비율
-        const periodPct = (days / totalDays) * 100;
+        // 전체 기간 비율 (분모: 수익률 일수 = n-1)
+        const periodPct = (days / totalActiveDays) * 100;
 
         return { regime, days, cumulativeReturn, annualized, mdd, periodPct };
     });


### PR DESCRIPTION
## Summary

- `utils.js`에 `computeRegimePerformance()` 순수 함수 추가 — 국면별 복리 누적 수익률, 연환산 수익률, 국면 내 MDD, 전체 기간 비율 계산
- `ui.js`에 `renderRegimePerformanceTable()` 렌더 함수 추가 — 국면 색상은 기존 `getRegimeColorClass()` 재사용
- `index.html` Performance 탭에 국면별 성과 테이블 HTML 삽입 (Portfolio vs SPY 테이블 바로 아래)
- `main.js` `renderPerformanceTab()` 안에 호출 연결 (Live 단일 계좌 모드 전용)

## 화면 구성

| 국면 | 일수 | 누적 수익률 | 연환산 수익률 | 국면 내 MDD | 전체 비율 |
|------|------|-----------|-------------|------------|---------|
| Bull | ... | +xx.xx% | +xx.x% | -x.xx% | xx.x% |
| Sideways | ... | ... | ... | ... | ... |
| Bear_Weak | ... | ... | ... | ... | ... |
| Bear_Strong | ... | ... | ... | ... | ... |
| Crash | ... | ... | ... | ... | ... |

## Test plan

- [ ] Live 모드 Performance 탭 진입 시 테이블 렌더링 확인
- [ ] 각 국면 색상이 올바르게 표시되는지 확인 (Bull=green, Bear=red, Sideways=yellow, Crash=red-bg)
- [ ] 누적/연환산 수익률 부호(+/-) 및 색상 정상 표시 확인
- [ ] MDD -5% 초과 시 text-danger 강조 확인
- [ ] Backtest Compare 모드에서는 테이블 미노출 확인 (innerHTML 교체 방식이므로 자동 제외)
- [ ] 데이터 없을 때 "데이터 없음" 폴백 메시지 확인

Closes #295

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZEDCMej1ZRg8ookj1Z6at)_