### PR TITLE
feat: Performance 탭 승률/손익비 통계 카드 추가

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -278,6 +278,46 @@
                     </div>
                 </div>
 
+                <!-- Win/Loss Statistics Cards -->
+                <div class="row g-3 mb-3">
+                    <div class="col-6 col-md-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center p-3">
+                                <h6 class="text-muted small mb-1">Win Rate</h6>
+                                <h5 class="fw-bold mb-0" id="win-rate-value">-</h5>
+                                <div class="small text-muted" id="win-loss-total-months">-</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center p-3">
+                                <h6 class="text-muted small mb-1">Avg Win</h6>
+                                <h5 class="fw-bold mb-0" id="avg-win-value">-</h5>
+                                <div class="small text-muted">이익 월 평균</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center p-3">
+                                <h6 class="text-muted small mb-1">Avg Loss</h6>
+                                <h5 class="fw-bold mb-0" id="avg-loss-value">-</h5>
+                                <div class="small text-muted">손실 월 평균</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body text-center p-3">
+                                <h6 class="text-muted small mb-1">Profit Factor</h6>
+                                <h5 class="fw-bold mb-0" id="profit-factor-value">-</h5>
+                                <div class="small text-muted">총이익 / 총손실</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Rolling Returns + DD/Calmar Cards -->
                 <div class="row g-3 mb-4">
                     <div class="col-6 col-md-4 col-lg-2">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -41,7 +41,8 @@ import {
     renderOperationsPanel,
     renderRegimePerformanceTable,
     renderYTDCard,
-    renderDividendSummaryCards
+    renderDividendSummaryCards,
+    renderWinLossCards
 } from './ui.js?v=5';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=5';
@@ -208,6 +209,7 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
         renderPerformanceSummaryCards(summaryData);
         renderRegimePerformanceTable(summaryData);
         renderYTDCard(summaryData);
+        renderWinLossCards(summaryData);
         renderRollingReturnCards(summaryData);
         renderCurrentDrawdownCard(summaryData);
         renderCalmarCard(summaryData);

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -760,22 +760,29 @@ export function renderWinLossCards(summaryData) {
         el.className = 'fw-bold mb-0 ' + colorClass;
     };
 
-    setCard('win-rate-value',
-        stats.totalMonths > 0 ? stats.winRate.toFixed(1) + '%' : 'N/A',
-        stats.winRate >= 50 ? 'text-success' : 'text-danger');
+    if (stats.totalMonths === 0) {
+        setCard('win-rate-value', 'N/A', 'text-muted');
+        setCard('avg-win-value', 'N/A', 'text-muted');
+        setCard('avg-loss-value', 'N/A', 'text-muted');
+        setCard('profit-factor-value', 'N/A', 'text-muted');
+    } else {
+        setCard('win-rate-value',
+            stats.winRate.toFixed(1) + '%',
+            stats.winRate >= 50 ? 'text-success' : 'text-danger');
 
-    setCard('avg-win-value',
-        stats.avgWin > 0 ? '+' + stats.avgWin.toFixed(2) + '%' : 'N/A',
-        'text-success');
+        setCard('avg-win-value',
+            stats.avgWin > 0 ? '+' + stats.avgWin.toFixed(2) + '%' : 'N/A',
+            stats.avgWin > 0 ? 'text-success' : 'text-muted');
 
-    setCard('avg-loss-value',
-        stats.avgLoss < 0 ? stats.avgLoss.toFixed(2) + '%' : 'N/A',
-        'text-danger');
+        setCard('avg-loss-value',
+            stats.avgLoss < 0 ? stats.avgLoss.toFixed(2) + '%' : 'N/A',
+            stats.avgLoss < 0 ? 'text-danger' : 'text-muted');
 
-    const pfText = !isFinite(stats.profitFactor) ? '∞' : stats.profitFactor.toFixed(2) + '×';
-    const pfClass = !isFinite(stats.profitFactor) || stats.profitFactor >= 2.0
-        ? 'text-success' : (stats.profitFactor >= 1.0 ? 'text-dark' : 'text-danger');
-    setCard('profit-factor-value', pfText, pfClass);
+        const pfText = !isFinite(stats.profitFactor) ? '∞' : stats.profitFactor.toFixed(2) + '×';
+        const pfClass = !isFinite(stats.profitFactor) || stats.profitFactor >= 2.0
+            ? 'text-success' : (stats.profitFactor >= 1.0 ? 'text-dark' : 'text-danger');
+        setCard('profit-factor-value', pfText, pfClass);
+    }
 
     const hintEl = document.getElementById('win-loss-total-months');
     if (hintEl) hintEl.innerText = `${stats.totalMonths}개월 기준`;

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -21,7 +21,8 @@ import {
     getStatusFreshness,
     computeRegimePerformance,
     computeYTDReturn,
-    computeDividendYield
+    computeDividendYield,
+    computeWinLossStats
 } from './utils.js?v=5';
 
 /**
@@ -744,4 +745,38 @@ export function renderDividendSummaryCards(summaryData, marketType = 'overseas')
             </div>
         </div>
     `;
+}
+
+/**
+ * Performance 탭 - 승률/손익비 통계 카드 4개 렌더링
+ */
+export function renderWinLossCards(summaryData) {
+    const stats = computeWinLossStats(summaryData);
+
+    const setCard = (id, value, colorClass) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.innerText = value;
+        el.className = 'fw-bold mb-0 ' + colorClass;
+    };
+
+    setCard('win-rate-value',
+        stats.totalMonths > 0 ? stats.winRate.toFixed(1) + '%' : 'N/A',
+        stats.winRate >= 50 ? 'text-success' : 'text-danger');
+
+    setCard('avg-win-value',
+        stats.avgWin > 0 ? '+' + stats.avgWin.toFixed(2) + '%' : 'N/A',
+        'text-success');
+
+    setCard('avg-loss-value',
+        stats.avgLoss < 0 ? stats.avgLoss.toFixed(2) + '%' : 'N/A',
+        'text-danger');
+
+    const pfText = !isFinite(stats.profitFactor) ? '∞' : stats.profitFactor.toFixed(2) + '×';
+    const pfClass = !isFinite(stats.profitFactor) || stats.profitFactor >= 2.0
+        ? 'text-success' : (stats.profitFactor >= 1.0 ? 'text-dark' : 'text-danger');
+    setCard('profit-factor-value', pfText, pfClass);
+
+    const hintEl = document.getElementById('win-loss-total-months');
+    if (hintEl) hintEl.innerText = `${stats.totalMonths}개월 기준`;
 }

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -823,7 +823,7 @@ export function computeWinLossStats(summaryData) {
     return {
         winRate: (wins.length / monthly.length) * 100,
         avgWin: wins.length > 0 ? (grossWin / wins.length) * 100 : 0,
-        avgLoss: losses.length > 0 ? (losses.reduce((s, m) => s + m.return, 0) / losses.length) * 100 : 0,
+        avgLoss: losses.length > 0 ? (-grossLoss / losses.length) * 100 : 0,
         profitFactor: grossLoss > 0 ? grossWin / grossLoss : Infinity,
         totalMonths: monthly.length,
     };

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -804,6 +804,32 @@ export function computeDividendYield(summaryData) {
 }
 
 /**
+ * 승률/손익비 통계 (월 단위)
+ * @param {Array} summaryData - summary 배열
+ * @returns {{winRate:number, avgWin:number, avgLoss:number, profitFactor:number, totalMonths:number}}
+ */
+export function computeWinLossStats(summaryData) {
+    const monthly = computeMonthlyReturns(summaryData);
+    if (monthly.length === 0) {
+        return { winRate: 0, avgWin: 0, avgLoss: 0, profitFactor: 0, totalMonths: 0 };
+    }
+
+    const wins = monthly.filter(m => m.return > 0);
+    const losses = monthly.filter(m => m.return < 0);
+
+    const grossWin = wins.reduce((s, m) => s + m.return, 0);
+    const grossLoss = Math.abs(losses.reduce((s, m) => s + m.return, 0));
+
+    return {
+        winRate: (wins.length / monthly.length) * 100,
+        avgWin: wins.length > 0 ? (grossWin / wins.length) * 100 : 0,
+        avgLoss: losses.length > 0 ? (losses.reduce((s, m) => s + m.return, 0) / losses.length) * 100 : 0,
+        profitFactor: grossLoss > 0 ? grossWin / grossLoss : Infinity,
+        totalMonths: monthly.length,
+    };
+}
+
+/**
  * 연간 수익률 계산 (포트폴리오 vs SPY)
  * @param {Array} summaryData - summary 배열 (date, total_value, spy_price 필드 필요)
  * @returns {Array<{year:string, portfolioReturn:number, spyReturn:number, isYTD:boolean}>}


### PR DESCRIPTION
## Summary\n\n- Performance 탭에 Win Rate, Avg Win, Avg Loss, Profit Factor 4개 통계 카드 추가\n- 월별 수익률 기반으로 수익의 \"질\"을 정량화하는 보조 지표\n- 기존 `computeMonthlyReturns()` 함수를 재사용하여 백엔드 변경 없이 구현\n\n## 변경 파일\n\n| 파일 | 내용 |\n|------|------|\n| `docs/js/utils.js` | `computeWinLossStats()` 계산 함수 추가 |\n| `docs/js/ui.js` | `renderWinLossCards()` 렌더링 함수 추가 |\n| `docs/index.html` | Performance 탭 내 카드 4개 HTML 추가 |\n| `docs/js/main.js` | 렌더 호출 연결 |\n\n## Test plan\n\n- [ ] Performance 탭에서 4개 카드(Win Rate, Avg Win, Avg Loss, Profit Factor) 정상 렌더링 확인\n- [ ] Profit Factor 색상: ≥2.0 초록, 1.0~2.0 검정, <1.0 빨강\n- [ ] 데이터 없을 때 N/A 표시 확인\n- [ ] 기존 테스트 통과 (613 passed, 94.64% coverage)\n\nCloses #298\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01Y2wYkJy7srcnkL884bVNWw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2wYkJy7srcnkL884bVNWw)_