### PR TITLE
[#296] Performance 탭: 드로다운 히스토리 차트(Underwater Chart) 추가

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -348,6 +348,19 @@
                     </div>
                 </div>
 
+                <!-- Drawdown History (Underwater Chart) -->
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white py-3">
+                        <h5 class="mb-0"><i class="fas fa-water me-2 text-danger"></i>드로다운 히스토리 (Underwater Chart)</h5>
+                        <div class="text-muted small mt-1">역대 신고점 대비 낙폭 (%) — 0% 기준선 아래가 수면 아래 구간 (낙폭 깊이·지속기간·회복속도 확인)</div>
+                    </div>
+                    <div class="card-body">
+                        <div style="height: 220px;">
+                            <canvas id="drawdownChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Monthly Returns Heatmap -->
                 <div class="card border-0 shadow-sm mb-4">
                     <div class="card-header bg-white py-3">

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -637,7 +637,7 @@ export function renderCumulativePnlChart(summaryData, marketType = 'overseas') {
 export function renderDrawdownChart(summaryData) {
     const canvas = document.getElementById('drawdownChart');
     if (!canvas) return;
-    if (drawdownChart) drawdownChart.destroy();
+    if (drawdownChart) { drawdownChart.destroy(); drawdownChart = null; }
     if (!summaryData || summaryData.length === 0) return;
 
     const series = computeDrawdownSeries(summaryData);

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -10,6 +10,7 @@ import {
     computeMonthlyReturns,
     computeCumulativePnl,
     computeAlphaSeries,
+    computeDrawdownSeries,
     computeRegimeDistribution,
     computeTradeReasonDistribution,
     computeMonthlyTradeFrequency,
@@ -25,6 +26,7 @@ let yearlyDividendChart = null;
 
 // 신규 차트 인스턴스
 let cumulativePnlChart = null;
+let drawdownChart = null;
 let alphaLineChart = null;
 let monthlyHeatmapChart = null;
 let tradeReasonPieChart = null;
@@ -211,7 +213,7 @@ export function renderGroupBarChart(statusData, groupConfig, marketType = 'overs
 export function resizeAllCharts() {
     [
         stratChart, groupBarChartInstance, unifiedChart, cumulativeDividendChart, yearlyDividendChart,
-        cumulativePnlChart, alphaLineChart, monthlyHeatmapChart, tradeReasonPieChart,
+        cumulativePnlChart, drawdownChart, alphaLineChart, monthlyHeatmapChart, tradeReasonPieChart,
         monthlyFrequencyChart, tickerContributionChart, currentAllocationDoughnut,
         historicalAllocationChart, regimeDistributionDoughnut
     ].forEach(chart => {
@@ -548,8 +550,9 @@ export function renderUnifiedChart(summaryData, marketType = 'overseas') {
 export function updatePerformanceChartRange(summaryData, range, marketType = 'overseas') {
     const filtered = filterByDateRange(summaryData, range);
     renderUnifiedChart(filtered, marketType);
-    // 신규: 누적 P&L / Alpha / 월별 히트맵도 기간에 맞춰 함께 갱신
+    // 신규: 누적 P&L / 드로다운 / Alpha / 월별 히트맵도 기간에 맞춰 함께 갱신
     renderCumulativePnlChart(filtered, marketType);
+    renderDrawdownChart(filtered);
     renderAlphaLineChart(filtered);
     renderMonthlyHeatmap(filtered);
 }
@@ -619,6 +622,75 @@ export function renderCumulativePnlChart(summaryData, marketType = 'overseas') {
                             const v = ctx.parsed.y;
                             const sign = v >= 0 ? '+' : '-';
                             return `누적 손익: ${sign}${currSymbol}${Math.abs(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+/**
+ * 드로다운 히스토리 차트 (Underwater Chart)
+ * 역대 신고점 대비 낙폭(%) 시계열 — 0% 기준선 아래 빨간 영역
+ */
+export function renderDrawdownChart(summaryData) {
+    const canvas = document.getElementById('drawdownChart');
+    if (!canvas) return;
+    if (drawdownChart) drawdownChart.destroy();
+    if (!summaryData || summaryData.length === 0) return;
+
+    const series = computeDrawdownSeries(summaryData);
+    const labels = series.map(p => p.date);
+    const values = series.map(p => p.drawdown);
+
+    drawdownChart = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels,
+            datasets: [{
+                label: '드로다운 (%)',
+                data: values,
+                borderColor: 'rgba(220, 53, 69, 0.85)',
+                backgroundColor: 'rgba(220, 53, 69, 0.15)',
+                fill: true,
+                tension: 0.1,
+                pointRadius: 0,
+                borderWidth: 1.5
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            scales: {
+                x: { grid: { display: false }, ticks: { maxTicksLimit: 8 } },
+                y: {
+                    max: 0,
+                    title: { display: true, text: '드로다운 (%)' },
+                    ticks: {
+                        callback: v => v.toFixed(1) + '%'
+                    }
+                }
+            },
+            plugins: {
+                legend: { display: false },
+                annotation: {
+                    annotations: {
+                        zeroLine: {
+                            type: 'line',
+                            yMin: 0, yMax: 0,
+                            borderColor: 'rgba(108, 117, 125, 0.6)',
+                            borderWidth: 1,
+                            borderDash: [4, 4]
+                        }
+                    }
+                },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => {
+                            const v = ctx.parsed.y;
+                            return `드로다운: ${v.toFixed(2)}%`;
                         }
                     }
                 }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -10,6 +10,7 @@ import {
     renderCumulativeDividendChart,
     renderYearlyDividendChart,
     renderCumulativePnlChart,
+    renderDrawdownChart,
     renderAlphaLineChart,
     renderMonthlyHeatmap,
     renderTradeReasonPie,
@@ -208,6 +209,7 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
         renderCalmarCard(summaryData);
         renderUnifiedChart(summaryData, marketType);
         renderCumulativePnlChart(summaryData, marketType);
+        renderDrawdownChart(summaryData);
         renderAlphaLineChart(summaryData);
         renderMonthlyHeatmap(summaryData);
         renderStrategyChart(summaryData);

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -411,6 +411,22 @@ export function computeRollingReturn(summaryData, days) {
 }
 
 /**
+ * 드로다운 시계열 계산 (Underwater Chart용)
+ * drawdown(t) = (total_value(t) / max(total_value[0..t]) - 1) × 100
+ * @param {Array} summaryData
+ * @returns {Array<{date:string, drawdown:number}>} 항상 0 이하
+ */
+export function computeDrawdownSeries(summaryData) {
+    if (!summaryData || summaryData.length === 0) return [];
+    let peak = -Infinity;
+    return summaryData.map(d => {
+        if (d.total_value > peak) peak = d.total_value;
+        const dd = peak > 0 ? (d.total_value / peak - 1) * 100 : 0;
+        return { date: d.date, drawdown: dd };
+    });
+}
+
+/**
  * 현재 드로다운 진행일 및 깊이
  * 마지막 peak 이후 경과한 거래일 수와 peak 대비 현재값의 낙폭(%)
  * @param {Array} summaryData

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -420,8 +420,9 @@ export function computeDrawdownSeries(summaryData) {
     if (!summaryData || summaryData.length === 0) return [];
     let peak = -Infinity;
     return summaryData.map(d => {
-        if (d.total_value > peak) peak = d.total_value;
-        const dd = peak > 0 ? (d.total_value / peak - 1) * 100 : 0;
+        const val = d.total_value ?? 0;
+        if (val > peak) peak = val;
+        const dd = peak > 0 ? (val / peak - 1) * 100 : 0;
         return { date: d.date, drawdown: dd };
     });
 }


### PR DESCRIPTION
## Summary

- `utils.js`에 `computeDrawdownSeries()` 추가 — `total_value` 기반 시점별 낙폭(%) 시계열 계산
- `charts.js`에 `renderDrawdownChart()` 구현 — 빨간 반투명 fill, 0% 기준선, 기간 필터 연동
- `index.html` Performance 탭 누적 P&L/Alpha 섹션 아래에 `drawdownChart` canvas 삽입
- `main.js` `renderPerformanceTab()`에 `renderDrawdownChart()` 호출 연결

## 드로다운 정의

```
drawdown(t) = (total_value(t) / max(total_value[0..t]) - 1) × 100
```

## 구현 세부사항

- 데이터 소스: 기존 `summary.json`의 `total_value` 필드 (백엔드 변경 없음)
- Chart.js `fill: true`, `backgroundColor: 'rgba(220, 53, 69, 0.15)'` — 빨간 반투명
- Y축 `max: 0` 고정으로 0% 기준선이 항상 위에 표시
- `chartjs-plugin-annotation`으로 0% 기준 점선 표시
- 기간 선택(1M/3M/6M/1Y/ALL) 변경 시 다른 차트들과 함께 자동 갱신

## Test plan

- [ ] Performance 탭 진입 시 Underwater Chart가 누적 P&L 아래, 월별 히트맵 위에 표시되는지 확인
- [ ] 신고점 시점은 0%, 이후 하락 구간은 음수 빨간 영역으로 표시되는지 확인
- [ ] 기간 선택 버튼(1M/3M 등) 클릭 시 차트가 해당 기간으로 갱신되는지 확인
- [ ] 탭 전환 후 재진입 시 차트가 정상적으로 표시되는지 확인 (lazy render)

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eRg4wmmhipEAABRx3RtKx

---
_Generated by [Claude Code](https://claude.ai/code/session_016eRg4wmmhipEAABRx3RtKx)_