### PR TITLE
feat(frontend): 포트폴리오 상세보기 → 단일 계좌 상세 페이지 라우팅

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -809,6 +809,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=5"></script>
+    <script type="module" src="js/main.js?v=20260621-1"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -142,10 +142,14 @@ async function loadLiveMode() {
         });
     }));
 
-    if (accountIds.length === 1) {
+    const singleAccountId = urlParams.get('account');
+    const targetId = singleAccountId && accountsData.has(singleAccountId) ? singleAccountId : null;
+
+    if (accountIds.length === 1 || targetId) {
         // 단일 계좌: 기존 UI (경로만 계좌 서브디렉토리로 수정)
-        const data = accountsData.get(accountIds[0]);
-        const marketType = (ACCOUNT_MARKET_TYPES[accountIds[0]] || 'overseas');
+        const id = targetId || accountIds[0];
+        const data = accountsData.get(id);
+        const marketType = (ACCOUNT_MARKET_TYPES[id] || 'overseas');
         _renderSingleAccount(data, marketType);
     } else {
         // 다중 계좌: 비교 UI

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -142,6 +142,7 @@ async function loadLiveMode() {
         });
     }));
 
+    const urlParams = new URLSearchParams(window.location.search);
     const singleAccountId = urlParams.get('account');
     const targetId = singleAccountId && accountsData.has(singleAccountId) ? singleAccountId : null;
 

--- a/docs/js/portfolio-cards.js
+++ b/docs/js/portfolio-cards.js
@@ -129,7 +129,7 @@ function buildCard(id, data, marketType) {
                     </div>
                     ${groupBar}
                     <div class="mt-auto pt-2">
-                        <a href="index.html" class="btn btn-outline-secondary btn-sm w-100">
+                        <a href="index.html?account=${id}" class="btn btn-outline-secondary btn-sm w-100">
                             상세 보기 <i class="fas fa-arrow-right ms-1"></i>
                         </a>
                     </div>

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,6 +1,6 @@
 // docs/js/portfolio-main.js
 import { loadAccountsMeta } from './utils.js?v=6';
-import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=2';
+import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260621-1';
 import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -64,6 +64,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-    <script type="module" src="js/portfolio-main.js?v=2"></script>
+    <script type="module" src="js/portfolio-main.js?v=20260621-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## 문제

포트폴리오 페이지의 "상세 보기" 버튼을 클릭하면 `index.html`로만 이동해, 멀티 계좌 비교 UI(Overview)가 표시되고 개별 계좌의 메트릭/벤치마크 탭이 보이지 않음.

## 원인

- `portfolio-cards.js`: `href="index.html"` — 계좌 ID 없이 이동
- `main.js`: 계좌가 2개 이상이면 항상 비교 UI로 분기, 단일 계좌 상세 UI 진입 불가

## 수정

- `portfolio-cards.js`: 링크를 `index.html?account={id}`로 변경
- `main.js`: `?account=id` 파라미터가 있고 유효한 계좌이면 단일 계좌 상세 UI(`_renderSingleAccount`) 렌더링
- ESM 캐시 무효화를 위한 버전 갱신: `v=20260621-1`

## 동작 흐름

```
portfolio.html → "상세 보기" 클릭
  → index.html?account=my_test
    → ?account 파라미터 감지
    → my_test 단일 계좌 상세 UI (Overview / Performance / Allocation / Trades 탭)
```

## Test plan

- [ ] 포트폴리오 페이지에서 "상세 보기" 클릭 시 `?account=my_test` URL로 이동 확인
- [ ] 해당 페이지에 단일 계좌 Overview(메트릭, 보유종목)가 표시되는지 확인
- [ ] Performance 탭: 수익률 차트, 벤치마크 등 표시 확인
- [ ] 브라우저 뒤로가기 시 포트폴리오 페이지로 복귀 확인
- [ ] `?account=` 파라미터 없는 직접 접근 시 기존 멀티 계좌 비교 UI 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqARTt34vUi6sawCxUMPBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqARTt34vUi6sawCxUMPBQ)_