### PR TITLE
feat(dashboard): trades 탭 거래 내역에 체결 단가 표시

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -838,6 +838,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260622-1"></script>
+    <script type="module" src="js/main.js?v=20260622-2"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -838,6 +838,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260621-2"></script>
+    <script type="module" src="js/main.js?v=20260622-1"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260621-1';
+} from './ui.js?v=20260622-1';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=6';
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260622-1';
+} from './ui.js?v=20260622-2';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=6';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -383,7 +383,7 @@ export function renderTradeHistory(historyData, page = undefined, marketType = '
         // 체결 종목 배지 생성
         let actionsHtml = tx.executions.map(ex => `
             <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
-                ${ex.action} ${getTickerAlias(ex.ticker, cachedGroupConfig)} (${ex.quantity})${ex.price != null ? ' @' + formatAmount(ex.price, cachedMarketType) : ''}
+                ${ex.action} ${getTickerAlias(ex.ticker, cachedGroupConfig)} (${ex.quantity})${Number.isFinite(ex.price) ? ' @' + formatAmount(ex.price, cachedMarketType) : ''}
             </span>
         `).join('');
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -383,7 +383,7 @@ export function renderTradeHistory(historyData, page = undefined, marketType = '
         // 체결 종목 배지 생성
         let actionsHtml = tx.executions.map(ex => `
             <span class="badge ${ex.action === 'BUY' ? 'bg-success' : 'bg-danger'} order-badge me-1 mb-1">
-                ${ex.action} ${getTickerAlias(ex.ticker, cachedGroupConfig)} (${ex.quantity})
+                ${ex.action} ${getTickerAlias(ex.ticker, cachedGroupConfig)} (${ex.quantity})${ex.price != null ? ' @' + formatAmount(ex.price, cachedMarketType) : ''}
             </span>
         `).join('');
 


### PR DESCRIPTION
## 배경

단일 계좌 페이지 **Trades 탭**의 Trade History 테이블에서, Actions 배지가 `BUY 411060 (1)`처럼 **종목·수량만** 보여주고 **체결 단가는 표시하지 않았습니다.** `ex.price` 값이 `history.json`에 이미 존재함에도 화면 어디에도 노출되지 않아, 어떤 가격에 체결됐는지 확인할 수 없었습니다.

## 변경 내용

거래 내역 배지에 체결 단가를 추가합니다.

- `BUY 411060 (1)` → `BUY 411060 (1) @₩29,095`
- `marketType`에 따라 통화 자동 적용 (`domestic` → `₩`, `overseas` → `$`)
- 기존에 import된 `formatAmount` 재사용 (신규 의존성 없음)
- `ex.price`가 없는 구버전 레코드는 `@...` 표기를 생략해 안전하게 처리

### ESM 캐시 무효화 체인
`ui.js` 내용 변경에 따라 하위 모듈 캐시가 무효화되도록 상위로 버전 갱신:
- `docs/js/ui.js` — 배지 렌더링 로직 수정
- `docs/js/main.js` — `./ui.js?v=20260621-1` → `?v=20260622-1`
- `docs/index.html` — `main.js?v=20260621-2` → `?v=20260622-1`

## 검증

샘플 데이터(`docs/data/my_test/history.json`)로 배지 출력 확인:

| marketType | 출력 |
|---|---|
| domestic | `BUY 411060.KS (1) @₩29,095` |
| overseas | `BUY 411060.KS (1) @$29,095.00` |
| price 없음 | `SELL XXX (2)` (단가 생략) |

프론트엔드 JS 단위 테스트는 없으며, Python 테스트와는 무관한 변경입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VnJV5tq3uQBX46Wd9cySK

---
_Generated by [Claude Code](https://claude.ai/code/session_017VnJV5tq3uQBX46Wd9cySK)_