### PR TITLE
[P3] Performance 탭: Information Ratio 지표 추가 (#301)

### DIFF
--- a/docs/js/account-compare-ui.js
+++ b/docs/js/account-compare-ui.js
@@ -50,6 +50,7 @@ export function renderAccountOverview(accountsData) {
         ['Volatility',    'volatility',   'percent_abs', false],
         ['Sharpe',        'sharpe',       'ratio',       true],
         ['Calmar',        'calmar',       'ratio',       true],
+        ['Information Ratio', 'ir',       'ratio',       true],
     ];
 
     function buildSection(ids, marketType) {

--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -62,6 +62,7 @@ export function renderCompareOverview(enginesData) {
         ['Sortino', 'sortino', 'ratio', true],
         ['Calmar', 'calmar', 'ratio', true],
         ['Beta', 'beta', 'ratio', null],
+        ['Information Ratio', 'ir', 'ratio', true],
     ];
 
     /**

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -312,6 +312,16 @@ export function renderPerformanceSummaryCards(summaryData) {
         </tr>
     `;
 
+    // Information Ratio 행 (포트폴리오 전용, SPY는 정의상 0)
+    const ir = p.ir;
+    const irClass = ir >= 0.5 ? 'text-success fw-bold' : ir < 0 ? 'text-danger fw-bold' : 'text-dark fw-bold';
+    html += `
+        <tr class="table-light">
+            <td class="ps-3 fw-bold">Information Ratio</td>
+            <td class="text-end ${irClass}" colspan="2">${ir.toFixed(2)}</td>
+        </tr>
+    `;
+
     tbody.innerHTML = html;
 }
 

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -224,10 +224,14 @@ export function computeAdvancedMetrics(summaryData, initialCash = null) {
 
     // Information Ratio = AnnualizedAlpha / TrackingError
     const excessReturns = portReturns.map((r, i) => r - spyReturns[i]);
-    const meanExcess = excessReturns.reduce((s, r) => s + r, 0) / excessReturns.length;
-    const trackingVariance = excessReturns.reduce((s, r) => s + Math.pow(r - meanExcess, 2), 0) / (excessReturns.length - 1);
-    const trackingError = Math.sqrt(trackingVariance) * Math.sqrt(252);
-    portMetrics.ir = trackingError > 0 ? (meanExcess * 252) / trackingError : 0;
+    let ir = 0;
+    if (excessReturns.length > 1) {
+        const meanExcess = excessReturns.reduce((s, r) => s + r, 0) / excessReturns.length;
+        const trackingVariance = excessReturns.reduce((s, r) => s + Math.pow(r - meanExcess, 2), 0) / (excessReturns.length - 1);
+        const trackingError = Math.sqrt(trackingVariance) * Math.sqrt(252);
+        ir = trackingError > 0 ? (meanExcess * 252) / trackingError : 0;
+    }
+    portMetrics.ir = ir;
     spyMetrics.ir = 0;
 
     return { portfolio: portMetrics, spy: spyMetrics };

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -144,9 +144,9 @@ export function getAssetGroup(ticker, groupConfig) {
  * @returns {{portfolio: Object, spy: Object}} 양쪽 지표 객체
  */
 export function computeAdvancedMetrics(summaryData, initialCash = null) {
-    const empty = { totalReturn: 0, cagr: 0, mdd: 0, volatility: 0, sharpe: 0, sortino: 0, calmar: 0, beta: 1.0 };
+    const empty = { totalReturn: 0, cagr: 0, mdd: 0, volatility: 0, sharpe: 0, sortino: 0, calmar: 0, beta: 1.0, ir: 0 };
     if (!summaryData || summaryData.length < 2) {
-        return { portfolio: { ...empty }, spy: { ...empty, beta: 1.0 } };
+        return { portfolio: { ...empty }, spy: { ...empty, beta: 1.0, ir: 0 } };
     }
 
     const first = summaryData[0];
@@ -221,6 +221,14 @@ export function computeAdvancedMetrics(summaryData, initialCash = null) {
 
     portMetrics.beta = beta;
     spyMetrics.beta = 1.0;
+
+    // Information Ratio = AnnualizedAlpha / TrackingError
+    const excessReturns = portReturns.map((r, i) => r - spyReturns[i]);
+    const meanExcess = excessReturns.reduce((s, r) => s + r, 0) / excessReturns.length;
+    const trackingVariance = excessReturns.reduce((s, r) => s + Math.pow(r - meanExcess, 2), 0) / (excessReturns.length - 1);
+    const trackingError = Math.sqrt(trackingVariance) * Math.sqrt(252);
+    portMetrics.ir = trackingError > 0 ? (meanExcess * 252) / trackingError : 0;
+    spyMetrics.ir = 0;
 
     return { portfolio: portMetrics, spy: spyMetrics };
 }


### PR DESCRIPTION
## Summary

- `utils.js`: `computeAdvancedMetrics()`에 IR 계산 로직 추가 — `portfolio.ir` (연환산 Alpha / Tracking Error), `spy.ir = 0` (정의상)
- `ui.js`: `renderPerformanceSummaryCards()`의 Alpha 행 아래(맨 마지막)에 IR 행 추가 — 포트폴리오 단독 표시, colspan 처리
- `compare-ui.js`: 멀티 엔진 비교 테이블 `metricDefs`에 `['Information Ratio', 'ir', 'ratio', true]` 추가
- `account-compare-ui.js`: 계좌 비교 테이블 `metricDefs`에 동일하게 추가

## 색상 기준 (ui.js)

| IR 값 | 색상 |
|-------|------|
| ≥ 0.5 | 초록 (우수) |
| 0 ~ 0.5 | 기본 (평범) |
| < 0 | 빨강 (SPY보다 못함) |

## Test plan

- [ ] Performance 탭 테이블 하단에 Information Ratio 행이 표시되는지 확인
- [ ] IR > 0.5 → 초록, IR < 0 → 빨강, 중간 → 기본색 확인
- [ ] 멀티 엔진 비교 테이블에 IR 행이 표시되는지 확인
- [ ] 계좌 비교 테이블에 IR 행이 표시되는지 확인
- [ ] 데이터가 1개 이하일 때 IR이 0으로 fallback되는지 확인

Closes #301

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGMeM7LhfGARdJqTo8QvWE)_