### PR TITLE
feat(ui): Sharpe/Sortino에 무위험 수익률(Rf) 반영

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260624-4"></script>
+    <script type="module" src="js/main.js?v=20260624-5"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260624-5"></script>
+    <script type="module" src="js/main.js?v=20260624-6"></script>
 </body>
 </html>

--- a/docs/js/account-compare-charts.js
+++ b/docs/js/account-compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/account-compare-charts.js
 // 라이브 다중 계좌 비교 전용 차트
 
-import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=20260624-4';
+import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=20260624-5';
 
 let accountPerformanceChart = null;
 let accountStrategyChart = null;

--- a/docs/js/account-compare-charts.js
+++ b/docs/js/account-compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/account-compare-charts.js
 // 라이브 다중 계좌 비교 전용 차트
 
-import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=20260624-3';
+import { filterByDateRange, ACCOUNT_COLORS } from './utils.js?v=20260624-4';
 
 let accountPerformanceChart = null;
 let accountStrategyChart = null;

--- a/docs/js/account-compare-ui.js
+++ b/docs/js/account-compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ACCOUNT_COLORS,
     ACCOUNT_MARKET_TYPES,
-} from './utils.js?v=20260624-3';
+} from './utils.js?v=20260624-4';
 
 /**
  * Overview 탭 - 계좌별 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)
@@ -25,7 +25,7 @@ export function renderAccountOverview(accountsData) {
 
     const accountMetrics = {};
     for (const [id, data] of accountsData) {
-        accountMetrics[id] = computeAdvancedMetrics(data.summary, null);
+        accountMetrics[id] = computeAdvancedMetrics(data.summary, null, ACCOUNT_MARKET_TYPES[id]);
     }
 
     const today = new Date().toISOString().slice(0, 10);

--- a/docs/js/account-compare-ui.js
+++ b/docs/js/account-compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ACCOUNT_COLORS,
     ACCOUNT_MARKET_TYPES,
-} from './utils.js?v=20260624-4';
+} from './utils.js?v=20260624-5';
 
 /**
  * Overview 탭 - 계좌별 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -16,7 +16,7 @@ import {
     computeMonthlyTradeFrequency,
     computeTickerContribution,
     computeAnnualReturns
-} from './utils.js?v=20260624-3';
+} from './utils.js?v=20260624-4';
 
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
 let stratChart = null;

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -16,7 +16,7 @@ import {
     computeMonthlyTradeFrequency,
     computeTickerContribution,
     computeAnnualReturns
-} from './utils.js?v=20260624-4';
+} from './utils.js?v=20260624-5';
 
 // 차트 인스턴스 (모듈 스코프, 모드 전환 시 기존 차트 삭제용)
 let stratChart = null;

--- a/docs/js/compare-charts.js
+++ b/docs/js/compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/compare-charts.js
 // 멀티 엔진 비교 전용 차트
 
-import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=20260624-3';
+import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=20260624-4';
 
 let comparePerformanceChart = null;
 let compareStrategyChart = null;

--- a/docs/js/compare-charts.js
+++ b/docs/js/compare-charts.js
@@ -1,7 +1,7 @@
 // docs/js/compare-charts.js
 // 멀티 엔진 비교 전용 차트
 
-import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=20260624-4';
+import { filterByDateRange, ENGINE_COLORS, ENGINE_MARKET_TYPES } from './utils.js?v=20260624-5';
 
 let comparePerformanceChart = null;
 let compareStrategyChart = null;

--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ENGINE_COLORS,
     ENGINE_MARKET_TYPES,
-} from './utils.js?v=20260624-3';
+} from './utils.js?v=20260624-4';
 
 /**
  * Overview 탭 - 엔진 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)
@@ -29,7 +29,7 @@ export function renderCompareOverview(enginesData) {
     const engineMetrics = {};
     for (const [name, data] of enginesData) {
         const initialCash = data.status?.initial_cash ?? null;
-        engineMetrics[name] = computeAdvancedMetrics(data.summary, initialCash);
+        engineMetrics[name] = computeAdvancedMetrics(data.summary, initialCash, ENGINE_MARKET_TYPES[name]);
     }
 
     // 각 엔진 최종 자산

--- a/docs/js/compare-ui.js
+++ b/docs/js/compare-ui.js
@@ -9,7 +9,7 @@ import {
     formatPercent,
     ENGINE_COLORS,
     ENGINE_MARKET_TYPES,
-} from './utils.js?v=20260624-4';
+} from './utils.js?v=20260624-5';
 
 /**
  * Overview 탭 - 엔진 비교 요약 테이블 렌더링 (해외/국내 섹션 분리)

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,19 +46,19 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260624-4';
+} from './ui.js?v=20260624-5';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-3';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-4';
 
 import {
     renderCompareOverview,
     renderCompareTradesTab,
-} from './compare-ui.js?v=4';
+} from './compare-ui.js?v=5';
 
 import {
     renderAccountOverview,
     renderAccountTradesTab,
-} from './account-compare-ui.js?v=3';
+} from './account-compare-ui.js?v=4';
 
 import {
     renderAccountPerformanceChart,
@@ -232,7 +232,7 @@ function _renderSingleAccount({ summary: summaryData, status: statusData, histor
 
     function renderPerformanceTab() {
         if (perfRendered) return;
-        renderPerformanceSummaryCards(summaryData);
+        renderPerformanceSummaryCards(summaryData, marketType);
         renderRegimePerformanceTable(summaryData);
         renderYTDCard(summaryData);
         renderWinLossCards(summaryData);

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -48,7 +48,7 @@ import {
     initTooltips
 } from './ui.js?v=20260624-5';
 
-import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-4';
+import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-5';
 
 import {
     renderCompareOverview,

--- a/docs/js/portfolio-cards.js
+++ b/docs/js/portfolio-cards.js
@@ -3,7 +3,7 @@ import {
     formatAmount,
     ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES,
     getRegimeColorClass
-} from './utils.js?v=20260624-4';
+} from './utils.js?v=20260624-5';
 
 /**
  * 통화별 합산 배너 렌더링

--- a/docs/js/portfolio-cards.js
+++ b/docs/js/portfolio-cards.js
@@ -3,7 +3,7 @@ import {
     formatAmount,
     ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES,
     getRegimeColorClass
-} from './utils.js?v=20260624-3';
+} from './utils.js?v=20260624-4';
 
 /**
  * 통화별 합산 배너 렌더링

--- a/docs/js/portfolio-charts.js
+++ b/docs/js/portfolio-charts.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-charts.js
-import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260624-3';
+import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260624-4';
 
 let comparisonChart = null;
 

--- a/docs/js/portfolio-charts.js
+++ b/docs/js/portfolio-charts.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-charts.js
-import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260624-4';
+import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260624-5';
 
 let comparisonChart = null;
 

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-main.js
-import { loadAccountsMeta } from './utils.js?v=20260624-4';
+import { loadAccountsMeta } from './utils.js?v=20260624-5';
 import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260621-1';
 import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
 

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-main.js
-import { loadAccountsMeta } from './utils.js?v=20260624-3';
+import { loadAccountsMeta } from './utils.js?v=20260624-4';
 import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260621-1';
 import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -25,7 +25,7 @@ import {
     computeYTDReturn,
     computeDividendYield,
     computeWinLossStats
-} from './utils.js?v=20260624-4';
+} from './utils.js?v=20260624-5';
 
 import { METRIC_TOOLTIPS } from './metric-tooltips.js?v=20260621-1';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -25,7 +25,7 @@ import {
     computeYTDReturn,
     computeDividendYield,
     computeWinLossStats
-} from './utils.js?v=20260624-3';
+} from './utils.js?v=20260624-4';
 
 import { METRIC_TOOLTIPS } from './metric-tooltips.js?v=20260621-1';
 
@@ -255,8 +255,8 @@ export function updateDecisionLogic(lastData) {
 /**
  * Performance 탭 - 포트폴리오 vs S&P500 비교 테이블 렌더링
  */
-export function renderPerformanceSummaryCards(summaryData) {
-    const metrics = computeAdvancedMetrics(summaryData);
+export function renderPerformanceSummaryCards(summaryData, marketType = null) {
+    const metrics = computeAdvancedMetrics(summaryData, null, marketType);
     const p = metrics.portfolio;
 
     // 표시할 벤치마크 컬럼 구성 (데이터에 존재하는 것만, 정해진 순서대로)

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -162,12 +162,23 @@ export function getAssetGroup(ticker, groupConfig) {
 }
 
 /**
+ * 무위험 수익률(연율). 현재 3개월 단기국채 금리 기준.
+ * 금리는 천천히 변하므로 상수로 두고 필요 시 수동 갱신한다
+ * (Sharpe/Sortino의 초과수익 분자에만 영향, 통화별로 다름).
+ */
+export const RISK_FREE_RATE_ANNUAL = {
+    overseas: 0.038,  // 미국 3개월 T-bill
+    domestic: 0.027,  // 한국 3개월 단기국채
+};
+
+/**
  * 포트폴리오 & SPY 벤치마크 고급 지표 계산
  * @param {Array} summaryData - summary 배열 (total_value, spy_price 포함)
  * @param {number|null} initialCash - 실제 초기 자본 (status.json의 initial_cash). 없으면 summary 첫 값 사용.
+ * @param {string|null} marketType - 'overseas'|'domestic'. 통화별 무위험 수익률 선택용(미지정 시 Rf=0).
  * @returns {{portfolio: Object, spy: Object}} 양쪽 지표 객체
  */
-export function computeAdvancedMetrics(summaryData, initialCash = null) {
+export function computeAdvancedMetrics(summaryData, initialCash = null, marketType = null) {
     const empty = { totalReturn: 0, cagr: 0, mdd: 0, volatility: 0, sharpe: 0, sortino: 0, calmar: 0, beta: 1.0, ir: 0 };
     // total_value=0 레코드는 브로커 API 오류로 인한 잘못된 데이터이므로 제외
     summaryData = summaryData ? summaryData.filter(d => d.total_value > 0) : [];
@@ -182,6 +193,10 @@ export function computeAdvancedMetrics(summaryData, initialCash = null) {
     // 기간 (연 단위)
     const msPerYear = 365.25 * 24 * 60 * 60 * 1000;
     const years = Math.max((new Date(last.date) - new Date(first.date)) / msPerYear, 1 / 365);
+
+    // 무위험 수익률 일간 환산 (3개월 단기국채 연율 → 일률). marketType 미지정 시 0.
+    const rfAnnual = RISK_FREE_RATE_ANNUAL[marketType] ?? 0;
+    const rfDaily = Math.pow(1 + rfAnnual, 1 / 252) - 1;
 
     // 벤치마크 기준가 시계열 (S&P500 우선, 구버전 폴백 spy_price)
     const { prices: benchPrices } = benchmarkPriceSeries(summaryData);
@@ -215,16 +230,18 @@ export function computeAdvancedMetrics(summaryData, initialCash = null) {
         const variance = dailyReturns.reduce((s, r) => s + Math.pow(r - meanRet, 2), 0) / (dailyReturns.length - 1);
         const volatility = Math.sqrt(variance) * Math.sqrt(252) * 100;
 
-        // Sharpe Ratio (무위험 수익률 0 가정)
-        const sharpe = volatility !== 0 ? (meanRet / Math.sqrt(variance)) * Math.sqrt(252) : 0;
+        // Sharpe Ratio (무위험 수익률 초과수익 기준)
+        const std = Math.sqrt(variance);
+        const excessMean = meanRet - rfDaily;
+        const sharpe = std !== 0 ? (excessMean / std) * Math.sqrt(252) : 0;
 
-        // Sortino Ratio (하방 변동성만)
-        const downsideReturns = dailyReturns.filter(r => r < 0);
+        // Sortino Ratio (MAR = 무위험 수익률, 하방 편차만)
+        const downsideReturns = dailyReturns.filter(r => r < rfDaily);
         const downsideVariance = downsideReturns.length > 0
-            ? downsideReturns.reduce((s, r) => s + Math.pow(r, 2), 0) / (dailyReturns.length - 1)
+            ? downsideReturns.reduce((s, r) => s + Math.pow(r - rfDaily, 2), 0) / (dailyReturns.length - 1)
             : 0;
         const downsideStd = Math.sqrt(downsideVariance);
-        const sortino = downsideStd !== 0 ? (meanRet / downsideStd) * Math.sqrt(252) : 0;
+        const sortino = downsideStd !== 0 ? (excessMean / downsideStd) * Math.sqrt(252) : 0;
 
         // Calmar Ratio (CAGR / |MDD|)
         const calmar = mdd !== 0 ? (cagr / 100) / Math.abs(mdd / 100) : 0;

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -227,7 +227,9 @@ export function computeAdvancedMetrics(summaryData, initialCash = null, marketTy
 
         // Volatility (연환산)
         const meanRet = dailyReturns.reduce((s, r) => s + r, 0) / dailyReturns.length;
-        const variance = dailyReturns.reduce((s, r) => s + Math.pow(r - meanRet, 2), 0) / (dailyReturns.length - 1);
+        const variance = dailyReturns.length > 1
+            ? dailyReturns.reduce((s, r) => s + Math.pow(r - meanRet, 2), 0) / (dailyReturns.length - 1)
+            : 0;
         const volatility = Math.sqrt(variance) * Math.sqrt(252) * 100;
 
         // Sharpe Ratio (무위험 수익률 초과수익 기준)
@@ -237,7 +239,7 @@ export function computeAdvancedMetrics(summaryData, initialCash = null, marketTy
 
         // Sortino Ratio (MAR = 무위험 수익률, 하방 편차만)
         const downsideReturns = dailyReturns.filter(r => r < rfDaily);
-        const downsideVariance = downsideReturns.length > 0
+        const downsideVariance = downsideReturns.length > 0 && dailyReturns.length > 1
             ? downsideReturns.reduce((s, r) => s + Math.pow(r - rfDaily, 2), 0) / (dailyReturns.length - 1)
             : 0;
         const downsideStd = Math.sqrt(downsideVariance);


### PR DESCRIPTION
## 배경

Sharpe/Sortino 비율이 **무위험 수익률(Rf)=0** 으로 단순화돼 있었다. 실제 Rf(현재 3개월 단기국채 금리)를 반영해 초과수익 기준으로 계산한다.

## 저장 위치 / 값

`utils.js`에 통화별 상수로 둔다 (Sharpe/Sortino 계산이 프론트 전용이라 config.py 아님). **금리는 천천히 변하므로 상수로 두고 필요 시 수동 갱신** (Sharpe 민감도상 0↔비0 차이는 크지만 미세 변동 영향은 작음).

```js
// 무위험 수익률(연율) — 현재 3개월 단기국채 금리 기준
export const RISK_FREE_RATE_ANNUAL = {
    overseas: 0.038,  // 미국 3개월 T-bill
    domestic: 0.027,  // 한국 3개월 단기국채
};
```

## 변경

- **`utils.js`** — `computeAdvancedMetrics(summaryData, initialCash, marketType)`로 통화별 Rf 선택. 연율→일률 환산(`(1+Rf)^(1/252)-1`) 후:
  - Sharpe = `(평균일간수익 − Rf) / σ × √252`
  - Sortino = MAR=Rf 기준 하방 편차로 동일 분자
  - **Calmar/MDD/Volatility/Return 등은 불변** (Rf 무관)
- **호출처 marketType 전달**: 성과탭(`renderPerformanceSummaryCards`), 엔진 비교(`compare-ui`), 계좌 비교(`account-compare-ui`). → 단일/비교 화면 Sharpe가 **같은 잣대**로 일관.
- Sharpe 툴팁은 이미 "무위험 수익률을 초과한 수익..."이라 **코드가 설명과 일치**하게 됨(툴팁 수정 불필요).

## 참고
- 단기채 *주가*는 summary.json에 넣지 않음 — Rf는 가격이 아니라 *금리*이고, 단기채 가격은 수익(분배금)을 못 담아 0에 가깝게 나오기 때문.
- `marketType` 미지정 호출(예: Calmar 카드)은 Rf=0 폴백 → Calmar는 Rf 무관이라 무영향.
- 금리 갱신 시 `RISK_FREE_RATE_ANNUAL` 두 값만 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX)_