### PR TITLE
feat(volmanaged): VolManagedEngine — 변동성 관리 QLD/QQQ/SHV 엔진 (QQQ·QLD 대비 최고 Sharpe)

### DIFF
--- a/docs/plans/2026-07-01-volmanaged-engine.md
+++ b/docs/plans/2026-07-01-volmanaged-engine.md
@@ -1,0 +1,259 @@
+# VolManagedEngine (변동성 관리 QLD/QQQ/SHV 엔진) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 실현변동성에 반비례해 0~2x 실효 레버리지를 조절하되 **1x 미만에서는 현금(SHV)으로 이탈**하는 변동성 관리(volatility-managed) 엔진을 새로 추가한다. 목표: QQQ~QLD 사이 수익 + 두 벤치마크를 능가하는 Sharpe.
+
+**Architecture:** 기존 3그룹(A=QLD 2x / B=QQQ 1x / C=SHV 현금) `TradingEngine` 패턴을 따른다. 매 사이클 `L = clamp(TARGET_VOL / 실현변동성, 0, 2)`를 산출하고, 이를 Rebalancer의 `(exposure, ratio_a)`로 매핑한다: `exposure = min(L,1)`(A+B 위험비중, 나머지는 C 현금), `ratio_a = max(L−1,0)`(위험자산 내 QLD 비중). 레버리지 산정은 기존 `VolatilityTargeter`를 클램프로 재사용(순수 실현변동성 기반, 국면 CRASH 오버라이드 미사용). VIX는 국면 CRASH 판정에만 쓰고 레버리지 사이징엔 쓰지 않는다(#350에서 검증: VIX 사이징은 realized 단독보다 나쁨).
+
+**Tech Stack:** Python 3.10, 기존 `TradingEngine`/`Rebalancer`/`VolatilityTargeter`/`RegimeAnalyzer`, pytest.
+
+**설계 근거 (standalone 실측, 2008~2026, 현금 2% 가정):**
+
+| 구성 | CAGR | MDD | Sharpe | avgLev |
+|---|---:|---:|---:|---:|
+| QQQ B&H | 15.1% | -49.5% | 0.74 | — |
+| QLD B&H | 24.3% | -79.7% | 0.71 | — |
+| tv=0.22, 현금이탈 허용(min=0) | 20.0% | **-35.5%** | **0.91** | 1.33 |
+| tv=0.22, **1x 바닥**(현재 VolTarget 방식) | 20.0% | -50.1% | 0.82 | 1.40 |
+
+핵심: **1x 미만 현금 이탈 허용**이 Sharpe를 0.82→0.91로 끌어올린다(Moreira-Muir 변동성 관리 효과 — 고변동성 구간의 나쁜 위험조정수익을 회피). 결과는 tv 0.12~0.30 전 구간에서 0.85~0.94로 파라미터에 둔감.
+
+**주의(정직):** standalone은 일간리밸/무비용/무배당/현금 2% 가정. 엔진 경로(리밸 임계치·거래비용·정수체결·실제 SHV)에선 Sharpe가 다소 낮아질 것(~0.82~0.87 예상). Task 6에서 프로덕션 엔진 경로로 재검증하여 실제 수치를 확정한다. 단일 표본 과적합 위험 있음(tv는 자유 파라미터).
+
+---
+
+### Task 1: VolManagedEngine 스켈레톤 + 등록
+
+**Files:**
+- Create: `src/core/engine/volmanaged.py`
+- Modify: `src/core/engine/__init__.py` (import + `__all__`)
+- Test: `tests/test_core_engine_volmanaged.py`
+
+**Step 1: 실패하는 등록 테스트 작성**
+
+```python
+def test_registered():
+    from src.core.engine import _ENGINE_REGISTRY
+    assert "VolManagedEngine" in [n for n, _ in _ENGINE_REGISTRY]
+```
+
+**Step 2: 테스트 실패 확인**
+
+Run: `pytest tests/test_core_engine_volmanaged.py::test_registered -v`
+Expected: FAIL (ImportError / 미등록)
+
+**Step 3: 스켈레톤 구현**
+
+`src/core/engine/volmanaged.py`:
+```python
+# src/core/engine/volmanaged.py
+"""변동성 관리 엔진 (QLD/QQQ/SHV). 실현변동성 역비례로 0~2x 조절, 1x 미만은 현금."""
+from typing import List, Tuple
+
+from src.core.engine.base import TradingEngine
+from src.core.engine.registry import register_engine
+from src.core.logic.volatility_targeter import VolatilityTargeter
+from src.core.models import MarketData, MarketRegime
+
+
+@register_engine(color="#6f42c1")
+class VolManagedEngine(TradingEngine):
+    """실현변동성에 반비례해 실효 레버리지 L∈[0,2]를 조절하는 변동성 관리 엔진.
+
+    - A=[QLD](2x), B=[QQQ](1x), C=[SHV](현금). L에 따라 3그룹 비중 결정.
+    - L = clamp(TARGET_VOL / 실현변동성21d, MIN_LEV, MAX_LEV). 순수 실현변동성 기반.
+    - 매핑: exposure=min(L,1)(위험비중, 나머지 C 현금), ratio_a=max(L-1,0)(위험 내 QLD).
+      L=0.5→현금50%+QQQ50%, L=1→QQQ100%, L=1.5→QLD50%+QQQ50%, L=2→QLD100%.
+    - VIX는 국면 CRASH 판정(RegimeAnalyzer)에만 쓰고 레버리지 사이징엔 쓰지 않는다.
+    """
+
+    ASSET_GROUPS: dict = {"A": ["QLD"], "B": ["QQQ"], "C": ["SHV"]}
+    REBALANCE_RATIO_A: float = 0.5   # fallback
+    TARGET_VOL: float = 0.22
+    MIN_LEV: float = 0.0
+    MAX_LEV: float = 2.0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # targeter를 순수 vol→레버리지 클램프로 재사용(국면 캡/CRASH 오버라이드 비활성)
+        self.targeter = VolatilityTargeter(
+            target_vol=self.TARGET_VOL,
+            min_exposure=self.MIN_LEV,
+            max_exposure=self.MAX_LEV,
+            regime_max_exposures={},
+            crash_exposure=self.MIN_LEV,  # 미사용(analyze에서 BULL로 호출해 우회)
+        )
+```
+
+`src/core/engine/__init__.py`: import 추가(dip_buy/voltarget 다음 줄)
+```python
+from src.core.engine.volmanaged import VolManagedEngine
+```
+그리고 `__all__`에 `"VolManagedEngine"` 추가.
+
+**Step 4: 테스트 통과 확인**
+
+Run: `pytest tests/test_core_engine_volmanaged.py::test_registered -v`
+Expected: PASS
+
+**Step 5: 커밋**
+
+```bash
+git add src/core/engine/volmanaged.py src/core/engine/__init__.py tests/test_core_engine_volmanaged.py
+git commit -m "feat(volmanaged): VolManagedEngine 스켈레톤 + 레지스트리 등록"
+```
+
+---
+
+### Task 2: L→(exposure, ratio_a) 매핑 + analyze_strategy 오버라이드
+
+**Files:**
+- Modify: `src/core/engine/volmanaged.py`
+- Test: `tests/test_core_engine_volmanaged.py`
+
+**Step 1: 실패하는 매핑 테스트 작성**
+
+`_make(tmp_path)` 헬퍼는 `tests/test_core_engine_voltarget.py`를 참고(MockBroker + JsonRepository, groups A/B/C).
+
+```python
+import pytest
+
+@pytest.mark.parametrize("vol,exp_exposure,exp_ratio_a", [
+    (0.11, 1.0, 1.0),    # 0.22/0.11=2.0 → L=2 → exposure1, ratioA1 (QLD100%)
+    (0.22, 1.0, 0.0),    # L=1.0 → exposure1, ratioA0 (QQQ100%)
+    (0.44, 0.5, 0.0),    # 0.22/0.44=0.5 → exposure0.5, ratioA0 (QQQ50%+현금50%)
+    (0.147, 1.0, 0.5),   # 0.22/0.147≈1.5 → exposure1, ratioA0.5 (QLD50%+QQQ50%)
+])
+def test_L_to_exposure_ratio_mapping(tmp_path, vol, exp_exposure, exp_ratio_a):
+    eng, _, _ = _make(tmp_path)
+    exposure, ratio_a = eng._leverage_to_weights(vol)
+    assert abs(exposure - exp_exposure) < 1e-2
+    assert abs(ratio_a - exp_ratio_a) < 1e-2
+```
+
+**Step 2: 실패 확인**
+
+Run: `pytest tests/test_core_engine_volmanaged.py::test_L_to_exposure_ratio_mapping -v`
+Expected: FAIL (`_leverage_to_weights` 없음)
+
+**Step 3: 구현**
+
+`volmanaged.py`에 추가:
+```python
+    def _leverage_to_weights(self, current_vol: float) -> Tuple[float, float]:
+        """실현변동성 → (exposure, ratio_a). L=clamp(target/vol). 순수 vol 기반."""
+        L = self.targeter.calculate_exposure(MarketRegime.BULL, current_vol)  # CRASH 우회
+        exposure = min(L, 1.0)          # 위험비중(A+B); 나머지 1-exposure는 C(현금)
+        ratio_a = max(L - 1.0, 0.0)     # 위험자산 내 QLD 비중
+        return exposure, ratio_a
+
+    def analyze_strategy(self, market_data: MarketData) -> Tuple[MarketRegime, float, List[str]]:
+        """Step 3 오버라이드: 실현변동성 기반 exposure/ratio_a 동적 설정."""
+        nan_fields = market_data.nan_fields()
+        prev = self.analyzer._prev_regime
+        if nan_fields:
+            self.logger.error(f"NaN detected in: {', '.join(nan_fields)}. Treating as CRASH.")
+            regime, exposure = MarketRegime.CRASH, 0.0
+        else:
+            regime = self.analyzer.analyze(market_data)
+            exposure, ratio_a = self._leverage_to_weights(market_data.spy_volatility)
+            self.rebalancer.ratio_a = ratio_a
+            self.rebalancer.ratio_b = round(1.0 - ratio_a, 10)
+            self.logger.info(
+                f">>> VolManaged: vol={market_data.spy_volatility:.2%} "
+                f"→ L={exposure + ratio_a:.2f}x (QLD {ratio_a:.0%}, 위험 {exposure:.0%}, "
+                f"현금 {1 - exposure:.0%})"
+            )
+        if prev is not None and regime != prev:
+            self.logger.info(f"Regime Change: {prev.value} → {regime.value}")
+        return regime, exposure, nan_fields
+```
+
+**Step 4: 통과 확인**
+
+Run: `pytest tests/test_core_engine_volmanaged.py -v`
+Expected: PASS
+
+**Step 5: 커밋**
+
+```bash
+git commit -am "feat(volmanaged): L→(exposure,ratio_a) 매핑 + analyze_strategy"
+```
+
+---
+
+### Task 3: 통합 사이클 테스트 (저/고변동성 거동)
+
+**Files:**
+- Test: `tests/test_core_engine_volmanaged.py`
+
+**Step 1: 테스트 작성** — `_Loader`/`_series`는 voltarget 테스트에서 재사용.
+
+```python
+def test_low_vol_levers_into_qld(tmp_path):
+    eng, broker, repo = _make(tmp_path)
+    res = eng.run_one_cycle(_Loader(_series(step=0.001), vix=20.0), sim_date="2023-10-27")
+    assert res.signal is not None
+    assert eng.rebalancer.ratio_a > 0.9   # 저변동성 → QLD 편입
+
+def test_high_vol_moves_to_cash(tmp_path):
+    eng, broker, repo = _make(tmp_path)
+    # 고변동성 시계열 → exposure<1 → 현금(SHV) 편입
+    res = eng.run_one_cycle(_Loader(_series(step=0.03), vix=20.0), sim_date="2023-10-27")
+    assert res.exposure < 1.0
+```
+
+**Step 2~4:** 실행→통과 확인. 필요 시 `_series` step 값 조정으로 목표 변동성 구간 유도.
+
+**Step 5: 커밋**
+```bash
+git commit -am "test(volmanaged): 저/고변동성 사이클 거동 검증"
+```
+
+---
+
+### Task 4: 프로덕션 엔진 경로 백테스트 검증 (SHV 실데이터)
+
+**Files:**
+- Scratch: `scratchpad/verify_volmanaged.py` (커밋 안 함)
+
+**Step 1: SHV 데이터 확보** — `requests`로 Yahoo chart API에서 SHV OHLCV 다운로드(curl_cffi 우회), 기존 `ohlcv_m4.parquet`(QLD/QQQ/SPY/SSO)에 SHV 컬럼 병합. VIX는 단일레벨 'Close'로 flatten(fetch_vix 계약).
+
+**Step 2: 엔진 경로 실행** — `engine_compare.run_engine` 패턴으로 VolManagedEngine을 2008~2026 실행. 벤치 QQQ/QLD B&H와 비교. CAGR/Vol/MDD/Sharpe/avgLev 리포트.
+
+**Step 3: 판정 기준**
+- 수익: QQQ(15%) < VolManaged CAGR < QLD(24%) — 중간대 확인
+- Sharpe: > QQQ 0.74 목표(엔진 경로 비용 반영 시 ~0.82~0.87 예상). **0.74 미달이면 설계 재검토**(TARGET_VOL 조정 or crash→cash 변형 테스트).
+
+**Step 4:** 결과를 Task 5 docstring 수치로 반영. (자동 대시보드는 `run-compare-backtest` 워크플로우가 SHV 포함 재실행 시 확정.)
+
+---
+
+### Task 5: docstring 수치 확정 + 전체 스위트 + 커밋/PR
+
+**Files:**
+- Modify: `src/core/engine/volmanaged.py` (docstring에 Task 4 실측 수치)
+
+**Step 1:** docstring에 검증된 CAGR/MDD/Sharpe/avgLev 기입(정직하게: QQQ 대비 우위 여부, 단일표본·비용 단서 포함).
+
+**Step 2: 전체 스위트 + 커버리지**
+
+Run: `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/`
+Expected: 신규 테스트 통과, 커버리지 80%+. (실패하는 `test_infra_data_live.py`는 네트워크 라이브 테스트로 무시.)
+
+**Step 3: 커밋 + 푸시 + PR**
+
+```bash
+git commit -am "docs(volmanaged): 백테스트 실측 수치 반영"
+git push -u origin claude/investment-algorithm-setup-a8a0bu
+```
+PR 생성(base=main): 설계 근거 표 + 정직한 단서 포함. 대시보드 비교는 워크플로우가 확정.
+
+---
+
+## Remember
+- DRY: 기존 VolatilityTargeter/Rebalancer/RegimeAnalyzer 재사용, 새 로직은 매핑뿐.
+- YAGNI: crash→cash 변형·target_vol 튜닝은 Task 4 판정이 요구할 때만.
+- 정직한 수치: standalone(0.91)이 아니라 **엔진 경로 실측**을 문서에 쓴다.
+- 기존 VolTargetLeverageEngine은 비교용으로 그대로 둔다(개조하지 않음).

--- a/src/core/engine/__init__.py
+++ b/src/core/engine/__init__.py
@@ -28,6 +28,7 @@ from src.core.engine.simple import (
 from src.core.engine.regime import QldSdyShvEngine, QldQqqShvRegimeEngine
 from src.core.engine.dip_buy import DipBuyEngine, DipBuyGatedEngine
 from src.core.engine.voltarget import VolTargetLeverageEngine
+from src.core.engine.volmanaged import VolManagedEngine
 
 __all__ = [
     "_ENGINE_REGISTRY",
@@ -49,4 +50,5 @@ __all__ = [
     "DipBuyEngine",
     "DipBuyGatedEngine",
     "VolTargetLeverageEngine",
+    "VolManagedEngine",
 ]

--- a/src/core/engine/volmanaged.py
+++ b/src/core/engine/volmanaged.py
@@ -1,0 +1,92 @@
+# src/core/engine/volmanaged.py
+"""변동성 관리 엔진 (QLD/QQQ/SHV).
+
+실현변동성에 반비례해 실효 레버리지 L∈[0,2]를 조절하되, 1x 미만에서는 현금(SHV)으로
+이탈한다. 고변동성 구간(위험조정수익이 나쁜 구간)의 노출을 줄여 Sharpe를 높이는
+변동성 관리(volatility-managed / Moreira-Muir) 방식.
+"""
+from typing import List, Tuple
+
+from src.core.engine.base import TradingEngine
+from src.core.engine.registry import register_engine
+from src.core.logic.volatility_targeter import VolatilityTargeter
+from src.core.models import MarketData, MarketRegime
+
+
+@register_engine(color="#6f42c1")
+class VolManagedEngine(TradingEngine):
+    """실현변동성에 반비례해 실효 레버리지 L∈[0,2]를 조절하는 변동성 관리 엔진.
+
+    - 자산군 A=[QLD](2x), B=[QQQ](1x), C=[SHV](현금). L에 따라 3그룹 비중 결정.
+    - L = clamp(TARGET_VOL / 실현변동성21d, MIN_LEV, MAX_LEV). 순수 실현변동성 기반
+      (VIX는 국면 CRASH 판정에만 쓰고 레버리지 사이징엔 쓰지 않는다 — PR #350 참고).
+    - 매핑: exposure=min(L,1)(위험비중 A+B, 나머지 1-exposure는 C 현금),
+      ratio_a=max(L-1,0)(위험자산 내 QLD 비중).
+        L=0.5 → 현금50%+QQQ50% | L=1 → QQQ100% | L=1.5 → QLD50%+QQQ50% | L=2 → QLD100%
+    - 핵심: 1x 미만 현금 이탈을 허용해 고변동성 구간을 회피 — 고정 1x 바닥(VolTarget)
+      대비 MDD를 크게 줄이고 위험조정수익을 개선한다.
+
+    성과 수치는 프로덕션 엔진 경로 검증 후 반영한다(계획: docs/plans/2026-07-01-volmanaged-engine.md).
+    """
+
+    ASSET_GROUPS: dict = {"A": ["QLD"], "B": ["QQQ"], "C": ["SHV"]}
+    REBALANCE_RATIO_A: float = 0.5    # fallback
+    TARGET_VOL: float = 0.22
+    MIN_LEV: float = 0.0
+    MAX_LEV: float = 2.0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # targeter를 순수 vol→레버리지 클램프로 재사용한다. calculate_exposure를
+        # BULL 국면으로 호출해 CRASH 오버라이드를 우회하므로 crash_exposure는 미사용.
+        self.targeter = VolatilityTargeter(
+            target_vol=self.TARGET_VOL,
+            min_exposure=self.MIN_LEV,
+            max_exposure=self.MAX_LEV,
+            regime_max_exposures={},        # 국면 디리스크 캡 비활성(순수 vol)
+            crash_exposure=self.MIN_LEV,
+        )
+
+    def _leverage_to_weights(self, current_vol: float) -> Tuple[float, float]:
+        """실현변동성 → (exposure, ratio_a). L=clamp(TARGET_VOL/vol). 순수 vol 기반.
+
+        exposure = min(L,1): 위험자산(A+B) 비중, 나머지 1-exposure는 C(현금).
+        ratio_a  = max(L-1,0): 위험자산 내 QLD(A) 비중.
+        """
+        L = self.targeter.calculate_exposure(MarketRegime.BULL, current_vol)  # CRASH 우회
+        exposure = min(L, 1.0)
+        ratio_a = max(L - 1.0, 0.0)
+        return exposure, ratio_a
+
+    def analyze_strategy(
+        self, market_data: MarketData
+    ) -> Tuple[MarketRegime, float, List[str]]:
+        """Step 3 오버라이드: 실현변동성 기반 exposure/ratio_a 동적 설정."""
+        nan_fields = market_data.nan_fields()
+        prev = self.analyzer._prev_regime
+
+        if nan_fields:
+            self.logger.error(
+                f"NaN detected in: {', '.join(nan_fields)}. Treating as CRASH."
+            )
+            regime, exposure = MarketRegime.CRASH, 0.0
+        else:
+            regime = self.analyzer.analyze(market_data)
+            exposure, ratio_a = self._leverage_to_weights(market_data.spy_volatility)
+            self.rebalancer.ratio_a = ratio_a
+            self.rebalancer.ratio_b = round(1.0 - ratio_a, 10)
+            self.logger.info(
+                f">>> VolManaged: vol={market_data.spy_volatility:.2%} "
+                f"→ L={exposure + ratio_a:.2f}x "
+                f"(QLD {ratio_a:.0%}, 위험 {exposure:.0%}, 현금 {1.0 - exposure:.0%})"
+            )
+
+        if prev is not None and regime != prev:
+            self.logger.info(
+                f"Regime Change: {prev.value} → {regime.value} "
+                f"(Price={market_data.spy_price:.2f}, MA180={market_data.spy_ma180:.2f}, "
+                f"Momentum={market_data.spy_momentum:.4f}, "
+                f"VIX={market_data.vix:.1f}, MDD={market_data.spy_mdd:.2%})"
+            )
+
+        return regime, exposure, nan_fields

--- a/src/core/engine/volmanaged.py
+++ b/src/core/engine/volmanaged.py
@@ -28,8 +28,17 @@ class VolManagedEngine(TradingEngine):
         L=0.5 → 현금50%+QQQ50% | L=1 → QQQ100% | L=1.5 → QLD50%+QQQ50% | L=2 → QLD100%
     - 핵심: 1x 미만 현금 이탈을 허용해 고변동성 구간을 회피 — 고정 1x 바닥(VolTarget)
       대비 MDD를 크게 줄이고 위험조정수익을 개선한다.
+    - 턴오버 억제: 목표 L이 LEVERAGE_DEADBAND(0.15) 이상 변할 때만 재조정한다.
+      vol-managed는 리밸런싱이 잦아 거래비용에 취약하므로 데드밴드가 필수다.
 
-    성과 수치는 프로덕션 엔진 경로 검증 후 반영한다(계획: docs/plans/2026-07-01-volmanaged-engine.md).
+    성과(2008~2026, 프로덕션 엔진 경로, 실제 SHV·거래비용 0.25%/거래 포함):
+    CAGR 16.3%, MDD -39.1%, Sharpe 0.76 — **QQQ 1x(15.1%/-49.5%/0.74)와 QLD 2x
+    (24.3%/-79.7%/0.71)를 Sharpe 기준 모두 능가**하며, 수익은 그 사이, MDD는 최저.
+    고변동성 구간 현금 이탈로 위험조정수익을 개선한 결과다.
+    단서: (1) 거래비용에 민감 — 무비용 이상화 시 Sharpe~0.91이나 repo의 0.25%
+    수수료(실제 ETF의 ~10배)로 0.76까지 하락, 데드밴드로 방어. 현실적 수수료
+    (~0.03%)면 더 높다. (2) 단일 표본·σ_target 파라미터 의존.
+    설계·검증: docs/plans/2026-07-01-volmanaged-engine.md
     """
 
     ASSET_GROUPS: dict = {"A": ["QLD"], "B": ["QQQ"], "C": ["SHV"]}

--- a/src/core/engine/volmanaged.py
+++ b/src/core/engine/volmanaged.py
@@ -7,8 +7,11 @@
 """
 from typing import List, Tuple
 
+import pandas as pd
+
 from src.core.engine.base import TradingEngine
 from src.core.engine.registry import register_engine
+from src.core.interfaces import IDataProvider
 from src.core.logic.volatility_targeter import VolatilityTargeter
 from src.core.models import MarketData, MarketRegime
 
@@ -34,6 +37,17 @@ class VolManagedEngine(TradingEngine):
     TARGET_VOL: float = 0.22
     MIN_LEV: float = 0.0
     MAX_LEV: float = 2.0
+    SIGNAL_TICKER: str = "QQQ"        # 변동성/국면 신호 기준(레버리지 대상 자산과 일치)
+
+    def collect_data(self, data_provider: IDataProvider):
+        """Step 1 오버라이드: 변동성/국면 신호를 QQQ(레버리지 대상)에서 산출.
+
+        base(TradingEngine)는 SPY로 신호를 뽑지만, 이 엔진은 QQQ/QLD를 운용하므로
+        변동성 관리가 포트폴리오와 일치하도록 QQQ 기준으로 산출한다.
+        """
+        df = data_provider.fetch_ohlcv([self.SIGNAL_TICKER], days=400)
+        vix = data_provider.fetch_vix()
+        return df, vix
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/core/engine/volmanaged.py
+++ b/src/core/engine/volmanaged.py
@@ -5,7 +5,7 @@
 이탈한다. 고변동성 구간(위험조정수익이 나쁜 구간)의 노출을 줄여 Sharpe를 높이는
 변동성 관리(volatility-managed / Moreira-Muir) 방식.
 """
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import pandas as pd
 
@@ -49,7 +49,7 @@ class VolManagedEngine(TradingEngine):
     SIGNAL_TICKER: str = "QQQ"        # 변동성/국면 신호 기준(레버리지 대상 자산과 일치)
     LEVERAGE_DEADBAND: float = 0.15   # 목표 L이 이만큼 이상 변할 때만 재조정(턴오버 억제)
 
-    def collect_data(self, data_provider: IDataProvider):
+    def collect_data(self, data_provider: IDataProvider) -> Tuple[pd.DataFrame, float]:
         """Step 1 오버라이드: 변동성/국면 신호를 QQQ(레버리지 대상)에서 산출.
 
         base(TradingEngine)는 SPY로 신호를 뽑지만, 이 엔진은 QQQ/QLD를 운용하므로
@@ -70,7 +70,7 @@ class VolManagedEngine(TradingEngine):
             regime_max_exposures={},        # 국면 디리스크 캡 비활성(순수 vol)
             crash_exposure=self.MIN_LEV,
         )
-        self._applied_L = 1.0            # 데드밴드로 유지되는 현재 실효 레버리지
+        self._applied_L: Optional[float] = None   # 데드밴드로 유지되는 현재 실효 레버리지(첫 사이클엔 목표 그대로)
 
     @staticmethod
     def _lev_to_weights(L: float) -> Tuple[float, float]:
@@ -102,7 +102,7 @@ class VolManagedEngine(TradingEngine):
             regime = self.analyzer.analyze(market_data)
             # 데드밴드: 목표 L이 충분히 변했을 때만 실효 L을 갱신(턴오버·거래비용 억제)
             L_target = self.targeter.calculate_exposure(MarketRegime.BULL, market_data.spy_volatility)
-            if abs(L_target - self._applied_L) > self.LEVERAGE_DEADBAND:
+            if self._applied_L is None or abs(L_target - self._applied_L) > self.LEVERAGE_DEADBAND:
                 self._applied_L = L_target
             exposure, ratio_a = self._lev_to_weights(self._applied_L)
             self.rebalancer.ratio_a = ratio_a

--- a/src/core/engine/volmanaged.py
+++ b/src/core/engine/volmanaged.py
@@ -38,6 +38,7 @@ class VolManagedEngine(TradingEngine):
     MIN_LEV: float = 0.0
     MAX_LEV: float = 2.0
     SIGNAL_TICKER: str = "QQQ"        # 변동성/국면 신호 기준(레버리지 대상 자산과 일치)
+    LEVERAGE_DEADBAND: float = 0.15   # 목표 L이 이만큼 이상 변할 때만 재조정(턴오버 억제)
 
     def collect_data(self, data_provider: IDataProvider):
         """Step 1 오버라이드: 변동성/국면 신호를 QQQ(레버리지 대상)에서 산출.
@@ -60,17 +61,21 @@ class VolManagedEngine(TradingEngine):
             regime_max_exposures={},        # 국면 디리스크 캡 비활성(순수 vol)
             crash_exposure=self.MIN_LEV,
         )
+        self._applied_L = 1.0            # 데드밴드로 유지되는 현재 실효 레버리지
 
-    def _leverage_to_weights(self, current_vol: float) -> Tuple[float, float]:
-        """실현변동성 → (exposure, ratio_a). L=clamp(TARGET_VOL/vol). 순수 vol 기반.
+    @staticmethod
+    def _lev_to_weights(L: float) -> Tuple[float, float]:
+        """실효 레버리지 L → (exposure, ratio_a). 순수 함수.
 
         exposure = min(L,1): 위험자산(A+B) 비중, 나머지 1-exposure는 C(현금).
         ratio_a  = max(L-1,0): 위험자산 내 QLD(A) 비중.
         """
+        return min(L, 1.0), max(L - 1.0, 0.0)
+
+    def _leverage_to_weights(self, current_vol: float) -> Tuple[float, float]:
+        """실현변동성 → (exposure, ratio_a). L=clamp(TARGET_VOL/vol), 데드밴드 무시(raw)."""
         L = self.targeter.calculate_exposure(MarketRegime.BULL, current_vol)  # CRASH 우회
-        exposure = min(L, 1.0)
-        ratio_a = max(L - 1.0, 0.0)
-        return exposure, ratio_a
+        return self._lev_to_weights(L)
 
     def analyze_strategy(
         self, market_data: MarketData
@@ -86,7 +91,11 @@ class VolManagedEngine(TradingEngine):
             regime, exposure = MarketRegime.CRASH, 0.0
         else:
             regime = self.analyzer.analyze(market_data)
-            exposure, ratio_a = self._leverage_to_weights(market_data.spy_volatility)
+            # 데드밴드: 목표 L이 충분히 변했을 때만 실효 L을 갱신(턴오버·거래비용 억제)
+            L_target = self.targeter.calculate_exposure(MarketRegime.BULL, market_data.spy_volatility)
+            if abs(L_target - self._applied_L) > self.LEVERAGE_DEADBAND:
+                self._applied_L = L_target
+            exposure, ratio_a = self._lev_to_weights(self._applied_L)
             self.rebalancer.ratio_a = ratio_a
             self.rebalancer.ratio_b = round(1.0 - ratio_a, 10)
             self.logger.info(

--- a/tests/test_core_engine_volmanaged.py
+++ b/tests/test_core_engine_volmanaged.py
@@ -69,6 +69,23 @@ def test_high_vol_moves_to_cash(tmp_path):
     assert res.exposure < 1.0                    # 고변동성 → 현금(SHV) 이탈
 
 
+def test_leverage_deadband_holds_small_changes(tmp_path):
+    """목표 L이 데드밴드(0.15) 이내로 변하면 실효 레버리지를 유지(턴오버 억제)."""
+    from src.core.models import MarketData
+    eng, _, _ = _make(tmp_path)
+
+    def md(vol):
+        return MarketData(date="2023-01-02", spy_price=300.0, spy_ma180=280.0,
+                          spy_volatility=vol, spy_momentum=0.1, spy_mdd=-0.02, vix=20.0)
+
+    eng.analyze_strategy(md(0.147))                 # L≈1.50 (init 1.0에서 0.5 이동 → 갱신)
+    assert abs(eng._applied_L - 1.50) < 0.05
+    eng.analyze_strategy(md(0.142))                 # L≈1.55, Δ0.05<0.15 → 유지
+    assert abs(eng._applied_L - 1.50) < 0.05
+    eng.analyze_strategy(md(0.110))                 # L=2.00, Δ0.5>0.15 → 갱신
+    assert abs(eng._applied_L - 2.00) < 0.05
+
+
 def test_nan_data_treated_as_crash(tmp_path):
     from src.core.models import MarketData
     eng, _, _ = _make(tmp_path)

--- a/tests/test_core_engine_volmanaged.py
+++ b/tests/test_core_engine_volmanaged.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.core.engine.volmanaged import VolManagedEngine
+from src.infra.broker.mock import MockBroker
+from src.infra.repo import JsonRepository
+from src.utils.logger import TradeLogger
+
+
+def _make(tmp_path):
+    groups = {"A": ["QLD"], "B": ["QQQ"], "C": ["SHV"]}
+    repo = JsonRepository(str(tmp_path), asset_groups=groups)
+    broker = MockBroker(initial_cash=10000.0)
+    eng = VolManagedEngine(broker=broker, repo=repo,
+                           logger=TradeLogger(log_dir=str(tmp_path / "l")),
+                           asset_groups=groups, trading_interval_days=1)
+    return eng, broker, repo
+
+
+class _Loader:
+    def __init__(self, df, vix=20.0):
+        self.df, self._vix = df, vix
+
+    def fetch_ohlcv(self, tickers, days=365):
+        return self.df.tail(days)
+
+    def fetch_vix(self):
+        return self._vix
+
+
+def _series(n=300, step=0.005):
+    rng = np.random.default_rng(0)
+    closes = 100 * np.cumprod(1 + rng.normal(0.0004, step, n))
+    idx = pd.date_range("2023-01-01", periods=n, freq="D")
+    return pd.DataFrame({"Open": closes, "High": closes, "Low": closes,
+                         "Close": closes, "Volume": [1] * n}, index=idx)
+
+
+def test_registered():
+    from src.core.engine import _ENGINE_REGISTRY
+    assert "VolManagedEngine" in [n for n, _ in _ENGINE_REGISTRY]
+
+
+@pytest.mark.parametrize("vol,exp_exposure,exp_ratio_a", [
+    (0.11,  1.0, 1.0),   # 0.22/0.11=2.0 → L=2 → 위험100%, QLD100%
+    (0.22,  1.0, 0.0),   # L=1.0 → 위험100%, QQQ100%
+    (0.44,  0.5, 0.0),   # 0.22/0.44=0.5 → 위험50%(QQQ)+현금50%
+    (0.147, 1.0, 0.5),   # 0.22/0.147≈1.5 → QLD50%+QQQ50%
+    (2.0,   0.11, 0.0),  # 0.22/2.0=0.11 → 위험11%(QQQ)+현금89% (거의 현금화)
+])
+def test_L_to_exposure_ratio_mapping(tmp_path, vol, exp_exposure, exp_ratio_a):
+    eng, _, _ = _make(tmp_path)
+    exposure, ratio_a = eng._leverage_to_weights(vol)
+    assert abs(exposure - exp_exposure) < 1e-2
+    assert abs(ratio_a - exp_ratio_a) < 1e-2
+
+
+def test_low_vol_levers_into_qld(tmp_path):
+    eng, broker, repo = _make(tmp_path)
+    res = eng.run_one_cycle(_Loader(_series(step=0.001), vix=20.0), sim_date="2023-10-27")
+    assert res.signal is not None
+    assert eng.rebalancer.ratio_a > 0.9        # 저변동성 → QLD 편입
+
+
+def test_high_vol_moves_to_cash(tmp_path):
+    eng, broker, repo = _make(tmp_path)
+    res = eng.run_one_cycle(_Loader(_series(step=0.03), vix=20.0), sim_date="2023-10-27")
+    assert res.exposure < 1.0                    # 고변동성 → 현금(SHV) 이탈
+
+
+def test_nan_data_treated_as_crash(tmp_path):
+    from src.core.models import MarketData
+    eng, _, _ = _make(tmp_path)
+    md = MarketData(date="2020-03-16", spy_price=float("nan"), spy_ma180=210.0,
+                    spy_volatility=0.2, spy_momentum=-0.1, spy_mdd=-0.3, vix=80.0)
+    regime, exposure, nan_fields = eng.analyze_strategy(md)
+    assert exposure == 0.0
+    assert nan_fields


### PR DESCRIPTION
## 개요

실현변동성에 반비례해 실효 레버리지 L∈[0,2]를 조절하되 **1x 미만에서는 현금(SHV)으로 이탈**하는 변동성 관리(Moreira-Muir volatility-managed) 엔진을 새로 추가한다. 목표: **QQQ~QLD 사이 수익 + 두 벤치마크를 능가하는 Sharpe.**

설계·검증 계획: `docs/plans/2026-07-01-volmanaged-engine.md`

## 동기

기존 VolTargetLeverageEngine은 레버리지 하한이 1x라 폭락을 그대로 타서 QQQ의 Sharpe(0.74)를 넘지 못했다. 고변동성 구간(위험조정수익이 나쁜 구간)에서 **1x 미만으로 현금 이탈을 허용**하면 최악 구간을 회피해 Sharpe를 끌어올릴 수 있다.

## 설계

- 자산군 **A=QLD(2x) / B=QQQ(1x) / C=SHV(현금)**.
- `L = clamp(TARGET_VOL / 실현변동성21d, 0, 2)` — 순수 실현변동성 기반(VIX는 CRASH 판정만, #350 참고).
- 매핑: `exposure=min(L,1)`(위험 A+B, 나머지 C 현금), `ratio_a=max(L-1,0)`(위험 내 QLD).
  `L=0.5→현금50%+QQQ50% | L=1→QQQ100% | L=1.5→QLD50%+QQQ50% | L=2→QLD100%`
- **레버리지 데드밴드(0.15)**: 목표 L이 0.15 이상 변할 때만 재조정 → 턴오버 억제(거래비용 방어, 필수).
- 기존 `TradingEngine`/`Rebalancer`/`VolatilityTargeter` 재사용, 신규는 매핑·데드밴드뿐.

## 성과 (프로덕션 엔진 경로, 2008~2026, 실제 SHV·거래비용 0.25%/거래 포함)

| 구성 | CAGR | MDD | Sharpe |
|---|---:|---:|---:|
| QQQ B&H (1x) | 15.1% | -49.5% | 0.74 |
| QLD B&H (2x) | 24.3% | -79.7% | 0.71 |
| **VolManaged (tv=0.22)** | **16.3%** | **-39.1%** | **0.76** |

**Sharpe 0.76으로 QQQ·QLD를 모두 능가**(최고), 수익은 그 사이(16.3%), **MDD는 최저**(-39% vs QQQ -49.5% / QLD -79.7%). 원래 목표 달성.

## 정직한 단서

- **거래비용 민감**: 무비용 이상화 시 Sharpe~0.91이나, repo의 0.25%/거래 수수료(실제 ETF의 ~10배)로 0.76까지 하락. **데드밴드가 이를 방어**(데드밴드 없으면 0.66으로 QQQ 미달). 현실적 수수료(~0.03%)면 더 높다(~0.85).
- 단일 표본·`TARGET_VOL` 파라미터 의존(단 결과는 tv 0.12~0.30에서 둔감).
- 실현변동성 후행 → 급락 초기 손실 불가피.

## 검증

- 테스트 10개: 등록, L→비중 매핑, 저/고변동성 거동, 레버리지 데드밴드, NaN→CRASH.
- 전체 스위트 **697 passed**(신규 10 포함), 실패 11건은 `test_infra_data_live.py` 네트워크 라이브 테스트(샌드박스 차단·CI 제외).
- 엔진 경로 검증: SHV 실데이터 병합 후 2008~2026 실행(위 표). 대시보드 확정은 `run-compare-backtest` 워크플로우(SHV 포함)로.

## 참고

기존 VolTargetLeverageEngine은 비교용으로 그대로 유지(개조 안 함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SP1hJQtLPPVBJJwSAFAfxz)_