### PR TITLE
fix: JS 버전 파라미터 업데이트로 IR 캐시 갱신

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -746,6 +746,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=3"></script>
+    <script type="module" src="js/main.js?v=4"></script>
 </body>
 </html>

--- a/docs/js/account-compare-ui.js
+++ b/docs/js/account-compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ACCOUNT_COLORS,
     ACCOUNT_MARKET_TYPES,
-} from './utils.js?v=4';
+} from './utils.js?v=5';
 
 /**
  * Overview 탭 - 계좌별 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ENGINE_COLORS,
     ENGINE_MARKET_TYPES,
-} from './utils.js?v=2';
+} from './utils.js?v=5';
 
 /**
  * Overview 탭 - 엔진 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -40,19 +40,19 @@ import {
     renderOperationsPanel,
     renderRegimePerformanceTable,
     renderYTDCard
-} from './ui.js?v=4';
+} from './ui.js?v=5';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=4';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=5';
 
 import {
     renderCompareOverview,
     renderCompareTradesTab,
-} from './compare-ui.js?v=2';
+} from './compare-ui.js?v=3';
 
 import {
     renderAccountOverview,
     renderAccountTradesTab,
-} from './account-compare-ui.js?v=1';
+} from './account-compare-ui.js?v=2';
 
 import {
     renderAccountPerformanceChart,

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -21,7 +21,7 @@ import {
     getStatusFreshness,
     computeRegimePerformance,
     computeYTDReturn
-} from './utils.js?v=4';
+} from './utils.js?v=5';
 
 /**
  * 상단 내비게이션 바의 모드 버튼 및 상태 배지 업데이트

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -313,7 +313,7 @@ export function renderPerformanceSummaryCards(summaryData) {
     `;
 
     // Information Ratio 행 (포트폴리오 전용, SPY는 정의상 0)
-    const ir = p.ir;
+    const ir = p.ir ?? 0;
     const irClass = ir >= 0.5 ? 'text-success fw-bold' : ir < 0 ? 'text-danger fw-bold' : 'text-dark fw-bold';
     html += `
         <tr class="table-light">


### PR DESCRIPTION
## 문제

PR #305에서 IR 지표를 `ui.js`, `utils.js`, `compare-ui.js`, `account-compare-ui.js`에 추가했지만, 버전 파라미터를 올리지 않아 브라우저가 캐시된 구 버전을 그대로 사용했습니다.

```
# main.js가 이미 이전 PR에서 v=4로 임포트하고 있었음
import { ... } from './ui.js?v=4';   ← 브라우저 캐시: IR 없는 구버전
import { ... } from './utils.js?v=4'; ← 브라우저 캐시: ir 필드 없는 구버전
```

## 수정

| 파일 | 이전 | 이후 |
|------|------|------|
| `ui.js` | `?v=4` | `?v=5` |
| `utils.js` | `?v=4` | `?v=5` |
| `compare-ui.js` | `?v=2` | `?v=3` |
| `account-compare-ui.js` | `?v=1` | `?v=2` |
| `index.html` (main.js) | `?v=3` | `?v=4` |

추가로 `p.ir ?? 0` 방어 처리도 포함 (캐시 불일치 시 TypeError 방지)

## Test plan
- [ ] 하드 리프레시(Ctrl+Shift+R) 없이도 Performance 탭에서 IR 행이 보이는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGMeM7LhfGARdJqTo8QvWE)_