### PR TITLE
fix: bump JS cache-busting versions for win/loss cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -809,6 +809,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=4"></script>
+    <script type="module" src="js/main.js?v=5"></script>
 </body>
 </html>

--- a/docs/js/account-compare-ui.js
+++ b/docs/js/account-compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ACCOUNT_COLORS,
     ACCOUNT_MARKET_TYPES,
-} from './utils.js?v=5';
+} from './utils.js?v=6';
 
 /**
  * Overview 탭 - 계좌별 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ENGINE_COLORS,
     ENGINE_MARKET_TYPES,
-} from './utils.js?v=5';
+} from './utils.js?v=6';
 
 /**
  * Overview 탭 - 엔진 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -50,12 +50,12 @@ import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.
 import {
     renderCompareOverview,
     renderCompareTradesTab,
-} from './compare-ui.js?v=3';
+} from './compare-ui.js?v=4';
 
 import {
     renderAccountOverview,
     renderAccountTradesTab,
-} from './account-compare-ui.js?v=2';
+} from './account-compare-ui.js?v=3';
 
 import {
     renderAccountPerformanceChart,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -43,9 +43,9 @@ import {
     renderYTDCard,
     renderDividendSummaryCards,
     renderWinLossCards
-} from './ui.js?v=5';
+} from './ui.js?v=6';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=5';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=6';
 
 import {
     renderCompareOverview,

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -23,7 +23,7 @@ import {
     computeYTDReturn,
     computeDividendYield,
     computeWinLossStats
-} from './utils.js?v=5';
+} from './utils.js?v=6';
 
 /**
  * 상단 내비게이션 바의 모드 버튼 및 상태 배지 업데이트


### PR DESCRIPTION
## Summary\n\n- #310에서 추가된 승률/손익비 카드가 브라우저 캐시로 인해 값이 `-`로 표시되는 문제 수정\n- `utils.js`, `ui.js`, `main.js` 등 변경된 JS 모듈의 `?v=` 캐시 버스팅 파라미터를 올려 브라우저가 최신 코드를 로드하도록 함\n\n## Test plan\n\n- [ ] Performance 탭에서 Win Rate, Avg Win, Avg Loss, Profit Factor 카드에 실제 값이 표시되는지 확인\n- [ ] 브라우저 캐시 비우지 않고도 정상 동작하는지 확인\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01Y2wYkJy7srcnkL884bVNWw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2wYkJy7srcnkL884bVNWw)_