### PR TITLE
feat: Performance 탭에 YTD Return 카드 추가 (#299)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -265,6 +265,19 @@
                     </div>
                 </div>
 
+                <!-- YTD Return Card -->
+                <div class="row g-3 mb-3">
+                    <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center p-3">
+                                <h6 class="text-muted small mb-1">YTD Return</h6>
+                                <h5 class="fw-bold mb-1" id="ytd-portfolio">-</h5>
+                                <div class="small text-muted" id="ytd-spy">SPY -</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Rolling Returns + DD/Calmar Cards -->
                 <div class="row g-3 mb-4">
                     <div class="col-6 col-md-4 col-lg-2">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -38,8 +38,9 @@ import {
     renderStatusFreshnessBadge,
     renderFailedOrderAlert,
     renderOperationsPanel,
-    renderRegimePerformanceTable
-} from './ui.js?v=3';
+    renderRegimePerformanceTable,
+    renderYTDCard
+} from './ui.js?v=4';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=4';
 
@@ -204,6 +205,7 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
         if (perfRendered) return;
         renderPerformanceSummaryCards(summaryData);
         renderRegimePerformanceTable(summaryData);
+        renderYTDCard(summaryData);
         renderRollingReturnCards(summaryData);
         renderCurrentDrawdownCard(summaryData);
         renderCalmarCard(summaryData);

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -19,8 +19,9 @@ import {
     computeFailedExecutions,
     inferNextRebalanceDate,
     getStatusFreshness,
-    computeRegimePerformance
-} from './utils.js?v=3';
+    computeRegimePerformance,
+    computeYTDReturn
+} from './utils.js?v=4';
 
 /**
  * 상단 내비게이션 바의 모드 버튼 및 상태 배지 업데이트
@@ -441,6 +442,28 @@ function renderPagination(totalPages) {
 // ============================================================
 // 대시보드 확장: 신규 UI 렌더 함수들
 // ============================================================
+
+/**
+ * Performance 탭 - YTD Return 카드 (포트폴리오 + SPY 벤치마크)
+ */
+export function renderYTDCard(summaryData) {
+    const portfolioEl = document.getElementById('ytd-portfolio');
+    const spyEl = document.getElementById('ytd-spy');
+    if (!portfolioEl || !spyEl) return;
+
+    const ytd = computeYTDReturn(summaryData);
+    if (ytd.portfolio == null) {
+        portfolioEl.innerText = 'N/A';
+        portfolioEl.className = 'fw-bold mb-1 text-muted';
+        spyEl.innerText = 'SPY N/A';
+        spyEl.className = 'small text-muted';
+    } else {
+        portfolioEl.innerText = formatPercent(ytd.portfolio);
+        portfolioEl.className = 'fw-bold mb-1 ' + (ytd.portfolio >= 0 ? 'text-success' : 'text-danger');
+        spyEl.innerText = 'SPY ' + formatPercent(ytd.spy);
+        spyEl.className = 'small ' + (ytd.spy >= 0 ? 'text-success' : 'text-danger');
+    }
+}
 
 /**
  * Performance 탭 - 롤링 수익률 카드 4개

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -715,6 +715,21 @@ export function computeRegimePerformance(summaryData) {
 }
 
 /**
+ * YTD(연초 이후) 수익률 계산
+ * @param {Array} summaryData - summary 배열 (date, total_value, spy_price 필드 필요)
+ * @returns {{portfolio: number|null, spy: number|null}}
+ */
+export function computeYTDReturn(summaryData) {
+    const currentYear = new Date().getFullYear().toString();
+    const ytdData = summaryData.filter(d => d.date.startsWith(currentYear));
+    if (ytdData.length < 2) return { portfolio: null, spy: null };
+    return {
+        portfolio: (ytdData.at(-1).total_value / ytdData[0].total_value - 1) * 100,
+        spy: (ytdData.at(-1).spy_price / ytdData[0].spy_price - 1) * 100,
+    };
+}
+
+/**
  * groupConfig.aliases에서 티커의 한글명(alias)을 반환.
  * alias가 없으면 raw ticker를 그대로 반환.
  * @param {string} ticker

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -720,12 +720,19 @@ export function computeRegimePerformance(summaryData) {
  * @returns {{portfolio: number|null, spy: number|null}}
  */
 export function computeYTDReturn(summaryData) {
-    const currentYear = new Date().getFullYear().toString();
-    const ytdData = summaryData.filter(d => d.date.startsWith(currentYear));
+    if (!summaryData || summaryData.length === 0) return { portfolio: null, spy: null };
+    // 백테스트 지원: 실제 캘린더 연도 대신 데이터셋의 마지막 날짜 기준 연도 사용
+    const latestDate = summaryData[summaryData.length - 1].date;
+    if (!latestDate) return { portfolio: null, spy: null };
+    const dataYear = latestDate.slice(0, 4);
+    const ytdData = summaryData.filter(d => d.date && d.date.startsWith(dataYear));
     if (ytdData.length < 2) return { portfolio: null, spy: null };
+    const first = ytdData[0];
+    const last = ytdData[ytdData.length - 1];
+    if (!first.total_value || !first.spy_price) return { portfolio: null, spy: null };
     return {
-        portfolio: (ytdData.at(-1).total_value / ytdData[0].total_value - 1) * 100,
-        spy: (ytdData.at(-1).spy_price / ytdData[0].spy_price - 1) * 100,
+        portfolio: (last.total_value / first.total_value - 1) * 100,
+        spy: (last.spy_price / first.spy_price - 1) * 100,
     };
 }
 


### PR DESCRIPTION
## Summary

- `docs/js/utils.js`: `computeYTDReturn()` 함수 추가 — 연초 첫 거래일 기준으로 포트폴리오·SPY 수익률 계산
- `docs/js/ui.js`: `renderYTDCard()` 함수 추가 — 포트폴리오 수익률과 SPY 벤치마크 비교 두 줄 표시
- `docs/index.html`: 롤링 수익률 카드 행 위에 YTD Return 카드 별도 행으로 배치
- `docs/js/main.js`: `renderPerformanceTab()` 에 `renderYTDCard()` 호출 추가

## 변경사항 상세

YTD 카드는 기존 롤링 카드(1M/3M/6M/1Y) 행 바로 위에 별도 행(`col-12 col-sm-6 col-md-4 col-lg-3`)으로 배치합니다. SPY 비교 라인이 있어 기존 단일값 카드보다 조금 더 큰 공간이 적합합니다.

```
┌─────────────────┐
│  YTD Return     │
│  +12.4%         │  ← 포트폴리오
│  SPY +8.2%      │  ← 벤치마크 비교
└─────────────────┘
[ 1M | 3M | 6M | 1Y | Calmar | Current DD ]
```

백엔드 변경 없이 기존 `summary.json` 데이터만 사용합니다.

## Test plan

- [ ] Performance 탭 진입 시 YTD Return 카드가 롤링 카드 위에 표시되는지 확인
- [ ] 포트폴리오 수익률(+/- 색상)과 SPY 수익률 비교 라인이 올바르게 표시되는지 확인
- [ ] 연초 데이터가 없을 때 `N/A` 폴백이 정상 동작하는지 확인
- [ ] 기존 롤링 수익률 카드, Calmar, Current DD 카드에 영향 없는지 확인

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpPo3Vy4r1XVW2mgCQEvkF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpPo3Vy4r1XVW2mgCQEvkF)_