### PR TITLE
feat(memo): replace vertical line annotations with square point markers

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -67,7 +67,7 @@ import {
     resizeAccountCharts,
 } from './account-compare-charts.js?v=2';
 
-import { initMemoTab } from './memo.js?v=20260623-2';
+import { initMemoTab } from './memo.js?v=20260623-3';
 
 import {
     renderComparePerformanceChart,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -67,7 +67,7 @@ import {
     resizeAccountCharts,
 } from './account-compare-charts.js?v=2';
 
-import { initMemoTab } from './memo.js?v=20260623-1';
+import { initMemoTab } from './memo.js?v=20260623-2';
 
 import {
     renderComparePerformanceChart,

--- a/docs/js/memo.js
+++ b/docs/js/memo.js
@@ -136,6 +136,8 @@ class MemoTab {
         const portfolioPointStyle = labels.map((_, i) => commentIndexSet.has(i) ? 'rect' : 'circle');
         const portfolioPointBg = labels.map((_, i) => commentIndexSet.has(i) ? 'rgba(255, 193, 7, 0.9)' : 'transparent');
         const portfolioPointBorder = labels.map((_, i) => commentIndexSet.has(i) ? 'rgba(180, 130, 0, 1)' : 'transparent');
+        const portfolioPointHoverBg = labels.map((_, i) => commentIndexSet.has(i) ? 'rgba(255, 193, 7, 1)' : '#0d6efd');
+        const portfolioPointHoverBorder = labels.map((_, i) => commentIndexSet.has(i) ? 'rgba(180, 130, 0, 1)' : '#0d6efd');
 
         this.chart = new Chart(canvas, {
             type: 'line',
@@ -153,6 +155,8 @@ class MemoTab {
                         pointBorderColor: portfolioPointBorder,
                         pointBorderWidth: 1.5,
                         pointHoverRadius: portfolioPointRadius.map(r => r > 0 ? r + 2 : 4),
+                        pointHoverBackgroundColor: portfolioPointHoverBg,
+                        pointHoverBorderColor: portfolioPointHoverBorder,
                         fill: false,
                         tension: 0.1
                     },
@@ -183,6 +187,16 @@ class MemoTab {
                 plugins: {
                     legend: {
                         position: 'bottom',
+                        onClick: (e, legendItem, legend) => {
+                            if (legendItem.datasetIndex === undefined) return;
+                            const index = legendItem.datasetIndex;
+                            const ci = legend.chart;
+                            if (ci.isDatasetVisible(index)) {
+                                ci.hide(index);
+                            } else {
+                                ci.show(index);
+                            }
+                        },
                         labels: {
                             usePointStyle: true,
                             padding: 20,

--- a/docs/js/memo.js
+++ b/docs/js/memo.js
@@ -122,23 +122,20 @@ class MemoTab {
         const portfolioReturns = data.map(d => firstValue ? ((d.total_value / firstValue) - 1) * 100 : 0);
         const spyReturns = data.map(d => firstSpy ? ((d.spy_price / firstSpy) - 1) * 100 : 0);
 
-        // 코멘트 마커 어노테이션 생성
+        // 코멘트 마커: 해당 날짜 인덱스에 네모 포인트 스타일 적용
         this._commentLabelIndices = {};
-        const annotations = {};
         this.comments.forEach((c, i) => {
             const nearestDate = this._findNearestDate(labels, c.date);
             if (!nearestDate) return;
             this._commentLabelIndices[i] = labels.indexOf(nearestDate);
-            annotations[`comment_${i}`] = {
-                type: 'line',
-                xMin: nearestDate,
-                xMax: nearestDate,
-                borderColor: 'rgba(255, 193, 7, 0.9)',
-                borderWidth: 2,
-                borderDash: [5, 3],
-                drawTime: 'afterDraw'
-            };
         });
+
+        const commentIndexSet = new Set(Object.values(this._commentLabelIndices));
+        const hasComments = commentIndexSet.size > 0;
+        const portfolioPointRadius = labels.map((_, i) => commentIndexSet.has(i) ? 7 : 0);
+        const portfolioPointStyle = labels.map((_, i) => commentIndexSet.has(i) ? 'rect' : 'circle');
+        const portfolioPointBg = labels.map((_, i) => commentIndexSet.has(i) ? 'rgba(255, 193, 7, 0.9)' : 'transparent');
+        const portfolioPointBorder = labels.map((_, i) => commentIndexSet.has(i) ? 'rgba(180, 130, 0, 1)' : 'transparent');
 
         this.chart = new Chart(canvas, {
             type: 'line',
@@ -150,7 +147,12 @@ class MemoTab {
                         data: portfolioReturns,
                         borderColor: '#0d6efd',
                         borderWidth: 2,
-                        pointRadius: 0,
+                        pointRadius: portfolioPointRadius,
+                        pointStyle: portfolioPointStyle,
+                        pointBackgroundColor: portfolioPointBg,
+                        pointBorderColor: portfolioPointBorder,
+                        pointBorderWidth: 1.5,
+                        pointHoverRadius: portfolioPointRadius.map(r => r > 0 ? r + 2 : 4),
                         fill: false,
                         tension: 0.1
                     },
@@ -179,25 +181,24 @@ class MemoTab {
                     }
                 },
                 plugins: {
-                    annotation: { annotations },
                     legend: {
                         position: 'bottom',
                         labels: {
                             usePointStyle: true,
                             padding: 20,
                             generateLabels: chart => {
-                                const labels = Chart.defaults.plugins.legend.labels.generateLabels(chart);
-                                if (Object.keys(annotations).length > 0) {
-                                    labels.push({
+                                const items = Chart.defaults.plugins.legend.labels.generateLabels(chart);
+                                if (hasComments) {
+                                    items.push({
                                         text: '코멘트 (클릭)',
-                                        strokeStyle: 'rgba(255, 193, 7, 0.9)',
-                                        fillStyle: 'rgba(255, 193, 7, 0.3)',
-                                        lineWidth: 2,
-                                        pointStyle: 'line',
+                                        pointStyle: 'rect',
+                                        fillStyle: 'rgba(255, 193, 7, 0.9)',
+                                        strokeStyle: 'rgba(180, 130, 0, 1)',
+                                        lineWidth: 1.5,
                                         hidden: false
                                     });
                                 }
-                                return labels;
+                                return items;
                             }
                         }
                     },


### PR DESCRIPTION
## Summary

- 메모 탭 차트의 코멘트 마커를 노란 세로 점선 → 포트폴리오 선 위 **노란 네모(rect) 포인트**로 변경
- `chartjs-plugin-annotation` 의존 제거 (annotation 플러그인 설정 삭제)
- Chart.js의 배열 기반 `pointStyle`/`pointRadius`/`pointBackgroundColor`를 이용해 코멘트 날짜 인덱스에만 7px rect 마커 표시
- 범례 커스텀 항목도 `pointStyle: 'rect'`로 통일
- `memo.js` import 버전 `?v=20260623-2`로 갱신

## Test plan

- [ ] 메모 탭 진입 → 코멘트 없을 때 마커 없음 확인
- [ ] 코멘트 추가 → 해당 날짜 포트폴리오 선 위에 노란 네모 마커 표시 확인
- [ ] 마커에 마우스 올리면 툴팁에 코멘트 미리보기 표시 확인
- [ ] 마커 클릭 시 팝오버 정상 동작 확인
- [ ] 범례에 '코멘트 (클릭)' 항목이 네모 아이콘으로 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1aftzAusbmf4tyb8nbcfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1aftzAusbmf4tyb8nbcfD)_