### PR TITLE
feat(ui): 지표 테이블에 무위험 수익률 기준 안내 캡션

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260624-6"></script>
+    <script type="module" src="js/main.js?v=20260624-7"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -948,6 +948,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260624-7"></script>
+    <script type="module" src="js/main.js?v=20260624-8"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260624-5';
+} from './ui.js?v=20260624-6';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-5';
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260624-6';
+} from './ui.js?v=20260624-7';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-5';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -24,7 +24,8 @@ import {
     computeRegimePerformance,
     computeYTDReturn,
     computeDividendYield,
-    computeWinLossStats
+    computeWinLossStats,
+    RISK_FREE_RATE_ANNUAL
 } from './utils.js?v=20260624-5';
 
 import { METRIC_TOOLTIPS } from './metric-tooltips.js?v=20260621-1';
@@ -347,6 +348,18 @@ export function renderPerformanceSummaryCards(summaryData, marketType = null) {
 
     const tbody = document.querySelector('#metrics-comparison-table tbody');
     tbody.innerHTML = html;
+
+    // Rf 안내 캡션 — Sharpe/Sortino가 무위험 수익률을 반영함을 명시(항상 표시)
+    const table = document.getElementById('metrics-comparison-table');
+    if (table) {
+        const rf = RISK_FREE_RATE_ANNUAL[marketType];
+        const cap = table.querySelector('caption') || table.createCaption();
+        cap.className = 'text-muted small text-start px-3 py-2';
+        cap.style.captionSide = 'bottom';
+        cap.textContent = (rf != null)
+            ? `※ Sharpe·Sortino는 무위험 수익률 연 ${(rf * 100).toFixed(1)}% (${marketType === 'domestic' ? '한국' : '미국'} 3개월 단기국채) 기준`
+            : '※ Sharpe·Sortino는 무위험 수익률 0% 기준';
+    }
 }
 
 /**

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -352,8 +352,8 @@ export function renderPerformanceSummaryCards(summaryData, marketType = null) {
     // Rf 안내 캡션 — Sharpe/Sortino가 무위험 수익률을 반영함을 명시(항상 표시)
     const table = document.getElementById('metrics-comparison-table');
     if (table) {
-        const rf = RISK_FREE_RATE_ANNUAL[marketType];
-        const cap = table.querySelector('caption') || table.createCaption();
+        const rf = marketType ? RISK_FREE_RATE_ANNUAL[marketType] : null;
+        const cap = table.createCaption();  // 이미 있으면 기존 caption 반환(idempotent)
         cap.className = 'text-muted small text-start px-3 py-2';
         cap.style.captionSide = 'bottom';
         cap.textContent = (rf != null)


### PR DESCRIPTION
## 배경

#340에서 Sharpe/Sortino가 무위험 수익률(Rf)을 반영하도록 바꿨지만, **화면상 Rf가 적용됐는지 확인할 방법이 없었다.**

## 변경

지표 비교 테이블 하단에 **항상 보이는 안내 캡션**을 추가한다 (`ui.js`, `renderPerformanceSummaryCards`):

```
※ Sharpe·Sortino는 무위험 수익률 연 2.7% (한국 3개월 단기국채) 기준
```

- 계좌 통화(`marketType`)에 맞춰 `RISK_FREE_RATE_ANNUAL`에서 Rf를 읽어 **국내 2.7% / 해외 3.8%**로 표시.
- `<caption captionSide:bottom>`으로 테이블 하단에 렌더 → index.html 구조 변경 없음(JS만).
- Rf 미지정(예외) 시 "무위험 수익률 0% 기준" 표기.

## 참고
- `utils.js`는 변경 없음(기존 `RISK_FREE_RATE_ANNUAL` export를 import만 추가).
- ESM 캐시: `ui.js?v=20260624-6`, `main.js?v=20260624-7`.
- 금리 갱신 시에도 캡션이 자동으로 새 값을 반영(상수 한 곳만 수정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiTnD8shpXfrAWh4K6JbZX)_