### PR TITLE
feat: add annual returns vs SPY bar chart (#297)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -374,6 +374,19 @@
                     </div>
                 </div>
 
+                <!-- Annual Returns vs SPY -->
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white py-3">
+                        <h5 class="mb-0"><i class="fas fa-chart-bar me-2"></i>연간 수익률 vs SPY</h5>
+                        <div class="text-muted small mt-1">연도별 포트폴리오와 SPY 수익률 비교</div>
+                    </div>
+                    <div class="card-body">
+                        <div style="height: 300px;">
+                            <canvas id="annualReturnsChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Monthly Returns Heatmap -->
                 <div class="card border-0 shadow-sm mb-4">
                     <div class="card-header bg-white py-3">

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -14,7 +14,8 @@ import {
     computeRegimeDistribution,
     computeTradeReasonDistribution,
     computeMonthlyTradeFrequency,
-    computeTickerContribution
+    computeTickerContribution,
+    computeAnnualReturns
 } from './utils.js?v=3';
 
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
@@ -35,6 +36,7 @@ let tickerContributionChart = null;
 let currentAllocationDoughnut = null;
 let historicalAllocationChart = null;
 let regimeDistributionDoughnut = null;
+let annualReturnsChart = null;
 
 /**
  * Strategy Analysis 차트 렌더링 (투자 비중 + 모멘텀 듀얼 축)
@@ -215,7 +217,7 @@ export function resizeAllCharts() {
         stratChart, groupBarChartInstance, unifiedChart, cumulativeDividendChart, yearlyDividendChart,
         cumulativePnlChart, drawdownChart, alphaLineChart, monthlyHeatmapChart, tradeReasonPieChart,
         monthlyFrequencyChart, tickerContributionChart, currentAllocationDoughnut,
-        historicalAllocationChart, regimeDistributionDoughnut
+        historicalAllocationChart, regimeDistributionDoughnut, annualReturnsChart
     ].forEach(chart => {
         if (chart) chart.resize();
     });
@@ -1174,6 +1176,93 @@ export function renderRegimeDistributionDoughnut(summaryData) {
                         label: ctx => {
                             const pct = total > 0 ? (ctx.parsed / total * 100).toFixed(1) : '0';
                             return `${ctx.label}: ${ctx.parsed}일 (${pct}%)`;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+/**
+ * 연간 수익률 vs SPY Grouped Bar Chart
+ */
+export function renderAnnualReturnsChart(summaryData) {
+    const canvas = document.getElementById('annualReturnsChart');
+    if (!canvas) return;
+    if (annualReturnsChart) annualReturnsChart.destroy();
+    if (!summaryData || summaryData.length < 2) return;
+
+    const data = computeAnnualReturns(summaryData);
+    if (data.length === 0) return;
+
+    const labels = data.map(d => d.isYTD ? `${d.year} (YTD)` : d.year);
+
+    annualReturnsChart = new Chart(canvas, {
+        type: 'bar',
+        data: {
+            labels,
+            datasets: [
+                {
+                    label: 'Portfolio',
+                    data: data.map(d => d.portfolioReturn),
+                    backgroundColor: data.map(d => d.portfolioReturn >= 0 ? 'rgba(25, 135, 84, 0.75)' : 'rgba(220, 53, 69, 0.75)'),
+                    borderColor: data.map(d => d.portfolioReturn >= 0 ? '#198754' : '#dc3545'),
+                    borderWidth: 1,
+                    borderRadius: 4
+                },
+                {
+                    label: 'SPY',
+                    data: data.map(d => d.spyReturn),
+                    backgroundColor: data.map(d => d.spyReturn >= 0 ? 'rgba(253, 126, 20, 0.65)' : 'rgba(220, 53, 69, 0.45)'),
+                    borderColor: data.map(d => d.spyReturn >= 0 ? '#fd7e14' : '#dc3545'),
+                    borderWidth: 1,
+                    borderRadius: 4
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            scales: {
+                x: { grid: { display: false } },
+                y: {
+                    title: { display: true, text: 'Return (%)' },
+                    ticks: {
+                        callback: v => (v >= 0 ? '+' : '') + v.toFixed(0) + '%'
+                    }
+                }
+            },
+            plugins: {
+                legend: {
+                    position: 'bottom',
+                    labels: { boxWidth: 12, font: { size: 11 } }
+                },
+                annotation: {
+                    annotations: {
+                        zeroLine: {
+                            type: 'line',
+                            yMin: 0, yMax: 0,
+                            borderColor: 'rgba(108, 117, 125, 0.6)',
+                            borderWidth: 1,
+                            borderDash: [4, 4]
+                        }
+                    }
+                },
+                tooltip: {
+                    callbacks: {
+                        label: ctx => {
+                            const v = ctx.parsed.y;
+                            const sign = v >= 0 ? '+' : '';
+                            return `${ctx.dataset.label}: ${sign}${v.toFixed(2)}%`;
+                        },
+                        afterBody: ctx => {
+                            const idx = ctx[0].dataIndex;
+                            const d = data[idx];
+                            const alpha = d.portfolioReturn - d.spyReturn;
+                            const sign = alpha >= 0 ? '+' : '';
+                            return [`Alpha: ${sign}${alpha.toFixed(2)}%`];
                         }
                     }
                 }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -13,6 +13,7 @@ import {
     renderDrawdownChart,
     renderAlphaLineChart,
     renderMonthlyHeatmap,
+    renderAnnualReturnsChart,
     renderTradeReasonPie,
     renderMonthlyTradeFrequencyChart,
     renderTickerContributionChart,
@@ -214,6 +215,7 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
         renderCumulativePnlChart(summaryData, marketType);
         renderDrawdownChart(summaryData);
         renderAlphaLineChart(summaryData);
+        renderAnnualReturnsChart(summaryData);
         renderMonthlyHeatmap(summaryData);
         renderStrategyChart(summaryData);
         renderDividendSummaryCards(summaryData, marketType);

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -802,3 +802,31 @@ export function computeDividendYield(summaryData) {
 
     return { totalDividend, annualizedYield, ytdDividend };
 }
+
+/**
+ * 연간 수익률 계산 (포트폴리오 vs SPY)
+ * @param {Array} summaryData - summary 배열 (date, total_value, spy_price 필드 필요)
+ * @returns {Array<{year:string, portfolioReturn:number, spyReturn:number, isYTD:boolean}>}
+ */
+export function computeAnnualReturns(summaryData) {
+    if (!summaryData || summaryData.length < 2) return [];
+
+    const years = {};
+    summaryData.forEach(d => {
+        const year = d.date.slice(0, 4);
+        if (!years[year]) years[year] = [];
+        years[year].push(d);
+    });
+
+    const currentYear = new Date().getFullYear().toString();
+
+    return Object.entries(years)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .filter(([, days]) => days.length >= 2)
+        .map(([year, days]) => ({
+            year,
+            portfolioReturn: (days.at(-1).total_value / days[0].total_value - 1) * 100,
+            spyReturn: (days.at(-1).spy_price / days[0].spy_price - 1) * 100,
+            isYTD: year === currentYear,
+        }));
+}

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -818,15 +818,19 @@ export function computeAnnualReturns(summaryData) {
         years[year].push(d);
     });
 
-    const currentYear = new Date().getFullYear().toString();
+    const currentYear = summaryData[summaryData.length - 1].date.slice(0, 4);
 
     return Object.entries(years)
         .sort(([a], [b]) => a.localeCompare(b))
         .filter(([, days]) => days.length >= 2)
-        .map(([year, days]) => ({
-            year,
-            portfolioReturn: (days.at(-1).total_value / days[0].total_value - 1) * 100,
-            spyReturn: (days.at(-1).spy_price / days[0].spy_price - 1) * 100,
-            isYTD: year === currentYear,
-        }));
+        .map(([year, days]) => {
+            const firstDay = days[0];
+            const lastDay = days[days.length - 1];
+            return {
+                year,
+                portfolioReturn: firstDay.total_value ? (lastDay.total_value / firstDay.total_value - 1) * 100 : 0,
+                spyReturn: firstDay.spy_price ? (lastDay.spy_price / firstDay.spy_price - 1) * 100 : 0,
+                isYTD: year === currentYear,
+            };
+        });
 }


### PR DESCRIPTION
## Summary
- Performance 탭에 연간 수익률 vs SPY Grouped Bar Chart 추가
- `computeAnnualReturns()` 유틸 함수 추가 (연도별 첫날→마지막날 수익률 계산)
- 양수 초록/음수 빨강 색상, 진행 중 연도 YTD 표시, tooltip에 Alpha 표시

## 변경 파일
- `docs/js/utils.js` — `computeAnnualReturns()` 함수 추가
- `docs/js/charts.js` — `renderAnnualReturnsChart()` 함수 추가 + 인스턴스/리사이즈 등록
- `docs/index.html` — Performance 탭에 canvas 카드 삽입 (드로다운 차트 뒤, 월별 히트맵 앞)
- `docs/js/main.js` — import 및 렌더 호출 연결

## Test plan
- [ ] Live 모드에서 Performance 탭 진입 시 연간 수익률 바 차트가 정상 렌더링되는지 확인
- [ ] 양수 수익률 → 초록, 음수 수익률 → 빨강 색상 확인
- [ ] 현재 연도에 (YTD) 라벨이 표시되는지 확인
- [ ] tooltip hover 시 Portfolio, SPY, Alpha 값이 올바르게 표시되는지 확인
- [ ] 데이터 1년 미만일 때 YTD 1개 바만 표시되는지 확인
- [ ] 탭 전환 후 차트 리사이즈가 정상 작동하는지 확인

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzym5R8zTEFx9R6v9Je6Ji

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qzym5R8zTEFx9R6v9Je6Ji)_