### PR TITLE
fix(backtest): VIX MultiIndex 컬럼 평탄화 누락 수정

### DIFF
--- a/src/backtest/cache.py
+++ b/src/backtest/cache.py
@@ -176,7 +176,13 @@ class BacktestDataCache:
     ) -> Optional[pd.DataFrame]:
         try:
             df = yf.download("^VIX", start=start, end=end, progress=False)
-            return df if df is not None and not df.empty else None
+            if df is None or df.empty:
+                return None
+            # yfinance는 단일 티커도 MultiIndex 컬럼(('Close', '^VIX'))으로 반환하므로
+            # 단일 레벨('Close')로 평탄화한다 (fetch_vix의 스칼라 계약을 충족).
+            if isinstance(df.columns, pd.MultiIndex):
+                df = df.xs("^VIX", axis=1, level=1)
+            return df
         except Exception as e:
             self._logger.warning(f"VIX 다운로드 실패: {e}")
             return None

--- a/tests/test_backtest_cache.py
+++ b/tests/test_backtest_cache.py
@@ -55,6 +55,16 @@ def _make_vix(start, end):
     return pd.DataFrame({"Close": np.random.rand(len(dates)) * 10 + 15}, index=dates)
 
 
+def _make_vix_multiindex(start, end):
+    """실제 yfinance 1.x가 반환하는 형식: 단일 티커도 MultiIndex 컬럼(('Close', '^VIX'))"""
+    dates = pd.bdate_range(start, end)
+    columns = pd.MultiIndex.from_product(
+        [["Close", "Open", "High", "Low", "Volume"], ["^VIX"]]
+    )
+    data = np.random.rand(len(dates), len(columns)) * 10 + 15
+    return pd.DataFrame(data, index=dates, columns=columns)
+
+
 # ── 항상 전체 재다운로드 ──────────────────────────────────────────────────────
 
 class TestAlwaysRedownloads:
@@ -266,6 +276,42 @@ class TestSingleTickerNormalization:
 
         assert isinstance(df.columns, pd.MultiIndex)
         assert "SPY" in df.columns.get_level_values(1).unique()
+
+
+# ── VIX MultiIndex 평탄화 ─────────────────────────────────────────────────────
+
+class TestVixMultiIndexFlattening:
+    """yfinance가 단일 티커 VIX도 MultiIndex 컬럼으로 반환하는 경우 평탄화 검증"""
+
+    @patch("src.backtest.cache.yf.download")
+    def test_vix_multiindex_columns_flattened_to_single_level(self, mock_download, cache):
+        combined = _make_ohlcv_with_dividends(["SPY"], "2023-01-01", "2023-03-31")
+        vix = _make_vix_multiindex("2023-01-01", "2023-03-31")
+        mock_download.side_effect = [combined, vix]
+
+        _, vix_df, _ = cache.get_data(["SPY"], "2023-01-01", "2023-03-31")
+
+        assert not isinstance(vix_df.columns, pd.MultiIndex)
+        assert "Close" in vix_df.columns
+        assert pd.api.types.is_scalar(vix_df["Close"].iloc[0])
+
+    @patch("src.backtest.cache.yf.download")
+    def test_fetch_vix_returns_scalar_when_source_is_multiindex(self, mock_download, cache):
+        """cache.get_data가 반환한 vix를 BacktestDataLoader.fetch_vix()에 넘겨도
+        스칼라를 반환해야 한다 (회귀: 평탄화 누락 시 TypeError 발생)."""
+        from src.backtest.components import BacktestDataLoader
+
+        combined = _make_ohlcv_with_dividends(["SPY"], "2023-01-01", "2023-03-31")
+        vix = _make_vix_multiindex("2023-01-01", "2023-03-31")
+        mock_download.side_effect = [combined, vix]
+
+        df, vix_df, _ = cache.get_data(["SPY"], "2023-01-01", "2023-03-31")
+
+        loader = BacktestDataLoader(df, vix_df)
+        loader.set_date(vix_df.index[0])
+        result = loader.fetch_vix()
+
+        assert isinstance(result, float)
 
 
 # ── 다운로드 실패 처리 ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `compare-backtest` 워크플로우가 커밋 3be231d 이후 매 사이클 `TypeError: VIX 'Close'가 스칼라가 아닙니다: Series`로 실패하던 문제 수정
- 원인: yfinance 1.x는 단일 티커(`^VIX`)를 요청해도 MultiIndex 컬럼(`('Close', '^VIX')`)을 반환하는데, `src/backtest/cache.py`의 `_download_vix()`는 이를 단일 레벨로 평탄화하지 않았음. `#350`에서 추가된 `fetch_vix()`의 명시적 스칼라 검증에 걸려 매 거래일마다 예외 발생
- `_download_vix()`에서 OHLCV 다운로드와 동일하게 `xs('^VIX', axis=1, level=1)`로 티커 레벨을 제거해 단일 레벨 `'Close'` 컬럼을 보장하도록 수정

## Test plan
- [x] `tests/test_backtest_cache.py`에 실제 yfinance 응답 형식(MultiIndex VIX)을 재현하는 회귀 테스트 2건 추가, 수정 전 코드로 되돌려 동일한 `TypeError`가 재현됨을 확인
- [x] `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/` 전체 실행 — 커버리지 93.72% (요구치 80% 충족), `test_infra_data_live.py`의 11건 실패는 샌드박스 네트워크 제약(Yahoo Finance 실접속 불가)으로 인한 것으로 이번 변경과 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQfRFqe7CQXCwjWymaBoSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQfRFqe7CQXCwjWymaBoSo)_