### PR TITLE
feat(engine): 국내상장 ETF용 DomesticVolManagedEngine 추가

### DIFF
--- a/accounts.yaml.example
+++ b/accounts.yaml.example
@@ -7,7 +7,8 @@
 #
 # engine 값은 src/core/engine 디렉토리에 @register_engine 으로 등록된 이름을 사용합니다.
 # 예: QldSHVEngine, QldSdyEngine, QqqSdyEngine, SpyEngine, QqqEngine, Asset5Engine,
-#     DomesticAsset5Engine, QldSdyShvEngine, QldQqqShvRegimeEngine
+#     DomesticAsset5Engine, QldSdyShvEngine, QldQqqShvRegimeEngine, VolManagedEngine,
+#     DomesticVolManagedEngine
 
 accounts:
   - id: my_pension

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,8 @@ TICKER_ALIASES: dict[str, str] = {
     # 국내 ETF (yfinance 티커 기준)
     '226490.KS' : 'KODEX 코스피',
     '133690.KS' : 'TIGER 미국나스닥100',
+    '418660.KS' : 'TIGER 미국나스닥100레버리지(합성)',
+    '459580.KS' : 'KODEX CD금리액티브',
     '365780.KS' : 'ACE 국고채10년',
     '305080.KS' : 'TIGER 미국채10년선물',
     '411060.KS' : 'ACE KRX금현물',

--- a/src/core/engine/__init__.py
+++ b/src/core/engine/__init__.py
@@ -28,7 +28,7 @@ from src.core.engine.simple import (
 from src.core.engine.regime import QldSdyShvEngine, QldQqqShvRegimeEngine
 from src.core.engine.dip_buy import DipBuyEngine, DipBuyGatedEngine
 from src.core.engine.voltarget import VolTargetLeverageEngine
-from src.core.engine.volmanaged import VolManagedEngine
+from src.core.engine.volmanaged import VolManagedEngine, DomesticVolManagedEngine
 
 __all__ = [
     "_ENGINE_REGISTRY",
@@ -51,4 +51,5 @@ __all__ = [
     "DipBuyGatedEngine",
     "VolTargetLeverageEngine",
     "VolManagedEngine",
+    "DomesticVolManagedEngine",
 ]

--- a/src/core/engine/volmanaged.py
+++ b/src/core/engine/volmanaged.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Tuple
 
 import pandas as pd
 
+from src.config import ticker_display
 from src.core.engine.base import TradingEngine
 from src.core.engine.registry import register_engine
 from src.core.interfaces import IDataProvider
@@ -107,10 +108,11 @@ class VolManagedEngine(TradingEngine):
             exposure, ratio_a = self._lev_to_weights(self._applied_L)
             self.rebalancer.ratio_a = ratio_a
             self.rebalancer.ratio_b = round(1.0 - ratio_a, 10)
+            leveraged_ticker = ticker_display(self.ASSET_GROUPS["A"][0])
             self.logger.info(
                 f">>> VolManaged: vol={market_data.spy_volatility:.2%} "
                 f"→ L={exposure + ratio_a:.2f}x "
-                f"(QLD {ratio_a:.0%}, 위험 {exposure:.0%}, 현금 {1.0 - exposure:.0%})"
+                f"({leveraged_ticker} {ratio_a:.0%}, 위험 {exposure:.0%}, 현금 {1.0 - exposure:.0%})"
             )
 
         if prev is not None and regime != prev:
@@ -122,3 +124,21 @@ class VolManagedEngine(TradingEngine):
             )
 
         return regime, exposure, nan_fields
+
+
+@register_engine(color="#d63384", market_type="domestic", backtest=False)
+class DomesticVolManagedEngine(VolManagedEngine):
+    """VolManagedEngine의 국내상장 ETF 버전 (실거래 전용).
+
+    - 자산군 A=[418660.KS](TIGER 미국나스닥100레버리지(합성), 2x)
+             B=[133690.KS](TIGER 미국나스닥100, 1x)
+             C=[459580.KS](KODEX CD금리액티브, 현금성)
+    - 레버리지 산출 로직은 VolManagedEngine과 완전히 동일(상속), 자산군과 신호
+      티커만 국내상장 ETF로 교체한다.
+    - 418660.KS(2022년 상장)/459580.KS(2023년 상장)는 상장 이력이 짧아 장기
+      비교 백테스트가 불가능하므로 backtest=False로 등록해 실거래(main.py)에서만
+      사용한다.
+    """
+
+    ASSET_GROUPS: dict = {"A": ["418660.KS"], "B": ["133690.KS"], "C": ["459580.KS"]}
+    SIGNAL_TICKER: str = "133690.KS"

--- a/tests/test_core_engine_domestic_volmanaged.py
+++ b/tests/test_core_engine_domestic_volmanaged.py
@@ -1,0 +1,111 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.core.engine.volmanaged import DomesticVolManagedEngine
+from src.infra.broker.mock import MockBroker
+from src.infra.repo import JsonRepository
+from src.utils.logger import TradeLogger
+
+
+def _make(tmp_path):
+    groups = {"A": ["418660.KS"], "B": ["133690.KS"], "C": ["459580.KS"]}
+    repo = JsonRepository(str(tmp_path), asset_groups=groups)
+    broker = MockBroker(initial_cash=10000.0)
+    eng = DomesticVolManagedEngine(broker=broker, repo=repo,
+                                   logger=TradeLogger(log_dir=str(tmp_path / "l")),
+                                   asset_groups=groups, trading_interval_days=1)
+    return eng, broker, repo
+
+
+class _Loader:
+    def __init__(self, df, vix=20.0):
+        self.df, self._vix = df, vix
+
+    def fetch_ohlcv(self, tickers, days=365):
+        return self.df.tail(days)
+
+    def fetch_vix(self):
+        return self._vix
+
+
+def _series(n=300, step=0.005):
+    rng = np.random.default_rng(0)
+    closes = 100 * np.cumprod(1 + rng.normal(0.0004, step, n))
+    idx = pd.date_range("2023-01-01", periods=n, freq="D")
+    return pd.DataFrame({"Open": closes, "High": closes, "Low": closes,
+                         "Close": closes, "Volume": [1] * n}, index=idx)
+
+
+def test_registered():
+    from src.core.engine import _ENGINE_REGISTRY
+    assert "DomesticVolManagedEngine" in [n for n, _ in _ENGINE_REGISTRY]
+
+
+def test_registered_as_domestic_market_type():
+    from src.core.engine import _ENGINE_MARKET_TYPES
+    assert _ENGINE_MARKET_TYPES["DomesticVolManagedEngine"] == "domestic"
+
+
+def test_excluded_from_backtest():
+    from src.core.engine import _ENGINE_BACKTEST
+    assert _ENGINE_BACKTEST["DomesticVolManagedEngine"] is False
+
+
+def test_asset_groups_use_domestic_tickers():
+    assert DomesticVolManagedEngine.ASSET_GROUPS == {
+        "A": ["418660.KS"], "B": ["133690.KS"], "C": ["459580.KS"],
+    }
+
+
+def test_signal_ticker_is_domestic_qqq():
+    assert DomesticVolManagedEngine.SIGNAL_TICKER == "133690.KS"
+
+
+def test_collect_data_fetches_signal_ticker(tmp_path):
+    eng, _, _ = _make(tmp_path)
+    loader = _Loader(_series())
+    calls = {}
+
+    def fetch_ohlcv(tickers, days=400):
+        calls["tickers"] = tickers
+        return loader.df.tail(days)
+    loader.fetch_ohlcv = fetch_ohlcv
+
+    eng.collect_data(loader)
+    assert calls["tickers"] == ["133690.KS"]
+
+
+@pytest.mark.parametrize("vol,exp_exposure,exp_ratio_a", [
+    (0.11,  1.0, 1.0),   # 0.22/0.11=2.0 → L=2 → 위험100%, 418660.KS100%
+    (0.22,  1.0, 0.0),   # L=1.0 → 위험100%, 133690.KS100%
+    (0.44,  0.5, 0.0),   # 0.22/0.44=0.5 → 위험50%(133690.KS)+현금50%
+])
+def test_L_to_exposure_ratio_mapping(tmp_path, vol, exp_exposure, exp_ratio_a):
+    eng, _, _ = _make(tmp_path)
+    exposure, ratio_a = eng._leverage_to_weights(vol)
+    assert abs(exposure - exp_exposure) < 1e-2
+    assert abs(ratio_a - exp_ratio_a) < 1e-2
+
+
+def test_low_vol_levers_into_leveraged_etf(tmp_path):
+    eng, broker, repo = _make(tmp_path)
+    res = eng.run_one_cycle(_Loader(_series(step=0.001), vix=20.0), sim_date="2023-10-27")
+    assert res.signal is not None
+    assert eng.rebalancer.ratio_a > 0.9        # 저변동성 → 418660.KS 편입
+
+
+def test_high_vol_moves_to_cash(tmp_path):
+    eng, broker, repo = _make(tmp_path)
+    res = eng.run_one_cycle(_Loader(_series(step=0.03), vix=20.0), sim_date="2023-10-27")
+    assert res.exposure < 1.0                    # 고변동성 → 현금(459580.KS) 이탈
+
+
+def test_nan_data_treated_as_crash(tmp_path):
+    from src.core.models import MarketData
+    eng, _, _ = _make(tmp_path)
+    md = MarketData(date="2020-03-16", spy_price=float("nan"), spy_ma180=210.0,
+                    spy_volatility=0.2, spy_momentum=-0.1, spy_mdd=-0.3, vix=80.0)
+    regime, exposure, nan_fields = eng.analyze_strategy(md)
+    assert exposure == 0.0
+    assert nan_fields


### PR DESCRIPTION
## Summary
- 기존 `VolManagedEngine`(QLD/QQQ/SHV)은 그대로 두고, 국내상장 ETF로 운용하는 신규 라이브 전용 엔진 `DomesticVolManagedEngine`을 추가
- 자산군: A=`418660.KS`(TIGER 미국나스닥100레버리지(합성)), B=`133690.KS`(TIGER 미국나스닥100), C=`459580.KS`(KODEX CD금리액티브)
- 레버리지 산출 로직은 `VolManagedEngine` 상속으로 100% 재사용, `ASSET_GROUPS`/`SIGNAL_TICKER`만 교체
- `418660.KS`(2022년 상장)/`459580.KS`(2023년 상장)는 상장 이력이 짧아 장기 비교 백테스트가 불가능하므로 `@register_engine(market_type="domestic", backtest=False)`로 등록해 실거래(`main.py`)에서만 사용
- `TICKER_ALIASES`에 신규 티커 표시명 추가 (대시보드 한글명 노출용)
- 로그 메시지의 하드코딩된 "QLD" 라벨을 A그룹 티커 기반 동적 표시로 수정 (기존 엔진에도 적용되지만 동작은 동일)
- `accounts.yaml.example` 주석에 신규 엔진명 추가

## Test plan
- [x] `pytest tests/test_core_engine_domestic_volmanaged.py tests/test_core_engine_volmanaged.py -q` 통과
- [x] 전체 테스트 스위트 `pytest --cov=src --cov-fail-under=80 tests/` 통과 (커버리지 93.92%, 신규 코드 100%)
- [ ] 실거래 계좌(`accounts.yaml`)에서 `engine: DomesticVolManagedEngine`, `market_type: domestic`으로 설정 후 실사용 확인 필요


---
_Generated by [Claude Code](https://claude.ai/code/session_01PoSeuMhZF5b7wjzYEcrCjm)_