### PR TITLE
fix(ui): 성능탭 벤치마크 라벨 SPY → S&P500 정정

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -240,10 +240,10 @@
                     </div>
                 </div>
 
-                <!-- 포트폴리오 vs SPY 차트 -->
+                <!-- 포트폴리오 vs S&P500 차트 -->
                 <div class="card border-0 shadow-sm mb-4">
                     <div class="card-header bg-white py-3">
-                        <h5 class="mb-0"><i class="fas fa-chart-line me-2"></i>포트폴리오 vs SPY 수익률</h5>
+                        <h5 class="mb-0"><i class="fas fa-chart-line me-2"></i>포트폴리오 vs S&P500 수익률</h5>
                         <div class="text-muted small mt-1">첫날 기준 누적 수익률(%) 비교 — <span style="color:rgba(255,193,7,0.9)">▌</span> 노란 점선: 코멘트 시점 (클릭하면 내용 확인)</div>
                     </div>
                     <div class="card-body">
@@ -300,7 +300,7 @@
                 <!-- Performance Comparison Table -->
                 <div class="card border-0 shadow-sm mb-4">
                     <div class="card-header bg-white py-3">
-                        <h5 class="mb-0"><i class="fas fa-chart-bar me-2"></i>포트폴리오 vs SPY 벤치마크</h5>
+                        <h5 class="mb-0"><i class="fas fa-chart-bar me-2"></i>포트폴리오 vs S&P500 벤치마크</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -309,7 +309,7 @@
                                     <tr>
                                         <th class="ps-3">지표</th>
                                         <th class="text-end">포트폴리오</th>
-                                        <th class="text-end pe-3">SPY (벤치마크)</th>
+                                        <th class="text-end pe-3">S&P500 (벤치마크)</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -354,7 +354,7 @@
                             <div class="card-body text-center p-3">
                                 <h6 class="text-muted small mb-1" data-metric-tooltip="ytd">연초 대비 수익률 ⓘ</h6>
                                 <h5 class="fw-bold mb-1" id="ytd-portfolio">-</h5>
-                                <div class="small text-muted" id="ytd-spy">SPY -</div>
+                                <div class="small text-muted" id="ytd-spy">S&P500 -</div>
                             </div>
                         </div>
                     </div>
@@ -471,7 +471,7 @@
                     <div class="col-lg-6">
                         <div class="card border-0 shadow-sm h-100">
                             <div class="card-header bg-white py-3">
-                                <h5 class="mb-0"><i class="fas fa-exchange-alt me-2"></i>SPY 대비 초과수익 (Alpha)</h5>
+                                <h5 class="mb-0"><i class="fas fa-exchange-alt me-2"></i>S&P500 대비 초과수익 (Alpha)</h5>
                                 <div class="text-muted small mt-1">누적 초과수익률(%) — 양수 = 벤치마크 상회</div>
                             </div>
                             <div class="card-body">
@@ -496,11 +496,11 @@
                     </div>
                 </div>
 
-                <!-- Annual Returns vs SPY -->
+                <!-- Annual Returns vs S&P500 -->
                 <div class="card border-0 shadow-sm mb-4">
                     <div class="card-header bg-white py-3">
-                        <h5 class="mb-0"><i class="fas fa-chart-bar me-2"></i>연간 수익률 vs SPY</h5>
-                        <div class="text-muted small mt-1">연도별 포트폴리오와 SPY 수익률 비교</div>
+                        <h5 class="mb-0"><i class="fas fa-chart-bar me-2"></i>연간 수익률 vs S&P500</h5>
+                        <div class="text-muted small mt-1">연도별 포트폴리오와 S&P500 수익률 비교</div>
                     </div>
                     <div class="card-body">
                         <div style="height: 300px;">
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260623-4"></script>
+    <script type="module" src="js/main.js?v=20260624-1"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260622-4';
+} from './ui.js?v=20260624-1';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-2';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -253,7 +253,7 @@ export function updateDecisionLogic(lastData) {
 }
 
 /**
- * Performance 탭 - 포트폴리오 vs SPY 비교 테이블 렌더링
+ * Performance 탭 - 포트폴리오 vs S&P500 비교 테이블 렌더링
  */
 export function renderPerformanceSummaryCards(summaryData) {
     const metrics = computeAdvancedMetrics(summaryData);
@@ -461,7 +461,7 @@ function renderPagination(totalPages) {
 // ============================================================
 
 /**
- * Performance 탭 - YTD Return 카드 (포트폴리오 + SPY 벤치마크)
+ * Performance 탭 - YTD Return 카드 (포트폴리오 + S&P500 벤치마크)
  */
 export function renderYTDCard(summaryData) {
     const portfolioEl = document.getElementById('ytd-portfolio');
@@ -472,12 +472,12 @@ export function renderYTDCard(summaryData) {
     if (ytd.portfolio == null) {
         portfolioEl.innerText = 'N/A';
         portfolioEl.className = 'fw-bold mb-1 text-muted';
-        spyEl.innerText = 'SPY N/A';
+        spyEl.innerText = 'S&P500 N/A';
         spyEl.className = 'small text-muted';
     } else {
         portfolioEl.innerText = formatPercent(ytd.portfolio);
         portfolioEl.className = 'fw-bold mb-1 ' + (ytd.portfolio >= 0 ? 'text-success' : 'text-danger');
-        spyEl.innerText = 'SPY ' + formatPercent(ytd.spy);
+        spyEl.innerText = 'S&P500 ' + formatPercent(ytd.spy);
         spyEl.className = 'small ' + (ytd.spy >= 0 ? 'text-success' : 'text-danger');
     }
 }


### PR DESCRIPTION
## 배경

벤치마크 기능(#334)에서 **데이터 기준은 SPY → S&P500으로 전환**했으나, 성능탭의 화면 라벨이 여전히 "SPY"로 남아 있었다. 그래서 대시보드가 "SPY 벤치마크만 쓰는 것처럼" 보이는 혼란이 있었다.

## 구조 정리 (참고)

| 위치 | 벤치마크 | 비고 |
|---|---|---|
| 통합 성능 차트 (`unifiedPerformanceChart`) | **3종 모두** (S&P500/NASDAQ100/KOSPI200 점선) | 3개가 다 나오는 유일한 곳 |
| vs-벤치마크 테이블 / Alpha / 연간수익 / YTD | **S&P500 1종** | 숫자 지표·알파는 단일 기준만 성립 |

이 PR은 후자(단일 S&P500 기준 요소)의 **stale "SPY" 라벨을 S&P500으로 정정**한다. 데이터/로직 변경은 없다 (라벨만).

## 변경

- `index.html`: vs-벤치마크 테이블 제목/컬럼, Alpha 제목, 연간수익 제목·설명, YTD 카드 초기값, 메모탭 "포트폴리오 vs S&P500 수익률" 제목
- `ui.js`: YTD 카드 동적 텍스트(`'SPY ' → 'S&P500 '`) + 관련 주석
- **유지**: `SPY MDD`(`spy_mdd`)는 벤치마크가 아니라 국면 판정 **신호 지표**라 그대로 둠

## 캐시

ESM 캐시 무효화: `ui.js?v=20260624-1`, `main.js?v=20260624-1` (index.html).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX)_