### PR TITLE
fix: unify all utils.js import versions to resolve module loading error

### DIFF
--- a/docs/js/account-compare-charts.js
+++ b/docs/js/account-compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/account-compare-charts.js
 // 라이브 다중 계좌 비교 전용 차트
 
-import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=4';
+import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=6';
 
 let accountPerformanceChart = null;
 let accountStrategyChart = null;

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -16,7 +16,7 @@ import {
     computeMonthlyTradeFrequency,
     computeTickerContribution,
     computeAnnualReturns
-} from './utils.js?v=3';
+} from './utils.js?v=6';
 
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
 let stratChart = null;

--- a/docs/js/compare-charts.js
+++ b/docs/js/compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/compare-charts.js
 // 멀티 엔진 비교 전용 차트
 
-import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=2';
+import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=6';
 
 let comparePerformanceChart = null;
 let compareStrategyChart = null;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -20,7 +20,7 @@ import {
     renderCurrentAllocationDoughnut,
     renderRegimeDistributionDoughnut,
     renderHistoricalAllocationChart
-} from './charts.js?v=3';
+} from './charts.js?v=4';
 
 import {
     updateModeUI,
@@ -62,7 +62,7 @@ import {
     renderAccountStrategyChart,
     updateAccountChartRange,
     resizeAccountCharts,
-} from './account-compare-charts.js?v=1';
+} from './account-compare-charts.js?v=2';
 
 import {
     renderComparePerformanceChart,
@@ -71,7 +71,7 @@ import {
     renderCompareYearlyDividendChart,
     updateCompareChartRange,
     resizeCompareCharts,
-} from './compare-charts.js?v=2';
+} from './compare-charts.js?v=3';
 
 document.addEventListener('DOMContentLoaded', async function() {
     // 1. URL 파라미터에서 모드 확인 (?mode=backtest)

--- a/docs/js/portfolio-cards.js
+++ b/docs/js/portfolio-cards.js
@@ -3,7 +3,7 @@ import {
     formatAmount,
     ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES,
     getRegimeColorClass
-} from './utils.js?v=3';
+} from './utils.js?v=6';
 
 /**
  * 통화별 합산 배너 렌더링

--- a/docs/js/portfolio-charts.js
+++ b/docs/js/portfolio-charts.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-charts.js
-import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=3';
+import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=6';
 
 let comparisonChart = null;
 

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,7 +1,7 @@
 // docs/js/portfolio-main.js
-import { loadAccountsMeta } from './utils.js?v=3';
-import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=1';
-import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=1';
+import { loadAccountsMeta } from './utils.js?v=6';
+import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=2';
+import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
 
 document.addEventListener('DOMContentLoaded', async () => {
     const base = 'data/';

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -64,6 +64,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-    <script type="module" src="js/portfolio-main.js?v=1"></script>
+    <script type="module" src="js/portfolio-main.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary\n\n- `computeWinLossStats` export를 찾지 못하는 SyntaxError 수정\n- **근본 원인**: 각 JS 파일이 `utils.js`를 서로 다른 `?v=` 값으로 import (`?v=2`, `?v=3`, `?v=4`, `?v=6`). ES 모듈은 쿼리 파라미터가 다르면 **별도 모듈로 중복 로드**하므로, 일부 모듈이 캐시된 구버전을 사용하면서 새 export를 인식하지 못함\n- 모든 `utils.js` import를 `?v=6`으로 통일하고, 변경된 하위 모듈을 참조하는 상위 모듈 버전도 함께 올림\n\n## 변경 파일 (8개)\n\n| 파일 | 변경 |\n|------|------|\n| `charts.js` | `?v=3` → `?v=6` |\n| `compare-charts.js` | `?v=2` → `?v=6` |\n| `account-compare-charts.js` | `?v=4` → `?v=6` |\n| `portfolio-cards.js` | `?v=3` → `?v=6` |\n| `portfolio-charts.js` | `?v=3` → `?v=6` |\n| `portfolio-main.js` | `?v=3` → `?v=6` |\n| `main.js` | 상위 import 버전 bump |\n| `portfolio.html` | `portfolio-main.js?v=1` → `?v=2` |\n\n## Test plan\n\n- [ ] 브라우저 콘솔에 `SyntaxError: does not provide an export named 'computeWinLossStats'` 오류 없음\n- [ ] Performance 탭 Win/Loss 카드에 실제 값 표시\n- [ ] Backtest 모드, Portfolio 페이지 정상 동작\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nhttps://claude.ai/code/session_01Y2wYkJy7srcnkL884bVNWw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2wYkJy7srcnkL884bVNWw)_