### PR TITLE
feat(dashboard): Operations 탭에 운영 모니터링 데이터 3종 추가

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -765,6 +765,31 @@
                     </div>
                 </div>
 
+                <!-- Operations Cards Row 2 -->
+                <div class="row g-3 mb-4">
+                    <div class="col-md-6">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted"><i class="fas fa-stream me-1"></i>실행 연속성</h6>
+                                <h4 class="fw-bold mb-0"><span id="ops-schedule-streak">-</span> <small class="text-muted">일 연속 정상</small></h4>
+                                <div class="small text-muted mt-1" id="ops-schedule-detail">-</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted"><i class="fas fa-bullseye me-1"></i>리밸런싱 트리거 근접도</h6>
+                                <h4 class="fw-bold mb-1" id="ops-rebal-proximity">-</h4>
+                                <div class="progress mb-2" style="height: 6px;">
+                                    <div class="progress-bar" id="ops-rebal-proximity-bar" role="progressbar" style="width: 0%;"></div>
+                                </div>
+                                <div class="small text-muted" id="ops-rebal-proximity-detail">-</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Failed Orders Detail + Recent Activity -->
                 <div class="row g-4 mb-4">
                     <div class="col-lg-7">
@@ -806,6 +831,9 @@
                                     <dt class="col-sm-5 text-muted">Last Updated</dt>
                                     <dd class="col-sm-7" id="ops-last-updated-raw">-</dd>
 
+                                    <dt class="col-sm-5 text-muted">마지막 리밸런싱</dt>
+                                    <dd class="col-sm-7" id="ops-last-rebal-actual">-</dd>
+
                                     <dt class="col-sm-5 text-muted">현재 국면</dt>
                                     <dd class="col-sm-7" id="ops-current-regime">-</dd>
 
@@ -838,6 +866,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260622-2"></script>
+    <script type="module" src="js/main.js?v=20260622-3"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -866,6 +866,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260622-3"></script>
+    <script type="module" src="js/main.js?v=20260622-4"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,9 +46,9 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260622-2';
+} from './ui.js?v=20260622-3';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=6';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=7';
 
 import {
     renderCompareOverview,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,9 +46,9 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260622-3';
+} from './ui.js?v=20260622-4';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=7';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=8';
 
 import {
     renderCompareOverview,

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -18,12 +18,14 @@ import {
     computeCurrentRegimeStreak,
     computeFailedExecutions,
     inferNextRebalanceDate,
+    computeExecutionGaps,
+    computeRebalanceProximity,
     getStatusFreshness,
     computeRegimePerformance,
     computeYTDReturn,
     computeDividendYield,
     computeWinLossStats
-} from './utils.js?v=6';
+} from './utils.js?v=7';
 
 import { METRIC_TOOLTIPS } from './metric-tooltips.js?v=20260621-1';
 
@@ -603,7 +605,7 @@ export function renderOperationsPanel(statusData, historyData, summaryData, grou
     const nextDateEl = document.getElementById('ops-next-rebal-date');
     const nextHintEl = document.getElementById('ops-next-rebal-hint');
     if (nextDateEl && nextHintEl) {
-        const inferred = inferNextRebalanceDate(historyData);
+        const inferred = inferNextRebalanceDate(historyData, statusData.last_rebalancing_date);
         if (inferred.confidence === 'insufficient') {
             nextDateEl.innerText = '데이터 부족';
             nextDateEl.className = 'fw-bold mb-0 text-muted';
@@ -611,7 +613,10 @@ export function renderOperationsPanel(statusData, historyData, summaryData, grou
         } else {
             nextDateEl.innerText = inferred.estimatedDate;
             nextDateEl.className = 'fw-bold mb-0 text-primary';
-            nextHintEl.innerText = `최근 평균 ${inferred.intervalDays}일 주기 (${inferred.confidence})`;
+            const anchorTxt = inferred.anchorSource === 'status'
+                ? `${inferred.anchorDate} 리밸런싱 기준`
+                : `최근 거래 ${inferred.anchorDate} 기준`;
+            nextHintEl.innerText = `${anchorTxt} · 평균 ${inferred.intervalDays}일 주기 (${inferred.confidence})`;
         }
     }
 
@@ -662,10 +667,57 @@ export function renderOperationsPanel(statusData, historyData, summaryData, grou
         if (el) el.innerText = text;
     };
     setText('ops-last-updated-raw', statusData.last_updated || '-');
+    setText('ops-last-rebal-actual', statusData.last_rebalancing_date || '-');
     setText('ops-current-regime', (statusData.strategy && statusData.strategy.regime || '-').replace('_', ' '));
     setText('ops-target-exposure', statusData.strategy ? (statusData.strategy.target_exposure * 100).toFixed(0) + '%' : '-');
     setText('ops-trigger-reason', (statusData.strategy && statusData.strategy.trigger_reason) || '-');
     setText('ops-total-trades', (historyData || []).length + '건');
+
+    // [6] 실행 연속성 카드 (스케줄 갭 감지)
+    const scheduleStreakEl = document.getElementById('ops-schedule-streak');
+    const scheduleDetailEl = document.getElementById('ops-schedule-detail');
+    if (scheduleStreakEl && scheduleDetailEl) {
+        const gaps = computeExecutionGaps(summaryData);
+        scheduleStreakEl.innerText = gaps.consecutiveOkDays;
+        if (gaps.totalRuns === 0) {
+            scheduleStreakEl.className = 'text-muted';
+            scheduleDetailEl.innerText = '실행 기록 없음';
+        } else if (gaps.missedTotal === 0) {
+            scheduleStreakEl.className = 'text-success';
+            scheduleDetailEl.innerText = `총 ${gaps.totalRuns}회 실행 · 누락 없음`;
+        } else {
+            scheduleStreakEl.className = 'text-warning';
+            const g = gaps.recentGap;
+            const recentTxt = g ? ` (최근 ${g.from}~${g.to})` : '';
+            scheduleDetailEl.innerText = `누락 의심 ${gaps.missedTotal}영업일 · 공휴일 가능${recentTxt}`;
+        }
+    }
+
+    // [7] 리밸런싱 트리거 근접도 카드
+    const proximityEl = document.getElementById('ops-rebal-proximity');
+    const proximityBarEl = document.getElementById('ops-rebal-proximity-bar');
+    const proximityDetailEl = document.getElementById('ops-rebal-proximity-detail');
+    if (proximityEl && proximityBarEl && proximityDetailEl) {
+        const prox = computeRebalanceProximity(summaryData);
+        if (!prox.available) {
+            proximityEl.innerText = 'N/A';
+            proximityEl.className = 'fw-bold mb-1 text-muted';
+            proximityBarEl.style.width = '0%';
+            proximityBarEl.className = 'progress-bar bg-secondary';
+            proximityDetailEl.innerText = '비율 데이터 부족';
+        } else {
+            const pct = prox.proximityPct;
+            const colorWord = prox.willTrigger ? 'danger' : (pct >= 70 ? 'warning' : 'success');
+            proximityEl.innerText = pct.toFixed(0) + '%';
+            proximityEl.className = 'fw-bold mb-1 text-' + colorWord;
+            proximityBarEl.style.width = Math.max(pct, 2) + '%';
+            proximityBarEl.className = 'progress-bar bg-' + colorWord;
+            const trigTxt = prox.willTrigger ? ' · 트리거 도달' : '';
+            proximityDetailEl.innerText =
+                `현재 A ${(prox.ratioA * 100).toFixed(1)}% / 목표 ${(prox.targetA * 100).toFixed(0)}% · ` +
+                `이탈 ${(prox.maxDev * 100).toFixed(1)}% / 임계 ${(prox.threshold * 100).toFixed(1)}%${trigTxt}`;
+        }
+    }
 }
 
 /**

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -25,7 +25,7 @@ import {
     computeYTDReturn,
     computeDividendYield,
     computeWinLossStats
-} from './utils.js?v=7';
+} from './utils.js?v=8';
 
 import { METRIC_TOOLTIPS } from './metric-tooltips.js?v=20260621-1';
 

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -600,7 +600,7 @@ export function computeFailedExecutions(historyData) {
  * @param {Array} historyData
  * @returns {{estimatedDate:string|null, intervalDays:number|null, confidence:string}}
  */
-export function inferNextRebalanceDate(historyData) {
+export function inferNextRebalanceDate(historyData, lastRebalanceDate = null) {
     if (!historyData || historyData.length < 3) {
         return { estimatedDate: null, intervalDays: null, confidence: 'insufficient' };
     }
@@ -622,17 +622,118 @@ export function inferNextRebalanceDate(historyData) {
         ? Math.round((intervals[mid - 1] + intervals[mid]) / 2)
         : Math.round(intervals[mid]);
 
-    const lastDate = dates[dates.length - 1];
+    // 앵커 우선순위: status.last_rebalancing_date(권위) > history 마지막 거래일
+    const anchor = lastRebalanceDate ? new Date(lastRebalanceDate) : null;
+    const lastDate = (anchor && !isNaN(anchor.getTime())) ? anchor : dates[dates.length - 1];
     const next = new Date(lastDate);
     next.setDate(next.getDate() + medianDays);
     const yyyy = next.getFullYear();
     const mm = String(next.getMonth() + 1).padStart(2, '0');
     const dd = String(next.getDate()).padStart(2, '0');
 
+    const ly = lastDate.getFullYear();
+    const lm = String(lastDate.getMonth() + 1).padStart(2, '0');
+    const ld = String(lastDate.getDate()).padStart(2, '0');
+
     return {
         estimatedDate: `${yyyy}-${mm}-${dd}`,
         intervalDays: medianDays,
+        anchorDate: `${ly}-${lm}-${ld}`,
+        anchorSource: (anchor && !isNaN(anchor.getTime())) ? 'status' : 'history',
         confidence: historyData.length >= 5 ? 'high' : 'medium'
+    };
+}
+
+/**
+ * 봇 실행 누락(스케줄 갭) 감지 — summary 날짜 시퀀스의 영업일 갭을 분석.
+ * summary는 봇 실행 1회당 1건이 누적되므로, 연속 영업일 사이의 빈 영업일은
+ * 실행 누락(또는 한국 공휴일)을 의미한다. 주말은 정상 제외한다.
+ * @param {Array} summaryData - summary 배열 (date 필드 필요)
+ * @returns {{totalRuns, lastRunDate, gaps, recentGap, missedTotal, consecutiveOkDays}}
+ */
+export function computeExecutionGaps(summaryData) {
+    const empty = { totalRuns: 0, lastRunDate: null, gaps: [], recentGap: null, missedTotal: 0, consecutiveOkDays: 0 };
+    if (!summaryData || summaryData.length === 0) return empty;
+
+    const dates = summaryData.map(d => d.date).filter(Boolean);
+    if (dates.length === 0) return empty;
+
+    const gaps = [];
+    for (let i = 1; i < dates.length; i++) {
+        const missing = _businessDaysStrictlyBetween(_parseLocalDate(dates[i - 1]), _parseLocalDate(dates[i]));
+        if (missing > 0) {
+            gaps.push({ from: dates[i - 1], to: dates[i], missingBusinessDays: missing });
+        }
+    }
+
+    // 최근부터 역순으로 연속 정상(갭 0) 실행일수 집계
+    let consecutiveOkDays = dates.length >= 1 ? 1 : 0;
+    for (let i = dates.length - 1; i >= 1; i--) {
+        const missing = _businessDaysStrictlyBetween(_parseLocalDate(dates[i - 1]), _parseLocalDate(dates[i]));
+        if (missing === 0) consecutiveOkDays++;
+        else break;
+    }
+
+    return {
+        totalRuns: dates.length,
+        lastRunDate: dates[dates.length - 1],
+        gaps,
+        recentGap: gaps.length ? gaps[gaps.length - 1] : null,
+        missedTotal: gaps.reduce((s, g) => s + g.missingBusinessDays, 0),
+        consecutiveOkDays,
+    };
+}
+
+/** "YYYY-MM-DD" → 로컬 자정 Date (TZ 흔들림 방지) */
+function _parseLocalDate(s) {
+    const [y, m, d] = (s || '').split('-').map(Number);
+    return new Date(y || 1970, (m || 1) - 1, d || 1);
+}
+
+/** start와 end 사이(양끝 제외)의 영업일(월~금) 수 */
+function _businessDaysStrictlyBetween(start, end) {
+    let count = 0;
+    const d = new Date(start);
+    d.setDate(d.getDate() + 1);
+    while (d < end) {
+        const wd = d.getDay();
+        if (wd !== 0 && wd !== 6) count++;
+        d.setDate(d.getDate() + 1);
+    }
+    return count;
+}
+
+/**
+ * 리밸런싱 트리거 근접도 — rebalancer.py의 상대이탈 판정 로직을 그대로 재현.
+ *   ratio_a = val_a / (val_a + val_b)  (현금 그룹 C 제외, risky 기준)
+ *   rel_dev = |ratio - target| / target,  트리거 = max(rel_dev_a, rel_dev_b) > threshold
+ * @param {Array} summaryData - summary 배열 (group_a/group_b/target_ratio_a/rebalance_threshold 필요)
+ * @returns {{available, ratioA, targetA, threshold, maxDev, proximityPct, willTrigger, date}}
+ */
+export function computeRebalanceProximity(summaryData) {
+    if (!summaryData || summaryData.length === 0) return { available: false };
+    const last = summaryData[summaryData.length - 1];
+    const valA = last.group_a || 0;
+    const valB = last.group_b || 0;
+    const risky = valA + valB;
+    const targetA = last.target_ratio_a;
+    const threshold = last.rebalance_threshold;
+    if (!risky || targetA == null || threshold == null || targetA <= 0) {
+        return { available: false };
+    }
+    const targetB = 1 - targetA;
+    const ratioA = valA / risky;
+    const ratioB = valB / risky;
+    const relDevA = Math.abs(ratioA - targetA) / targetA;
+    const relDevB = targetB > 0 ? Math.abs(ratioB - targetB) / targetB : 0;
+    const maxDev = Math.max(relDevA, relDevB);
+    const proximityPct = threshold > 0 ? Math.min((maxDev / threshold) * 100, 100) : 0;
+
+    return {
+        available: true,
+        ratioA, targetA, threshold, maxDev, proximityPct,
+        willTrigger: maxDev > threshold,
+        date: last.date,
     };
 }
 

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -604,9 +604,9 @@ export function inferNextRebalanceDate(historyData, lastRebalanceDate = null) {
     if (!historyData || historyData.length < 3) {
         return { estimatedDate: null, intervalDays: null, confidence: 'insufficient' };
     }
-    // 최근 5건 거래 날짜 수집 (오름차순)
+    // 최근 5건 거래 날짜 수집 (오름차순) — 로컬 자정 기준 파싱(TZ 시프트 방지)
     const recent = historyData.slice(-6);
-    const dates = recent.map(tx => new Date((tx.date || '').split(' ')[0]));
+    const dates = recent.map(tx => _parseLocalDate((tx.date || '').split(' ')[0]));
     const intervals = [];
     for (let i = 1; i < dates.length; i++) {
         const diff = (dates[i] - dates[i - 1]) / (1000 * 60 * 60 * 24);
@@ -623,7 +623,7 @@ export function inferNextRebalanceDate(historyData, lastRebalanceDate = null) {
         : Math.round(intervals[mid]);
 
     // 앵커 우선순위: status.last_rebalancing_date(권위) > history 마지막 거래일
-    const anchor = lastRebalanceDate ? new Date(lastRebalanceDate) : null;
+    const anchor = lastRebalanceDate ? _parseLocalDate((lastRebalanceDate || '').split(' ')[0]) : null;
     const lastDate = (anchor && !isNaN(anchor.getTime())) ? anchor : dates[dates.length - 1];
     const next = new Date(lastDate);
     next.setDate(next.getDate() + medianDays);
@@ -658,9 +658,12 @@ export function computeExecutionGaps(summaryData) {
     const dates = summaryData.map(d => d.date).filter(Boolean);
     if (dates.length === 0) return empty;
 
+    // 영업일 갭을 1회만 계산해 재사용(중복 파싱/연산 제거)
     const gaps = [];
+    const missingDays = [];
     for (let i = 1; i < dates.length; i++) {
         const missing = _businessDaysStrictlyBetween(_parseLocalDate(dates[i - 1]), _parseLocalDate(dates[i]));
+        missingDays.push(missing);
         if (missing > 0) {
             gaps.push({ from: dates[i - 1], to: dates[i], missingBusinessDays: missing });
         }
@@ -668,9 +671,8 @@ export function computeExecutionGaps(summaryData) {
 
     // 최근부터 역순으로 연속 정상(갭 0) 실행일수 집계
     let consecutiveOkDays = dates.length >= 1 ? 1 : 0;
-    for (let i = dates.length - 1; i >= 1; i--) {
-        const missing = _businessDaysStrictlyBetween(_parseLocalDate(dates[i - 1]), _parseLocalDate(dates[i]));
-        if (missing === 0) consecutiveOkDays++;
+    for (let i = missingDays.length - 1; i >= 0; i--) {
+        if (missingDays[i] === 0) consecutiveOkDays++;
         else break;
     }
 


### PR DESCRIPTION
## 개요
단일 계좌 페이지 Operations 탭(봇 health 모니터링)에 분석에 도움되는 운영 데이터 3종을 추가합니다. 국면·성과 데이터는 이미 충분했고, 부족했던 "봇이 제대로/제때 돌고 있나"라는 순수 운영 신호를 보강했습니다.

## 추가 기능

### 1. 실제 마지막 리밸런싱 날짜
- `status.json`에 저장돼 있으나 프론트엔드에서 한 번도 사용되지 않던 권위 필드 `last_rebalancing_date`를 노출
- "다음 리밸런싱 추정"을 history 추론 대신 이 날짜를 앵커로 계산 (없으면 기존 history 추론으로 폴백)
- 봇 상태 요약 dl에 "마지막 리밸런싱" 행 추가

### 2. 실행 연속성 (스케줄 갭 감지)
- `computeExecutionGaps()` 신규: `summary` 날짜 시퀀스의 영업일 갭을 분석해 실행 누락 감지 (주말 제외)
- 연속 정상 실행일수 / 누락 의심 영업일 표시
- 한국 공휴일과 실제 실패를 구분할 수 없어 "공휴일 가능"으로 안내

### 3. 리밸런싱 트리거 근접도
- `computeRebalanceProximity()` 신규: `rebalancer.py`의 상대이탈 판정 로직(`rel_dev = |ratio - target| / target`, `max_dev > threshold`)을 그대로 재현
- 현재 A비율 vs 목표/임계 대비 근접도(%)를 progress bar로 시각화
- 다음 실행에서 실제 매매가 발생할지 예측에 활용

## 검증
- 실제 `my_test` 데이터로 세 함수 동작 검증 (앵커 적용, 38회 실행 중 6일 연속·누락 의심 6영업일, A비율 41.4%/근접도 47% 미트리거)
- 빈 데이터·짧은 이력 등 엣지 케이스 안전 처리 확인
- `node --check` 문법 검증 통과
- 변경은 utils.js에 순수 함수 추가(소비자는 ui.js 단독) + Operations 탭 한정 → 다른 탭/페이지 영향 없음

## ESM 캐시 무효화
- `ui.js`: `utils.js?v=6→7`
- `main.js`: `ui.js?v=20260622-2→3`, `utils.js?v=6→7`
- `index.html`: `main.js?v=20260622-2→3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgyhR9Mz5sd2m8o4Cs97RD)_