### PR TITLE
feat(ui): 성능 지표 테이블 벤치마크 3종 컬럼 (#338 main 반영)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260624-3"></script>
+    <script type="module" src="js/main.js?v=20260624-4"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260624-1"></script>
+    <script type="module" src="js/main.js?v=20260624-2"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260624-2"></script>
+    <script type="module" src="js/main.js?v=20260624-3"></script>
 </body>
 </html>

--- a/docs/js/account-compare-charts.js
+++ b/docs/js/account-compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/account-compare-charts.js
 // 라이브 다중 계좌 비교 전용 차트
 
-import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=20260624-2';
+import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=20260624-3';
 
 let accountPerformanceChart = null;
 let accountStrategyChart = null;

--- a/docs/js/account-compare-ui.js
+++ b/docs/js/account-compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ACCOUNT_COLORS,
     ACCOUNT_MARKET_TYPES,
-} from './utils.js?v=20260624-2';
+} from './utils.js?v=20260624-3';
 
 /**
  * Overview 탭 - 계좌별 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -16,7 +16,7 @@ import {
     computeMonthlyTradeFrequency,
     computeTickerContribution,
     computeAnnualReturns
-} from './utils.js?v=20260624-2';
+} from './utils.js?v=20260624-3';
 
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
 let stratChart = null;

--- a/docs/js/compare-charts.js
+++ b/docs/js/compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/compare-charts.js
 // 멀티 엔진 비교 전용 차트
 
-import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=20260624-2';
+import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=20260624-3';
 
 let comparePerformanceChart = null;
 let compareStrategyChart = null;

--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ENGINE_COLORS,
     ENGINE_MARKET_TYPES,
-} from './utils.js?v=20260624-2';
+} from './utils.js?v=20260624-3';
 
 /**
  * Overview 탭 - 엔진 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,9 +46,9 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260624-1';
+} from './ui.js?v=20260624-2';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-2';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-3';
 
 import {
     renderCompareOverview,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260624-3';
+} from './ui.js?v=20260624-4';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-3';
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260624-2';
+} from './ui.js?v=20260624-3';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-3';
 

--- a/docs/js/portfolio-cards.js
+++ b/docs/js/portfolio-cards.js
@@ -3,7 +3,7 @@ import {
     formatAmount,
     ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES,
     getRegimeColorClass
-} from './utils.js?v=20260624-2';
+} from './utils.js?v=20260624-3';
 
 /**
  * 통화별 합산 배너 렌더링

--- a/docs/js/portfolio-charts.js
+++ b/docs/js/portfolio-charts.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-charts.js
-import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260624-2';
+import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260624-3';
 
 let comparisonChart = null;
 

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-main.js
-import { loadAccountsMeta } from './utils.js?v=20260624-2';
+import { loadAccountsMeta } from './utils.js?v=20260624-3';
 import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260621-1';
 import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -25,7 +25,7 @@ import {
     computeYTDReturn,
     computeDividendYield,
     computeWinLossStats
-} from './utils.js?v=20260624-2';
+} from './utils.js?v=20260624-3';
 
 import { METRIC_TOOLTIPS } from './metric-tooltips.js?v=20260621-1';
 
@@ -258,77 +258,90 @@ export function updateDecisionLogic(lastData) {
 export function renderPerformanceSummaryCards(summaryData) {
     const metrics = computeAdvancedMetrics(summaryData);
     const p = metrics.portfolio;
-    const s = metrics.spy;
 
-    // 지표 정의: [label, portValue, spyValue, format, higherIsBetter]
-    const rows = [
-        ['Total Return', p.totalReturn, s.totalReturn, 'percent',     true,  'totalReturn'],
-        ['CAGR',         p.cagr,        s.cagr,        'percent',     true,  'cagr'],
-        ['Max Drawdown', p.mdd,         s.mdd,         'percent',     false, 'mdd'],
-        ['Volatility',   p.volatility,  s.volatility,  'percent_abs', false, 'volatility'],
-        ['Sharpe Ratio', p.sharpe,      s.sharpe,      'ratio',       true,  'sharpe'],
-        ['Sortino Ratio',p.sortino,     s.sortino,     'ratio',       true,  'sortino'],
-        ['Calmar Ratio', p.calmar,      s.calmar,      'ratio',       true,  'calmar'],
-        ['Beta',         p.beta,        s.beta,        'ratio',       null,  'beta'],
-    ];
+    // 표시할 벤치마크 컬럼 구성 (데이터에 존재하는 것만, 정해진 순서대로)
+    const BENCH_ORDER = ['S&P500', 'NASDAQ100', 'KOSPI200'];
+    const BENCH_COLOR = { 'S&P500': '#fd7e14', 'NASDAQ100': '#17becf', 'KOSPI200': '#6f42c1' };
+    let cols = BENCH_ORDER
+        .filter(name => metrics.benchmarks && metrics.benchmarks[name])
+        .map(name => ({ name, m: metrics.benchmarks[name], color: BENCH_COLOR[name] }));
+    // 벤치마크 데이터가 전혀 없으면(구버전) S&P500 단일 컬럼으로 폴백
+    if (cols.length === 0) {
+        const s = metrics.spy;
+        cols = [{
+            name: 'S&P500',
+            color: BENCH_COLOR['S&P500'],
+            m: { ...s, portBeta: p.beta, portIR: p.ir, alpha: p.totalReturn - s.totalReturn },
+        }];
+    }
+    const primary = cols[0].m; // 포트폴리오 우열 색상 기준(주 벤치마크)
 
     function fmt(value, format) {
-        if (format === 'percent') {
-            const sign = value >= 0 ? '+' : '';
-            return sign + value.toFixed(2) + '%';
-        }
-        if (format === 'percent_abs') {
-            return value.toFixed(2) + '%';
-        }
+        if (value == null || !isFinite(value)) return 'N/A';
+        if (format === 'percent') return (value >= 0 ? '+' : '') + value.toFixed(2) + '%';
+        if (format === 'percent_abs') return value.toFixed(2) + '%';
         return value.toFixed(2);
     }
-
-    // 우열 판단: 포트폴리오가 우수하면 text-success, 열위하면 text-danger
-    function compareClass(portVal, spyVal, higherIsBetter) {
-        if (higherIsBetter === null) return ''; // Beta는 비교 안 함
-        if (Math.abs(portVal - spyVal) < 0.005) return ''; // 거의 동일
-        if (higherIsBetter) {
-            return portVal > spyVal ? 'text-success fw-bold' : 'text-danger';
-        } else {
-            // MDD, Volatility: 낮을수록 좋음 (MDD는 음수이므로 더 큰 값이 좋음)
-            return portVal > spyVal ? 'text-success fw-bold' : 'text-danger';
-        }
+    // 포트폴리오가 주 벤치마크 대비 우수하면 success, 열위면 danger
+    function portClassVs(portVal, refVal, higherIsBetter) {
+        if (higherIsBetter === null) return '';
+        if (Math.abs(portVal - refVal) < 0.005) return '';
+        return portVal > refVal ? 'text-success fw-bold' : 'text-danger';
     }
 
-    const tbody = document.querySelector('#metrics-comparison-table tbody');
+    // 헤더 (계좌 통화별로 벤치마크 셋이 다르므로 동적 생성)
+    const thead = document.querySelector('#metrics-comparison-table thead');
+    if (thead) {
+        thead.innerHTML = `
+            <tr>
+                <th class="ps-3">지표</th>
+                <th class="text-end">포트폴리오</th>
+                ${cols.map(c => `<th class="text-end pe-3"><span style="color:${c.color}">●</span> ${c.name}</th>`).join('')}
+            </tr>`;
+    }
+
+    // 독립 지표 행: 포트폴리오 + 각 인덱스의 자체 값
+    const stdRows = [
+        ['Total Return',  'totalReturn', 'percent',     true,  'totalReturn'],
+        ['CAGR',          'cagr',        'percent',     true,  'cagr'],
+        ['Max Drawdown',  'mdd',         'percent',     false, 'mdd'],
+        ['Volatility',    'volatility',  'percent_abs', false, 'volatility'],
+        ['Sharpe Ratio',  'sharpe',      'ratio',       true,  'sharpe'],
+        ['Sortino Ratio', 'sortino',     'ratio',       true,  'sortino'],
+        ['Calmar Ratio',  'calmar',      'ratio',       true,  'calmar'],
+    ];
     let html = '';
-    rows.forEach(([label, portVal, spyVal, format, higherIsBetter, tooltipKey]) => {
-        const portClass = compareClass(portVal, spyVal, higherIsBetter);
-        const ttAttr = tooltipKey ? ` data-metric-tooltip="${tooltipKey}"` : '';
+    stdRows.forEach(([label, key, format, better, tip]) => {
+        const portClass = portClassVs(p[key], primary[key], better);
         html += `
             <tr>
-                <td class="ps-3"${ttAttr}>${label} <span class="text-muted small">ⓘ</span></td>
-                <td class="text-end ${portClass}">${fmt(portVal, format)}</td>
-                <td class="text-end pe-3">${fmt(spyVal, format)}</td>
-            </tr>
-        `;
+                <td class="ps-3" data-metric-tooltip="${tip}">${label} <span class="text-muted small">ⓘ</span></td>
+                <td class="text-end ${portClass}">${fmt(p[key], format)}</td>
+                ${cols.map(c => `<td class="text-end pe-3">${fmt(c.m[key], format)}</td>`).join('')}
+            </tr>`;
     });
 
-    // Alpha 행 (포트폴리오 전용)
-    const alpha = p.totalReturn - s.totalReturn;
-    const alphaClass = alpha >= 0 ? 'text-success fw-bold' : 'text-danger fw-bold';
-    html += `
-        <tr class="table-light">
-            <td class="ps-3 fw-bold" data-metric-tooltip="alpha">Alpha <span class="text-muted small">ⓘ</span></td>
-            <td class="text-end ${alphaClass}" colspan="2">${alpha >= 0 ? '+' : ''}${alpha.toFixed(2)}%</td>
-        </tr>
-    `;
+    // 상대 지표 행: 포트폴리오의 '각 인덱스 대비' 값 (포트폴리오 컬럼은 의미 없어 '—')
+    const relRows = [
+        ['Alpha',             'alpha',    'percent', 'alpha', true],
+        ['Beta',              'portBeta', 'ratio',   'beta',  false],
+        ['Information Ratio', 'portIR',   'ratio',   'ir',    true],
+    ];
+    relRows.forEach(([label, key, format, tip, signColor]) => {
+        html += `
+            <tr class="table-light">
+                <td class="ps-3 fw-bold" data-metric-tooltip="${tip}">${label} <span class="text-muted small">ⓘ</span></td>
+                <td class="text-end text-muted">—</td>
+                ${cols.map(c => {
+                    const v = c.m[key];
+                    const cls = (signColor && v != null && isFinite(v))
+                        ? (v >= 0 ? 'text-success fw-bold' : 'text-danger') : '';
+                    return `<td class="text-end pe-3 ${cls}">${fmt(v, format)}</td>`;
+                }).join('')}
+            </tr>`;
+    });
 
-    // Information Ratio 행 (포트폴리오 전용, SPY는 정의상 0)
-    const ir = p.ir ?? 0;
-    const irClass = ir >= 0.5 ? 'text-success fw-bold' : ir < 0 ? 'text-danger fw-bold' : 'text-dark fw-bold';
-    html += `
-        <tr class="table-light">
-            <td class="ps-3 fw-bold" data-metric-tooltip="ir">Information Ratio <span class="text-muted small">ⓘ</span></td>
-            <td class="text-end ${irClass}" colspan="2">${ir.toFixed(2)}</td>
-        </tr>
-    `;
-
+    const tbody = document.querySelector('#metrics-comparison-table tbody');
     tbody.innerHTML = html;
 }
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -282,11 +282,13 @@ export function renderPerformanceSummaryCards(summaryData) {
         if (format === 'percent_abs') return value.toFixed(2) + '%';
         return value.toFixed(2);
     }
-    // 포트폴리오가 주 벤치마크 대비 우수하면 success, 열위면 danger
+    // 포트폴리오가 주 벤치마크 대비 우수하면 success, 열위면 danger.
+    // higherIsBetter에 따라 비교 방향을 결정한다(Volatility/MDD 등 낮을수록 좋은 지표 대응).
     function portClassVs(portVal, refVal, higherIsBetter) {
         if (higherIsBetter === null) return '';
         if (Math.abs(portVal - refVal) < 0.005) return '';
-        return portVal > refVal ? 'text-success fw-bold' : 'text-danger';
+        const isBetter = higherIsBetter ? (portVal > refVal) : (portVal < refVal);
+        return isBetter ? 'text-success fw-bold' : 'text-danger';
     }
 
     // 헤더 (계좌 통화별로 벤치마크 셋이 다르므로 동적 생성)
@@ -304,7 +306,7 @@ export function renderPerformanceSummaryCards(summaryData) {
     const stdRows = [
         ['Total Return',  'totalReturn', 'percent',     true,  'totalReturn'],
         ['CAGR',          'cagr',        'percent',     true,  'cagr'],
-        ['Max Drawdown',  'mdd',         'percent',     false, 'mdd'],
+        ['Max Drawdown',  'mdd',         'percent',     true,  'mdd'],
         ['Volatility',    'volatility',  'percent_abs', false, 'volatility'],
         ['Sharpe Ratio',  'sharpe',      'ratio',       true,  'sharpe'],
         ['Sortino Ratio', 'sortino',     'ratio',       true,  'sortino'],

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -286,6 +286,8 @@ export function renderPerformanceSummaryCards(summaryData) {
     // higherIsBetter에 따라 비교 방향을 결정한다(Volatility/MDD 등 낮을수록 좋은 지표 대응).
     function portClassVs(portVal, refVal, higherIsBetter) {
         if (higherIsBetter === null) return '';
+        // 비유한 값(N/A 지표)은 색상을 적용하지 않는다 (fmt가 'N/A'로 표시)
+        if (!Number.isFinite(portVal) || !Number.isFinite(refVal)) return '';
         if (Math.abs(portVal - refVal) < 0.005) return '';
         const isBetter = higherIsBetter ? (portVal > refVal) : (portVal < refVal);
         return isBetter ? 'text-success fw-bold' : 'text-danger';

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -172,7 +172,7 @@ export function computeAdvancedMetrics(summaryData, initialCash = null) {
     // total_value=0 레코드는 브로커 API 오류로 인한 잘못된 데이터이므로 제외
     summaryData = summaryData ? summaryData.filter(d => d.total_value > 0) : [];
     if (summaryData.length < 2) {
-        return { portfolio: { ...empty }, spy: { ...empty, beta: 1.0, ir: 0 } };
+        return { portfolio: { ...empty }, spy: { ...empty, beta: 1.0, ir: 0 }, benchmarks: {} };
     }
 
     const first = summaryData[0];
@@ -263,7 +263,44 @@ export function computeAdvancedMetrics(summaryData, initialCash = null) {
     portMetrics.ir = ir;
     spyMetrics.ir = 0;
 
-    return { portfolio: portMetrics, spy: spyMetrics };
+    // 각 벤치마크(존재 시)별 인덱스 지표 + 포트폴리오의 해당 지수 대비 상대지표.
+    // S&P500 전용 spy_price 폴백은 적용하지 않는다(다른 지수/통화 오염 방지) —
+    // 전 구간에 값이 있는 벤치마크만 컬럼으로 포함한다.
+    const BENCHMARK_NAMES = ['S&P500', 'NASDAQ100', 'KOSPI200'];
+    const benchmarks = {};
+    for (const name of BENCHMARK_NAMES) {
+        if (!summaryData.every(d => Number.isFinite(d?.benchmarks?.[name]))) continue;
+        const bPrices = summaryData.map(d => d.benchmarks[name]);
+        const bReturns = [];
+        for (let i = 1; i < n; i++) bReturns.push(bPrices[i] / bPrices[i - 1] - 1);
+        const m = calcMetrics(bPrices, bReturns);
+
+        // 포트폴리오 vs 이 인덱스: Beta
+        const meanB = bReturns.reduce((s, r) => s + r, 0) / bReturns.length;
+        let covB = 0, varB = 0;
+        for (let i = 0; i < portReturns.length; i++) {
+            covB += (portReturns[i] - meanPort) * (bReturns[i] - meanB);
+            varB += Math.pow(bReturns[i] - meanB, 2);
+        }
+        m.portBeta = varB !== 0 ? covB / varB : 1.0;
+
+        // 포트폴리오 vs 이 인덱스: Information Ratio
+        const exc = portReturns.map((r, i) => r - bReturns[i]);
+        let portIR = 0;
+        if (exc.length > 1) {
+            const me = exc.reduce((s, r) => s + r, 0) / exc.length;
+            const tv = exc.reduce((s, r) => s + Math.pow(r - me, 2), 0) / (exc.length - 1);
+            const te = Math.sqrt(tv) * Math.sqrt(252);
+            portIR = te > 0 ? (me * 252) / te : 0;
+        }
+        m.portIR = portIR;
+
+        // 포트폴리오 누적 초과수익 vs 이 인덱스
+        m.alpha = portMetrics.totalReturn - m.totalReturn;
+        benchmarks[name] = m;
+    }
+
+    return { portfolio: portMetrics, spy: spyMetrics, benchmarks };
 }
 
 /**


### PR DESCRIPTION
## 배경 — #338 복구

#338(지표 테이블 벤치마크 3종)이 **스택 PR base가 중간 라벨 브랜치였고 main으로 retarget되지 않아**, 머지가 `claude/benchmark-labels-spy-to-sp500`(이미 main에 머지된 dead-end 브랜치)로 들어갔습니다. 결과적으로 **기능이 main에 반영되지 않았습니다.**

이 PR은 동일한 변경(기능 + 리뷰 버그수정)을 **최신 main 위로 리베이스**해 main에 올립니다.

## 포함 내용 (= #338 전체)

### `utils.js` — `computeAdvancedMetrics` 확장 (하위호환)
- 기존 `{portfolio, spy}` 유지(비교 페이지·Calmar 카드 무영향) + **`benchmarks` 맵 추가**.
- 각 벤치마크의 자체 지표(Return/CAGR/MDD/Vol/Sharpe/Sortino/Calmar) + 포트폴리오의 해당 지수 대비 **Alpha/Beta/IR**.
- S&P500 전용 `spy_price` 폴백을 비-S&P500엔 미적용(통화/지수 오염 방지), 전 구간 보유 벤치마크만 포함.

### `ui.js` — `renderPerformanceSummaryCards` 멀티컬럼
- 동적 thead(계좌 통화별 셋 상이), 인덱스 컬러 도트.
- 독립 지표는 각 인덱스 자체값, Alpha/Beta/IR은 각 컬럼에 포트폴리오의 해당 지수 대비값.

### 리뷰 버그수정 (Gemini)
- `portClassVs`가 `higherIsBetter`를 반영하도록 수정 → Volatility(낮을수록 좋음) 색상 정정.
- Max Drawdown `higherIsBetter=true`(음수라 클수록 좋음).

## 캐시
ESM 무효화: `utils.js?v=20260624-3`, `ui.js?v=20260624-3`, `main.js?v=20260624-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX)_