### PR TITLE
fix: bump cache buster for annual returns chart

### DIFF
--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -16,7 +16,7 @@ import {
     computeMonthlyTradeFrequency,
     computeTickerContribution,
     computeAnnualReturns
-} from './utils.js?v=3';
+} from './utils.js?v=6';
 
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
 let stratChart = null;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -44,7 +44,7 @@ import {
     renderDividendSummaryCards
 } from './ui.js?v=5';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=5';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=6';
 
 import {
     renderCompareOverview,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -20,7 +20,7 @@ import {
     renderCurrentAllocationDoughnut,
     renderRegimeDistributionDoughnut,
     renderHistoricalAllocationChart
-} from './charts.js?v=3';
+} from './charts.js?v=4';
 
 import {
     updateModeUI,


### PR DESCRIPTION
## Summary
- `charts.js`의 `utils.js` import 캐시 버스터가 `v=3`으로 남아있어, 브라우저가 `computeAnnualReturns`가 없는 구버전을 캐시에서 로드하는 문제 수정
- `charts.js` utils import: `v=3` → `v=6`
- `main.js` charts import: `v=3` → `v=4`

## Test plan
- [ ] Performance 탭에서 연간 수익률 vs SPY 차트에 데이터가 정상 표시되는지 확인
- [ ] 하드 리프레시 없이도 차트가 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzym5R8zTEFx9R6v9Je6Ji

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qzym5R8zTEFx9R6v9Je6Ji)_