### PR TITLE
feat: DipBuyGatedSpyEngine — risk-off 때 현금 대신 SPY 보유 변형

### DIFF
--- a/src/core/engine/__init__.py
+++ b/src/core/engine/__init__.py
@@ -26,7 +26,7 @@ from src.core.engine.simple import (
     DomesticAsset5Engine,
 )
 from src.core.engine.regime import QldSdyShvEngine, QldQqqShvRegimeEngine
-from src.core.engine.dip_buy import DipBuyEngine, DipBuyGatedEngine
+from src.core.engine.dip_buy import DipBuyEngine, DipBuyGatedEngine, DipBuyGatedSpyEngine
 
 __all__ = [
     "_ENGINE_REGISTRY",
@@ -47,4 +47,5 @@ __all__ = [
     "QldQqqShvRegimeEngine",
     "DipBuyEngine",
     "DipBuyGatedEngine",
+    "DipBuyGatedSpyEngine",
 ]

--- a/src/core/engine/dip_buy.py
+++ b/src/core/engine/dip_buy.py
@@ -177,6 +177,9 @@ class DipBuyGatedEngine(DipBuyEngine):
     """
 
     TREND_GATE_MA: int = 200   # DipBuySignals.ma200 사용 (변경 시 지표 추가 필요)
+    # risk-off(추세 이탈) 때 보유할 자산. None이면 현금성(SHV)으로 대기.
+    # 예: "SPY"로 두면 추세 이탈 구간에 1x 광의시장을 보유(DipBuyGatedSpyEngine).
+    RISK_OFF_TICKER: Optional[str] = None
 
     def execute_cycle(
         self,
@@ -195,30 +198,85 @@ class DipBuyGatedEngine(DipBuyEngine):
         price = portfolio.current_prices.get(self._ticker, 0.0)
         ma = self.dip_signals.ma200 if self.dip_signals is not None else float("nan")
         risk_on = price > 0 and not math.isnan(ma) and ma > 0 and price >= ma
+        r = self.RISK_OFF_TICKER
 
         if risk_on:
-            # 추세 위 → 정상 DipBuy 위임
+            # risk-off 자산을 보유 중이면 먼저 청산(전환 사이클), 아니면 정상 DipBuy 위임
+            if r and portfolio.holdings.get(r, 0) > 0:
+                return self._finalize(self._exit_risk_off_asset(portfolio), portfolio,
+                                      f"추세 복귀 → {r} 청산 후 DipBuy 재개")
             return super().execute_cycle(market_data, portfolio, regime, exposure,
                                          nan_fields, sim_date, record_date)
 
-        # 추세 이탈(200MA 아래) → risk-off: 보유 QLD 전량 청산 후 SHV로 대기, 상태 리셋
+        # 추세 이탈(200MA 아래) → risk-off
+        if r:
+            return self._finalize(self._enter_risk_off_asset(portfolio), portfolio,
+                                  f"추세 이탈(200MA 아래) → {r} 100% 보유")
+        # 기본: 보유 QLD 전량 청산 후 현금성(SHV)으로 대기
         orders: List[Order] = []
         held = portfolio.holdings.get(self._ticker, 0)
         if held > 0 and price > 0:
             orders.append(Order(self._ticker, OrderAction.SELL, held, price))
         orders = self._apply_cash_reservoir(orders, portfolio)
+        return self._finalize(orders, portfolio, "추세 이탈(200MA 아래) → risk-off 현금화")
 
+    # ── risk-off 자산 전환 헬퍼 ─────────────────────────────────────────────
+    def _enter_risk_off_asset(self, portfolio: Portfolio) -> List[Order]:
+        """QLD·SHV 전량 청산 후 RISK_OFF_TICKER로 가용현금 전액 매수."""
+        r = self.RISK_OFF_TICKER
+        p_r = portfolio.current_prices.get(r, 0.0)
+        price = portfolio.current_prices.get(self._ticker, 0.0)
+        orders: List[Order] = []
+        cash_avail = portfolio.total_cash
+
+        qld_held = portfolio.holdings.get(self._ticker, 0)
+        if qld_held > 0 and price > 0:
+            orders.append(Order(self._ticker, OrderAction.SELL, qld_held, price))
+            cash_avail += qld_held * price
+        shv = self._cash_ticker
+        if shv:
+            p_shv = portfolio.current_prices.get(shv, 0.0)
+            shv_held = portfolio.holdings.get(shv, 0)
+            if shv_held > 0 and p_shv > 0:
+                orders.append(Order(shv, OrderAction.SELL, shv_held, p_shv))
+                cash_avail += shv_held * p_shv
+        if p_r > 0:
+            qty = math.floor(cash_avail / p_r)
+            if qty > 0:
+                orders.append(Order(r, OrderAction.BUY, qty, p_r))
+        return orders
+
+    def _exit_risk_off_asset(self, portfolio: Portfolio) -> List[Order]:
+        """RISK_OFF_TICKER 전량 청산 후 잔여 현금을 SHV로 스윕(다음 사이클 DipBuy 재개)."""
+        r = self.RISK_OFF_TICKER
+        p_r = portfolio.current_prices.get(r, 0.0)
+        orders: List[Order] = []
+        cash_avail = portfolio.total_cash
+        r_held = portfolio.holdings.get(r, 0)
+        if r_held > 0 and p_r > 0:
+            orders.append(Order(r, OrderAction.SELL, r_held, p_r))
+            cash_avail += r_held * p_r
+        shv = self._cash_ticker
+        if shv:
+            p_shv = portfolio.current_prices.get(shv, 0.0)
+            if p_shv > 0:
+                qty = math.floor(cash_avail / p_shv)
+                if qty > 0:
+                    orders.append(Order(shv, OrderAction.BUY, qty, p_shv))
+        return orders
+
+    def _finalize(self, orders: List[Order], portfolio: Portfolio, reason: str
+                  ) -> Tuple[TradeSignal, List[TradeExecution], Portfolio, bool]:
+        """risk-off/전환 주문을 실행하고 결과 튜플 생성 (DipBuy 비활성 → 상태 리셋)."""
         new_state = DipBuyState()
         self.dip_state = new_state
         self.repo.save_strategy_state(self.STATE_KEY, new_state.to_dict())
 
-        reason = "추세 이탈(200MA 아래) → risk-off 현금화"
         signal = TradeSignal(0.0, orders, reason)
         self.logger.info(f">>> Step 5: DipBuyGated ({reason})")
 
         executions: List[TradeExecution] = []
         final_pf = portfolio
-        is_rebalancing = bool(orders)
         if orders:
             executions = self.broker.execute_orders(orders)
             try:
@@ -226,5 +284,17 @@ class DipBuyGatedEngine(DipBuyEngine):
             except RuntimeError as e:
                 self.logger.error(f"거래 후 포트폴리오 조회 실패 — 거래 전 포트폴리오로 대체: {e}")
                 final_pf = portfolio
+        return signal, executions, final_pf, bool(orders)
 
-        return signal, executions, final_pf, is_rebalancing
+
+@register_engine(color="#20c997")
+class DipBuyGatedSpyEngine(DipBuyGatedEngine):
+    """DipBuyGated 변형 — risk-off(추세 이탈) 때 현금(SHV) 대신 SPY(1x)를 100% 보유.
+
+    QLD가 200일선 위면 눌림목 분할매수(QLD+SHV), 아래로 깨지면 전량 SPY로 전환한다.
+    추세 이탈 구간에서도 1x 광의시장 수익을 노리는 변형 — 다만 SPY도 하락장엔 함께
+    빠지므로 효과는 국면 의존적(현금 버전 대비 비교는 run-compare-backtest로 검증).
+    """
+
+    ASSET_GROUPS: dict = {"A": ["QLD"], "B": ["SPY"], "C": ["SHV"]}
+    RISK_OFF_TICKER: str = "SPY"

--- a/src/core/engine/dip_buy.py
+++ b/src/core/engine/dip_buy.py
@@ -195,10 +195,32 @@ class DipBuyGatedEngine(DipBuyEngine):
             return super().execute_cycle(market_data, portfolio, regime, exposure,
                                          nan_fields, sim_date, record_date)
 
+        if self.dip_signals is None:
+            signal = TradeSignal(0.0, [], "지표 데이터 없음 (dip_signals=None) — 매매 중단")
+            self.logger.error("dip_signals is None — 매매 중단")
+            return signal, [], portfolio, False
+
         price = portfolio.current_prices.get(self._ticker, 0.0)
-        ma = self.dip_signals.ma200 if self.dip_signals is not None else float("nan")
+        ma = self.dip_signals.ma200
         risk_on = price > 0 and not math.isnan(ma) and ma > 0 and price >= ma
         r = self.RISK_OFF_TICKER
+
+        # 가격 검증: 이번 사이클에 거래가 필요한 종목의 현재가가 없으면(≤0) 상태 변경 없이 중단.
+        # (특히 risk-off 전환 시 r 가격이 없으면 기존 자산만 팔고 r은 못 사 의도치 않게
+        #  100% 현금이 되는 문제를 방지 — 베이스 엔진의 zero-price 가드와 동일 철학)
+        bad = []
+        if portfolio.holdings.get(self._ticker, 0) > 0 and price <= 0:
+            bad.append(self._ticker)
+        if self._cash_ticker and portfolio.holdings.get(self._cash_ticker, 0) > 0 \
+                and portfolio.current_prices.get(self._cash_ticker, 0.0) <= 0:
+            bad.append(self._cash_ticker)
+        if r and portfolio.current_prices.get(r, 0.0) <= 0 \
+                and (not risk_on or portfolio.holdings.get(r, 0) > 0):
+            bad.append(r)
+        if bad:
+            reason = f"가격 조회 실패 — 매매 중단: {', '.join(bad)}"
+            self.logger.error(reason)
+            return TradeSignal(0.0, [], reason), [], portfolio, False
 
         if risk_on:
             # risk-off 자산을 보유 중이면 먼저 청산(전환 사이클), 아니면 정상 DipBuy 위임
@@ -269,8 +291,10 @@ class DipBuyGatedEngine(DipBuyEngine):
                   ) -> Tuple[TradeSignal, List[TradeExecution], Portfolio, bool]:
         """risk-off/전환 주문을 실행하고 결과 튜플 생성 (DipBuy 비활성 → 상태 리셋)."""
         new_state = DipBuyState()
+        # 이미 초기화 상태면 디스크 재쓰기를 건너뛴다 (장기 risk-off 구간 불필요 I/O 절감)
+        if self.dip_state.to_dict() != new_state.to_dict():
+            self.repo.save_strategy_state(self.STATE_KEY, new_state.to_dict())
         self.dip_state = new_state
-        self.repo.save_strategy_state(self.STATE_KEY, new_state.to_dict())
 
         signal = TradeSignal(0.0, orders, reason)
         self.logger.info(f">>> Step 5: DipBuyGated ({reason})")

--- a/tests/test_core_engine_dip_buy.py
+++ b/tests/test_core_engine_dip_buy.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.core.engine.dip_buy import DipBuyEngine, DipBuyGatedEngine
+from src.core.engine.dip_buy import DipBuyEngine, DipBuyGatedEngine, DipBuyGatedSpyEngine
 from src.core.logic.dip_buy_indicators import DipBuySignals
 from src.core.models import Order, OrderAction, Portfolio
 from src.infra.broker.mock import MockBroker
@@ -142,6 +142,57 @@ def test_gated_risk_on_delegates_to_dipbuy(tmp_path):
                    current_prices={"QLD": 120.0, "SHV": 100.0})
     signal, _, _, _ = eng.execute_cycle(None, pf, None, 0.5, [], "2024-01-01", "2024-01-01")
     assert "현금화" not in signal.reason       # risk-off 경로 아님
+
+
+def _make_gated_spy(tmp_path, holdings=None):
+    groups = {"A": ["QLD"], "B": ["SPY"], "C": ["SHV"]}
+    repo = JsonRepository(str(tmp_path), asset_groups=groups)
+    broker = MockBroker(initial_cash=10000.0, holdings=holdings or {})
+    logger = TradeLogger(log_dir=str(tmp_path / "gs"))
+    eng = DipBuyGatedSpyEngine(broker=broker, repo=repo, logger=logger,
+                               asset_groups=groups, trading_interval_days=1)
+    return eng, broker, repo
+
+
+def test_gated_spy_engine_registered():
+    from src.core.engine import _ENGINE_REGISTRY
+    assert "DipBuyGatedSpyEngine" in [n for n, _ in _ENGINE_REGISTRY]
+
+
+def test_gated_spy_risk_off_buys_spy(tmp_path):
+    eng, _, _ = _make_gated_spy(tmp_path)
+    # price(80) < ma200(100) → risk-off → QLD·SHV 청산 후 SPY 100%
+    eng.dip_signals = DipBuySignals("2024-01-01", 80.0, 85.0, 90.0, 95.0, 50.0, ma200=100.0)
+    pf = Portfolio(total_cash=0.0, holdings={"QLD": 50, "SHV": 10},
+                   current_prices={"QLD": 80.0, "SHV": 100.0, "SPY": 50.0})
+    signal, _, _, _ = eng.execute_cycle(None, pf, None, 0.0, [], "2024-01-01", "2024-01-01")
+    spy_buys = [o for o in signal.orders if o.ticker == "SPY" and o.action == OrderAction.BUY]
+    # 가용현금 = 0 + 50*80 + 10*100 = 5000 → SPY 5000/50 = 100주
+    assert spy_buys and spy_buys[0].quantity == 100
+    assert {o.ticker for o in signal.orders if o.action == OrderAction.SELL} == {"QLD", "SHV"}
+    assert "SPY" in signal.reason
+
+
+def test_gated_spy_risk_on_liquidates_spy(tmp_path):
+    eng, _, _ = _make_gated_spy(tmp_path)
+    # price(120) >= ma200(90), SPY 보유 중 → 전환 사이클: SPY 청산 후 SHV 스윕
+    eng.dip_signals = DipBuySignals("2024-01-01", 120.0, 110.0, 105.0, 100.0, 50.0, ma200=90.0)
+    pf = Portfolio(total_cash=0.0, holdings={"SPY": 100, "QLD": 0, "SHV": 0},
+                   current_prices={"QLD": 120.0, "SPY": 50.0, "SHV": 100.0})
+    signal, _, _, _ = eng.execute_cycle(None, pf, None, 0.5, [], "2024-01-01", "2024-01-01")
+    spy_sells = [o for o in signal.orders if o.ticker == "SPY" and o.action == OrderAction.SELL]
+    assert spy_sells and spy_sells[0].quantity == 100
+    assert "청산" in signal.reason
+
+
+def test_gated_spy_risk_on_no_spy_runs_dipbuy(tmp_path):
+    eng, _, _ = _make_gated_spy(tmp_path)
+    # risk-on이고 SPY 미보유 → 정상 DipBuy (전환/청산 reason 아님)
+    eng.dip_signals = DipBuySignals("2024-01-01", 120.0, 110.0, 105.0, 100.0, 50.0, ma200=90.0)
+    pf = Portfolio(total_cash=1000.0, holdings={"QLD": 0, "SPY": 0, "SHV": 0},
+                   current_prices={"QLD": 120.0, "SPY": 50.0, "SHV": 100.0})
+    signal, _, _, _ = eng.execute_cycle(None, pf, None, 0.5, [], "2024-01-01", "2024-01-01")
+    assert "청산" not in signal.reason and "100% 보유" not in signal.reason
 
 
 def test_multi_day_cycle_executes_orders(tmp_path):

--- a/tests/test_core_engine_dip_buy.py
+++ b/tests/test_core_engine_dip_buy.py
@@ -185,6 +185,26 @@ def test_gated_spy_risk_on_liquidates_spy(tmp_path):
     assert "청산" in signal.reason
 
 
+def test_gated_spy_halts_on_missing_risk_off_price(tmp_path):
+    """risk-off인데 SPY 가격이 없으면(≤0) QLD를 청산하지 않고 매매 중단 (의도치 않은 현금화 방지)."""
+    eng, _, _ = _make_gated_spy(tmp_path)
+    eng.dip_signals = DipBuySignals("2024-01-01", 80.0, 85.0, 90.0, 95.0, 50.0, ma200=100.0)
+    pf = Portfolio(total_cash=0.0, holdings={"QLD": 50, "SHV": 10},
+                   current_prices={"QLD": 80.0, "SHV": 100.0, "SPY": 0.0})
+    signal, _, _, _ = eng.execute_cycle(None, pf, None, 0.0, [], "2024-01-01", "2024-01-01")
+    assert signal.orders == []
+    assert "가격 조회 실패" in signal.reason
+
+
+def test_gated_halts_when_dip_signals_none(tmp_path):
+    eng, _, _ = _make_gated(tmp_path)
+    eng.dip_signals = None
+    pf = Portfolio(total_cash=1000.0, holdings={}, current_prices={"QLD": 100.0, "SHV": 100.0})
+    signal, _, _, _ = eng.execute_cycle(None, pf, None, 0.0, [], "2024-01-01", "2024-01-01")
+    assert signal.orders == []
+    assert "지표 데이터 없음" in signal.reason
+
+
 def test_gated_spy_risk_on_no_spy_runs_dipbuy(tmp_path):
     eng, _, _ = _make_gated_spy(tmp_path)
     # risk-on이고 SPY 미보유 → 정상 DipBuy (전환/청산 reason 아님)


### PR DESCRIPTION
## 개요

`DipBuyGatedEngine`(200일선 추세 게이트)의 변형. 추세 이탈(QLD가 200일선 아래) 구간에 **현금(SHV) 대신 SPY(1x 광의시장)를 100% 보유**한다. 추세 복귀 시 SPY를 청산하고 눌림목 분할매수(QLD+SHV)를 재개한다.

## 변경 사항

- `DipBuyGatedEngine`에 **`RISK_OFF_TICKER` 옵션 추가** (기본 `None` = 현금/SHV, 하위 호환 유지)
  - `None`: 기존 동작(risk-off → SHV 현금화)
  - 설정 시: risk-off → 해당 자산 100% 보유, risk-on 복귀 시 청산 후 DipBuy 재개
- **`DipBuyGatedSpyEngine`** 신규 등록: `RISK_OFF_TICKER="SPY"`, `ASSET_GROUPS={'A':['QLD'],'B':['SPY'],'C':['SHV']}` (B = risk-off 보유자산)
- risk-off 진입/이탈 헬퍼 분리: `_enter_risk_off_asset` / `_exit_risk_off_asset` / `_finalize`
- 변형 분기 테스트 추가(risk-off SPY 매수 / risk-on SPY 청산 / risk-on DipBuy 위임)

## 동작

| 국면 | DipBuyGatedEngine (현금) | DipBuyGatedSpyEngine (SPY) |
|---|---|---|
| QLD ≥ 200MA | QLD 눌림목 분할매수 + SHV | 동일 |
| QLD < 200MA | 전량 청산 → SHV 대기 | 전량 청산 → **SPY 100%** |

## 검증

- 신규 변형 분기 테스트 4개 포함 **dip-buy 테스트 43개 통과**
- 전체 스위트 **678 passed, 커버리지 94.19%**
- ⚠️ **2008 포함 성과 비교는 미포함**: 로컬 캐시에 SPY 장기 데이터가 없고(현재 캐시는 QLD/SSO) 이 환경은 yfinance가 차단되어 있어, 현금 게이트 vs SPY 게이트의 성과 비교는 `run-compare-backtest` 워크플로우(SPY 다운로드)로 대시보드에서 확인해야 한다. 레지스트리 등록으로 자동 포함됨.

## 맥락

DipBuy 엔진군 평가는 이슈 #344 참조. 이 변형은 "추세 이탈 구간에도 1x 광의시장 수익을 노린다"는 아이디어의 검증용이며, SPY도 하락장엔 함께 빠지므로 효과는 국면 의존적 → 대시보드 비교로 판단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SP1hJQtLPPVBJJwSAFAfxz)_