### PR TITLE
fix: 모바일 툴팁 탭(클릭) 지원

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -809,6 +809,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260621-1"></script>
+    <script type="module" src="js/main.js?v=20260621-2"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -809,6 +809,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260621-2"></script>
+    <script type="module" src="js/main.js?v=20260621-3"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -44,7 +44,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260621-2';
+} from './ui.js?v=20260621-3';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=6';
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -44,7 +44,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260621-1';
+} from './ui.js?v=20260621-2';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=6';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -797,6 +797,8 @@ export function renderWinLossCards(summaryData) {
  */
 export function initTooltips() {
     if (!window.bootstrap || !window.bootstrap.Tooltip) return;
+    const isTouchOnly = window.matchMedia('(hover: none)').matches;
+    const trigger = isTouchOnly ? 'click' : 'hover focus';
     document.querySelectorAll('[data-metric-tooltip]').forEach(el => {
         const key = el.getAttribute('data-metric-tooltip');
         const content = METRIC_TOOLTIPS[key];
@@ -806,7 +808,7 @@ export function initTooltips() {
         new window.bootstrap.Tooltip(el, {
             html: true,
             title: content,
-            trigger: 'hover focus click',
+            trigger,
             placement: 'right',
         });
         el.style.cursor = 'help';

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -806,7 +806,7 @@ export function initTooltips() {
         new window.bootstrap.Tooltip(el, {
             html: true,
             title: content,
-            trigger: 'hover focus',
+            trigger: 'hover focus click',
             placement: 'right',
         });
         el.style.cursor = 'help';


### PR DESCRIPTION
## 문제

모바일에서 hover 이벤트가 없어 `trigger: 'hover focus'`로 설정된 툴팁이 동작하지 않음.

## 수정

`trigger: 'hover focus click'`으로 변경하여 데스크탑 hover + 모바일 탭(클릭) 모두 지원.

- 데스크탑: 마우스 올리면 자동 표시 (기존과 동일)
- 모바일: 탭(터치)으로 표시/닫기

## 버전 업

`ui.js`: `v=20260621-1` → `v=20260621-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWziJa74tVK8ovsjDjm1qx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWziJa74tVK8ovsjDjm1qx)_