### PR TITLE
[UI/UX] Overview 탭 Asset Allocation 차트 높이 증가 (60px → 150px)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -169,7 +169,7 @@
                                 <h5 class="mb-0"><i class="fas fa-layer-group me-2"></i>자산 배분</h5>
                             </div>
                             <div class="card-body">
-                                <div style="height: 60px;">
+                                <div style="height: 150px;">
                                     <canvas id="groupBarChart"></canvas>
                                 </div>
                                 <div class="table-responsive mt-3">


### PR DESCRIPTION
## Summary
- Overview 탭 `groupBarChart` 높이를 60px → 150px으로 증가
- 기존 60px은 차트가 사실상 보이지 않는 수준이었음

## 변경 파일
- `docs/index.html` L172: `height: 60px` → `height: 150px`

## Test plan
- [ ] Overview 탭에서 자산 배분 막대 차트가 정상적으로 표시되는지 확인
- [ ] 다른 탭(Allocation 등) 레이아웃에 영향 없는지 확인

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyEJePrwSDVxXqJtcpVYis

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyEJePrwSDVxXqJtcpVYis)_