### PR TITLE
엔진별 결정요소(DecisionFactor) 자기서술 구조 도입

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -116,14 +116,13 @@
                         </div>
                     </div>
 
-                    <!-- Current Regime -->
+                    <!-- Decision Factors (엔진별 핵심 결정요소) -->
                     <div class="col-md-6 col-lg-3">
                         <div class="card h-100 border-0 shadow-sm">
                             <div class="card-body">
-                                <h6 class="text-muted"><i class="fas fa-flag me-1"></i>시장 국면</h6>
-                                <h3 class="fw-bold mb-0" id="regime-text">-</h3>
-                                <div class="mt-1 text-muted small">
-                                    모멘텀: <span id="momentum-score">-</span>
+                                <h6 class="text-muted"><i class="fas fa-flag me-1"></i>전략 결정요소</h6>
+                                <div id="decision-factors">
+                                    <h3 class="fw-bold mb-0">-</h3>
                                 </div>
                                 <div id="trigger-reason" class="mt-1 small text-muted fst-italic"></div>
                             </div>
@@ -948,6 +947,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@2.0.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Dashboard Logic (ES Modules) -->
-    <script type="module" src="js/main.js?v=20260628-1"></script>
+    <script type="module" src="js/main.js?v=20260714-1"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -46,7 +46,7 @@ import {
     renderDividendSummaryCards,
     renderWinLossCards,
     initTooltips
-} from './ui.js?v=20260624-7';
+} from './ui.js?v=20260714-1';
 
 import { loadEngineMeta, loadAccountsMeta, ACCOUNT_MARKET_TYPES } from './utils.js?v=20260624-5';
 

--- a/docs/js/ui.js
+++ b/docs/js/ui.js
@@ -96,13 +96,8 @@ export function updateSummaryCards(statusData, summaryData, marketType = 'overse
         }
     }
 
-    // [2] 시장 국면 (Market Regime)
-    const regimeEl = document.getElementById('regime-text');
-    regimeEl.innerText = strategy.regime.replace('_', ' ');
-    regimeEl.className = 'fw-bold mb-0 ' + getRegimeColorClass(strategy.regime);
-
-    // [2-2] 모멘텀 점수
-    document.getElementById('momentum-score').innerText = (strategy.market_score.spy_momentum * 100).toFixed(2) + '%';
+    // [2] 전략 결정요소 (엔진별 self-describing; 구버전 status는 국면 폴백)
+    renderDecisionCard(strategy);
 
     // [2-3] 트리거 사유
     const triggerEl = document.getElementById('trigger-reason');
@@ -127,6 +122,56 @@ export function updateSummaryCards(statusData, summaryData, marketType = 'overse
     if (strategy.market_score.spy_volatility !== undefined) {
         volEl.innerText = (strategy.market_score.spy_volatility * 100).toFixed(1) + '%';
     }
+}
+
+/** DecisionFactor 값 포맷팅 (format: percent | number | text) */
+function formatFactorValue(f) {
+    if (typeof f.value === 'number') {
+        if (f.format === 'percent') return (f.value * 100).toFixed(2) + '%';
+        if (f.format === 'number') return f.value.toFixed(2);
+    }
+    return String(f.value ?? '-');
+}
+
+/** threshold 위반 여부: 음수 기준(MDD 등)은 이하, 양수 기준(VIX/이격도)은 이상 */
+function isFactorBreached(f) {
+    if (f.threshold == null || typeof f.value !== 'number') return false;
+    return f.threshold < 0 ? f.value <= f.threshold : f.value >= f.threshold;
+}
+
+/**
+ * 전략 결정요소 카드 렌더링.
+ * 엔진이 status.json에 자기서술한 decision_factors 배열을 그대로 그린다
+ * (첫 항목 = 대표 요소). 배열이 없는 구버전 status.json은 국면+모멘텀 폴백.
+ */
+export function renderDecisionCard(strategy) {
+    const container = document.getElementById('decision-factors');
+    if (!container) return;
+
+    const factors = strategy.decision_factors;
+    if (!Array.isArray(factors) || factors.length === 0) {
+        const regime = strategy.regime.replace('_', ' ');
+        container.innerHTML =
+            `<h3 class="fw-bold mb-0 ${getRegimeColorClass(strategy.regime)}">${regime}</h3>` +
+            `<div class="mt-1 text-muted small">모멘텀: ${(strategy.market_score.spy_momentum * 100).toFixed(2)}%</div>`;
+        return;
+    }
+
+    const [head, ...rest] = factors;
+    const headClass = head.key === 'regime'
+        ? getRegimeColorClass(String(head.value)) : 'text-dark';
+    const headValue = head.key === 'regime'
+        ? String(head.value).replace('_', ' ') : formatFactorValue(head);
+    const rows = rest.slice(0, 3).map(f =>
+        `<div class="d-flex justify-content-between align-items-center small">` +
+        `<span class="text-muted">${f.label}</span>` +
+        `<span class="fw-bold ${isFactorBreached(f) ? 'text-danger' : ''}">${formatFactorValue(f)}</span>` +
+        `</div>`
+    ).join('');
+    container.innerHTML =
+        `<div class="text-muted small">${head.label}</div>` +
+        `<h3 class="fw-bold mb-0 ${headClass}">${headValue}</h3>` +
+        (rows ? `<div class="mt-1">${rows}</div>` : '');
 }
 
 /**

--- a/docs/plans/2026-07-14-decision-factors.md
+++ b/docs/plans/2026-07-14-decision-factors.md
@@ -1,0 +1,596 @@
+# 엔진별 결정요소(DecisionFactor) 자기서술 구조 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 각 전략 엔진이 자신의 핵심 의사결정 요소를 스스로 선언·산출하고, docs 대시보드가 엔진별 분기 없이 그 요소를 렌더링하도록 한다.
+
+**Architecture:** `DecisionFactor` 도메인 모델(자기서술적: key/label/value/format/threshold)을 추가하고, `TradingEngine`에 Template Method 훅 `decision_factors()`를 만들어 서브클래스가 오버라이드한다. `persist()`가 훅 결과를 `JsonRepository`에 넘겨 `status.json`(표시용 전체)과 `summary.json`(시계열용 key:value)에 직렬화한다. 프론트(`ui.js`)는 `decision_factors` 배열을 generic 렌더링하고, 배열이 없는 구버전 status.json은 기존 국면 표시로 폴백한다. repo/프론트는 전략 지식을 갖지 않는다.
+
+**Tech Stack:** Python 3.10 (dataclass), pytest + unittest.mock, vanilla JS (ESM), Bootstrap 5.
+
+**결정요소 소유 매트릭스 (구현 대상):**
+
+| 엔진 | 훅 구현 위치 | 핵심 요소 |
+|---|---|---|
+| `TradingEngine` (기본) | `base.py` (기본 구현) | 국면, 모멘텀, VIX, MDD, 실현변동성 |
+| `FullExposureEngine` + 설정 서브클래스 전부 | `base.py` (오버라이드) | 목표 A비율, 현재 A비율, 상대이탈 vs 임계치 |
+| `QldSdyShvEngine`/`QldQqqShvRegimeEngine` | 없음 — 기본 구현 사용 | 국면이 실제 핵심 결정요소 (기본이 정확) |
+| `VolManagedEngine` | `volmanaged.py` | 실현변동성 vs 목표, 실효 레버리지, 현금비중 |
+| `VolTargetLeverageEngine` | `voltarget.py` | 실현변동성 vs 목표, 실효 레버리지, QLD비중 |
+| `DipBuyEngine`(+Gated) | `dip_buy.py` | MA20/60/120 이격, RSI, 무장 트리거 수 |
+
+**주의사항:**
+- persist는 NaN 사이클에서 스킵되므로 훅은 정상 데이터 전제로 작성해도 되지만, 방어적으로 NaN 값을 걸러낸다 (`_save_json`의 sanitize가 NaN→null 최종 방어).
+- `TradeSignal.target_ratio_a`/`rebalance_threshold`는 유지 (기존 이격도 시계열 소비자 존재). 흡수/deprecate는 후속 작업.
+- summary.json의 기존 `spy_*`/`regime` 필드는 비교 차트가 사용하므로 유지.
+- JS/CSS 수정 시 CLAUDE.md 규칙대로 참조하는 모든 곳의 `?v=`를 `20260714-1`로 갱신 (ESM이므로 `main.js` 내 `ui.js` import 문자열 포함).
+
+---
+
+### Task 1: `DecisionFactor` 도메인 모델
+
+**Files:**
+- Modify: `src/core/models.py` (파일 끝에 추가)
+- Test: `tests/test_core_models.py`
+
+**Step 1: Write the failing test** — `tests/test_core_models.py`에 추가:
+
+```python
+class TestDecisionFactor(unittest.TestCase):
+    def test_기본값(self):
+        f = DecisionFactor(key="vix", label="VIX", value=17.2)
+        self.assertEqual(f.format, "number")
+        self.assertIsNone(f.threshold)
+
+    def test_직렬화(self):
+        f = DecisionFactor(key="mdd", label="SPY MDD", value=-0.07,
+                           format="percent", threshold=-0.20)
+        d = asdict(f)
+        self.assertEqual(d, {"key": "mdd", "label": "SPY MDD", "value": -0.07,
+                             "format": "percent", "threshold": -0.20})
+
+    def test_텍스트_값(self):
+        f = DecisionFactor(key="regime", label="시장 국면", value="Bull", format="text")
+        self.assertEqual(f.value, "Bull")
+```
+
+(테스트 파일 기존 import 스타일 확인 후 `from dataclasses import asdict`, `DecisionFactor` import 추가)
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_core_models.py -v -k DecisionFactor`
+Expected: FAIL (ImportError: cannot import name 'DecisionFactor')
+
+**Step 3: Write minimal implementation** — `src/core/models.py` (`DayResult` 앞이나 뒤에 추가):
+
+```python
+@dataclass(frozen=True)
+class DecisionFactor:
+    """엔진의 의사결정 핵심 요소 한 항목 (자기서술적 — 프론트가 그대로 렌더링).
+
+    key: 안정적 식별자 (summary 시계열 키로도 사용)
+    label: 표시명
+    value: 요소 값 (수치 또는 텍스트)
+    format: "number" | "percent" | "text" — 프론트 표시 형식
+    threshold: 판단 기준값 (있으면 프론트가 기준 대비 강조 표시)
+    """
+    key: str
+    label: str
+    value: float | str
+    format: str = "number"
+    threshold: Optional[float] = None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_core_models.py -v`
+Expected: PASS (전체)
+
+**Step 5: Commit**
+
+```bash
+git add src/core/models.py tests/test_core_models.py
+git commit -m "feat: DecisionFactor 도메인 모델 추가"
+```
+
+---
+
+### Task 2: JsonRepository 직렬화 (status.json + summary.json)
+
+**Files:**
+- Modify: `src/infra/repo.py:62-119` (`save_daily_summary`), `:154-206` (`update_status`)
+- Modify: `src/core/interfaces.py:74-91` (`IRepository` 시그니처)
+- Test: `tests/test_infra_repo.py`
+
+**Step 1: Write the failing tests** — `tests/test_infra_repo.py`에 추가 (기존 fixture 스타일 재사용):
+
+```python
+def test_update_status_decision_factors_저장(self):
+    factors = [DecisionFactor("vix", "VIX", 17.2, "number", threshold=30.0),
+               DecisionFactor("regime", "시장 국면", "Bull", "text")]
+    self.repo.update_status(MarketRegime.BULL, 0.9, self.pf, self.market, "이유",
+                            decision_factors=factors)
+    with open(self.repo.status_file) as f:
+        status = json.load(f)
+    saved = status["strategy"]["decision_factors"]
+    self.assertEqual(len(saved), 2)
+    self.assertEqual(saved[0], {"key": "vix", "label": "VIX", "value": 17.2,
+                                "format": "number", "threshold": 30.0})
+
+def test_update_status_decision_factors_미전달시_빈배열(self):
+    self.repo.update_status(MarketRegime.BULL, 0.9, self.pf, self.market, "이유")
+    with open(self.repo.status_file) as f:
+        status = json.load(f)
+    self.assertEqual(status["strategy"]["decision_factors"], [])
+
+def test_save_daily_summary_factors_시계열(self):
+    factors = [DecisionFactor("group_deviation", "A그룹 상대이탈", 0.03, "percent", 0.075)]
+    self.repo.save_daily_summary(self.market, self.signal, self.pf, MarketRegime.BULL,
+                                 decision_factors=factors)
+    with open(self.repo.summary_file) as f:
+        data = json.load(f)
+    self.assertEqual(data[-1]["factors"], {"group_deviation": 0.03})
+
+def test_save_daily_summary_factors_NaN은_null로(self):
+    factors = [DecisionFactor("x", "X", float("nan"), "number")]
+    self.repo.save_daily_summary(self.market, self.signal, self.pf, MarketRegime.BULL,
+                                 decision_factors=factors)
+    with open(self.repo.summary_file) as f:
+        data = json.load(f)
+    self.assertIsNone(data[-1]["factors"]["x"])
+```
+
+**Step 2: Run** `pytest tests/test_infra_repo.py -v -k decision or factors` → FAIL (unexpected keyword argument)
+
+**Step 3: Implementation**
+
+`src/core/interfaces.py` — import에 `DecisionFactor` 추가, 두 추상 메서드에 옵셔널 파라미터:
+
+```python
+    def save_daily_summary(self, market_data: MarketData, signal: TradeSignal,
+                           portfolio: Portfolio, regime: MarketRegime,
+                           daily_dividend: float = 0.0,
+                           date_override: Optional[str] = None,
+                           decision_factors: Optional[List[DecisionFactor]] = None) -> None: ...
+    ...
+    def update_status(self, regime: MarketRegime, exposure: float, portfolio: Portfolio,
+                      market_data: MarketData, reason: str,
+                      sim_date: Optional[str] = None,
+                      rebalancing_date: Optional[str] = None,
+                      decision_factors: Optional[List[DecisionFactor]] = None) -> None: ...
+```
+
+(참고: `save_daily_summary`의 추상 시그니처엔 `benchmarks`가 빠져있는 기존 불일치가 있음 — 이번엔 `decision_factors`만 추가하고 그대로 둔다)
+
+`src/infra/repo.py`:
+- `save_daily_summary(..., benchmarks=None, decision_factors=None)`: record에 추가
+  ```python
+  # [결정요소 시계열] 엔진이 선언한 key:value 축약본 (라벨/포맷은 status.json에만)
+  "factors": {f.key: f.value for f in (decision_factors or [])},
+  ```
+- `update_status(..., rebalancing_date=None, decision_factors=None)`: `status["strategy"]`에 추가
+  ```python
+  "decision_factors": [asdict(f) for f in (decision_factors or [])],
+  ```
+
+**Step 4: Run** `pytest tests/test_infra_repo.py -v` → PASS
+
+**Step 5: Commit** `git commit -m "feat: repo에 decision_factors 직렬화 추가 (status/summary)"`
+
+---
+
+### Task 3: TradingEngine 기본 훅 + persist 연결
+
+**Files:**
+- Modify: `src/core/engine/base.py` (import, `persist()`, 새 메서드 `decision_factors()`)
+- Test: `tests/test_core_engine.py`
+
+**Step 1: Write the failing tests** — `tests/test_core_engine.py`에 추가 (기존 엔진 fixture 재사용):
+
+```python
+def test_기본_결정요소는_국면_중심(self):
+    factors = self.engine.decision_factors(self.market_data, MarketRegime.BULL, 0.9,
+                                           self.signal, self.portfolio)
+    keys = [f.key for f in factors]
+    self.assertEqual(keys[0], "regime")           # 대표 요소 = 국면
+    self.assertIn("momentum", keys)
+    self.assertIn("vix", keys)
+    self.assertIn("mdd", keys)
+    self.assertIn("volatility", keys)
+    regime_f = factors[0]
+    self.assertEqual(regime_f.value, "Bull")
+    self.assertEqual(regime_f.format, "text")
+
+def test_persist가_결정요소를_repo에_전달(self):
+    # run_one_cycle 통합 경로: mock repo의 update_status/save_daily_summary가
+    # decision_factors 키워드를 받는지 검증
+    self.engine.run_one_cycle(self.data_provider, sim_date="2026-07-14")
+    _, kwargs = self.mock_repo.update_status.call_args
+    factors = kwargs["decision_factors"]
+    self.assertTrue(factors and factors[0].key == "regime")
+    _, kwargs = self.mock_repo.save_daily_summary.call_args
+    self.assertEqual(kwargs["decision_factors"], factors)
+```
+
+(mock repo가 MagicMock이 아닌 자체 Fake라면 시그니처에 `decision_factors=None` 추가)
+
+**Step 2: Run** `pytest tests/test_core_engine.py -v -k 결정요소` → FAIL (AttributeError: decision_factors)
+
+**Step 3: Implementation** — `src/core/engine/base.py`:
+
+import에 `DecisionFactor` 추가. `persist()` 본문 수정:
+
+```python
+        effective_record_date = record_date or sim_date or market_data.date
+        rebalancing_date = effective_record_date if is_rebalancing else None
+        factors = self.decision_factors(market_data, regime, exposure, signal, final_pf)
+        self.repo.save_daily_summary(market_data, signal, final_pf, regime,
+                                     daily_dividend=daily_dividend, date_override=record_date,
+                                     benchmarks=benchmark_prices,
+                                     decision_factors=factors)
+        self.repo.save_trade_history(executions, final_pf, signal.reason, sim_date=sim_date)
+        self.repo.update_status(
+            regime, exposure, final_pf, market_data, signal.reason,
+            sim_date=sim_date,
+            rebalancing_date=rebalancing_date,
+            decision_factors=factors,
+        )
+```
+
+새 메서드 (Overridable step methods 섹션, `analyze_strategy` 아래):
+
+```python
+    def decision_factors(
+        self,
+        market_data: MarketData,
+        regime: MarketRegime,
+        exposure: float,
+        signal: TradeSignal,
+        portfolio: Portfolio,
+    ) -> List[DecisionFactor]:
+        """이 엔진의 의사결정 핵심 요소 목록 (Step 6에서 저장, 대시보드 표시용).
+
+        첫 항목이 대시보드 카드의 대표(헤드라인) 요소가 된다.
+        기본 전략은 국면 판단이 핵심이므로 국면 관련 지표를 반환하며,
+        서브클래스는 자기 전략의 실제 결정요소로 오버라이드한다.
+        """
+        return [
+            DecisionFactor("regime", "시장 국면", regime.value, "text"),
+            DecisionFactor("momentum", "SPY 모멘텀", market_data.spy_momentum, "percent"),
+            DecisionFactor("vix", "VIX", market_data.vix, "number", threshold=30.0),
+            DecisionFactor("mdd", "SPY MDD", market_data.spy_mdd, "percent", threshold=-0.20),
+            DecisionFactor("volatility", "실현변동성(21d)", market_data.spy_volatility,
+                           "percent", threshold=self.targeter.target_vol),
+        ]
+```
+
+**Step 4: Run** `pytest tests/test_core_engine.py -v` → PASS. 이어서 `pytest tests/ -x -q --ignore=tests/test_infra_broker_kis_domestic_live.py -k "not _live"` 로 다른 Fake repo 시그니처 깨짐 확인·수정.
+
+**Step 5: Commit** `git commit -m "feat: TradingEngine.decision_factors 훅 추가 및 persist 연결"`
+
+---
+
+### Task 4: FullExposureEngine 오버라이드 (이격도 중심)
+
+**Files:**
+- Modify: `src/core/engine/base.py` (`FullExposureEngine`)
+- Test: `tests/test_full_exposure_engine.py`
+
+**Step 1: Write the failing tests**:
+
+```python
+def test_결정요소는_비율_이격_중심(self):
+    # A=600, B=400 보유, 목표 0.5 → 현재 A비율 0.6, 상대이탈 0.2
+    pf = Portfolio(total_cash=0, holdings={"QLD": 6, "SHV": 4},
+                   current_prices={"QLD": 100.0, "SHV": 100.0})
+    signal = TradeSignal(1.0, [], "이유", target_ratio_a=0.5, rebalance_threshold=0.075)
+    factors = self.engine.decision_factors(self.market_data, MarketRegime.BULL, 1.0, signal, pf)
+    by_key = {f.key: f for f in factors}
+    self.assertEqual(factors[0].key, "target_ratio_a")       # 대표 요소
+    self.assertAlmostEqual(by_key["current_ratio_a"].value, 0.6)
+    self.assertAlmostEqual(by_key["group_deviation"].value, 0.2)
+    self.assertEqual(by_key["group_deviation"].threshold, 0.075)
+    self.assertNotIn("regime", by_key)                        # 국면은 결정요소 아님
+
+def test_위험자산_없으면_이격도_생략(self):
+    pf = Portfolio(total_cash=1000, holdings={}, current_prices={})
+    signal = TradeSignal(1.0, [], "이유", target_ratio_a=0.5, rebalance_threshold=0.075)
+    factors = self.engine.decision_factors(self.market_data, MarketRegime.BULL, 1.0, signal, pf)
+    keys = [f.key for f in factors]
+    self.assertIn("target_ratio_a", keys)
+    self.assertNotIn("group_deviation", keys)
+```
+
+**Step 2: Run** → FAIL (기본 구현이 regime 반환)
+
+**Step 3: Implementation** — `FullExposureEngine`에 추가:
+
+```python
+    def decision_factors(
+        self,
+        market_data: MarketData,
+        regime: MarketRegime,
+        exposure: float,
+        signal: TradeSignal,
+        portfolio: Portfolio,
+    ) -> List[DecisionFactor]:
+        """Full Exposure 계열: 국면이 아니라 목표 비율 대비 이격도가 결정요소다."""
+        groups = self.rebalancer.groups
+        val_a = portfolio.get_group_value(groups.get('A', []))
+        val_b = portfolio.get_group_value(groups.get('B', []))
+        val_risky = val_a + val_b
+        eff_a, threshold = self.rebalancer.get_target_params(regime)
+        target_a = signal.target_ratio_a if signal.target_ratio_a is not None else eff_a
+        rebalance_threshold = signal.rebalance_threshold \
+            if signal.rebalance_threshold is not None else threshold
+
+        factors = [
+            DecisionFactor("target_ratio_a", "목표 A그룹 비율", target_a, "percent"),
+        ]
+        if val_risky > 0:
+            current_a = val_a / val_risky
+            factors.append(DecisionFactor("current_ratio_a", "현재 A그룹 비율",
+                                          current_a, "percent"))
+            if target_a > 0:
+                rel_dev = abs(current_a - target_a) / target_a
+                factors.append(DecisionFactor("group_deviation", "A그룹 상대이탈",
+                                              rel_dev, "percent",
+                                              threshold=rebalance_threshold))
+        factors.append(DecisionFactor("rebalance_threshold", "리밸런싱 임계치",
+                                      rebalance_threshold, "percent"))
+        return factors
+```
+
+**Step 4: Run** `pytest tests/test_full_exposure_engine.py tests/test_spy_engine.py tests/test_qqq_engine.py tests/test_new_engines.py -v` → PASS
+
+**Step 5: Commit** `git commit -m "feat: FullExposureEngine 결정요소를 비율 이격 중심으로 오버라이드"`
+
+---
+
+### Task 5: VolManaged / VolTarget 오버라이드 (변동성→레버리지 중심)
+
+**Files:**
+- Modify: `src/core/engine/volmanaged.py`, `src/core/engine/voltarget.py`
+- Test: `tests/test_core_engine_volmanaged.py`, `tests/test_core_engine_voltarget.py`
+
+**Step 1: Write the failing tests** (각 테스트 파일의 기존 fixture 재사용):
+
+```python
+# test_core_engine_volmanaged.py
+def test_결정요소는_변동성_레버리지_중심(self):
+    self.engine._applied_L = 1.3
+    factors = self.engine.decision_factors(self.market_data, MarketRegime.BULL, 1.0,
+                                           self.signal, self.portfolio)
+    by_key = {f.key: f for f in factors}
+    self.assertEqual(factors[0].key, "realized_vol")
+    self.assertEqual(by_key["realized_vol"].threshold, self.engine.TARGET_VOL)
+    self.assertAlmostEqual(by_key["effective_leverage"].value, 1.3)
+    self.assertIn("cash_weight", by_key)
+
+# test_core_engine_voltarget.py
+def test_결정요소는_변동성_레버리지_중심(self):
+    self.engine.rebalancer.ratio_a = 0.4   # L = 1.4
+    factors = self.engine.decision_factors(self.market_data, MarketRegime.BULL, 1.0,
+                                           self.signal, self.portfolio)
+    by_key = {f.key: f for f in factors}
+    self.assertEqual(factors[0].key, "realized_vol")
+    self.assertAlmostEqual(by_key["effective_leverage"].value, 1.4)
+    self.assertAlmostEqual(by_key["leveraged_weight"].value, 0.4)
+```
+
+**Step 2: Run** → FAIL
+
+**Step 3: Implementation**
+
+`volmanaged.py` (`VolManagedEngine`):
+
+```python
+    def decision_factors(self, market_data, regime, exposure, signal, portfolio):
+        """변동성 관리: 실현변동성 → 실효 레버리지 사이징이 결정요소다."""
+        L = self._applied_L if self._applied_L is not None \
+            else exposure + self.rebalancer.ratio_a
+        return [
+            DecisionFactor("realized_vol", "실현변동성(21d)", market_data.spy_volatility,
+                           "percent", threshold=self.TARGET_VOL),
+            DecisionFactor("target_vol", "목표 변동성", self.TARGET_VOL, "percent"),
+            DecisionFactor("effective_leverage", "실효 레버리지(x)", L, "number"),
+            DecisionFactor("cash_weight", "현금 비중", max(1.0 - exposure, 0.0), "percent"),
+        ]
+```
+
+`voltarget.py` (`VolTargetLeverageEngine`):
+
+```python
+    def decision_factors(self, market_data, regime, exposure, signal, portfolio):
+        """변동성 타겟: 실현변동성 → QLD/QQQ 블렌드 레버리지가 결정요소다."""
+        w = self.rebalancer.ratio_a          # QLD 비중 = L - 1
+        return [
+            DecisionFactor("realized_vol", "실현변동성(21d)", market_data.spy_volatility,
+                           "percent", threshold=self.TARGET_VOL),
+            DecisionFactor("target_vol", "목표 변동성", self.TARGET_VOL, "percent"),
+            DecisionFactor("effective_leverage", "실효 레버리지(x)", 1.0 + w, "number"),
+            DecisionFactor("leveraged_weight", "QLD 비중", w, "percent"),
+        ]
+```
+
+(타입 힌트/`DecisionFactor` import 추가. 시그니처는 base와 동일하게 명시)
+
+**Step 4: Run** 두 테스트 파일 + `test_core_engine_domestic_volmanaged.py` → PASS
+
+**Step 5: Commit** `git commit -m "feat: VolManaged/VolTarget 결정요소를 변동성-레버리지 중심으로 오버라이드"`
+
+---
+
+### Task 6: DipBuy 오버라이드 (MA 이격/RSI/트리거 상태)
+
+**Files:**
+- Modify: `src/core/engine/dip_buy.py` (`DipBuyEngine` — Gated는 상속)
+- Test: `tests/test_core_engine_dip_buy.py`
+
+**Step 1: Write the failing test**:
+
+```python
+def test_결정요소는_눌림목_지표_중심(self):
+    self.engine.dip_signals = DipBuySignals(date="2026-07-14", price=100.0,
+                                            ma20=98.0, ma60=95.0, ma120=90.0,
+                                            rsi=45.0, ma200=88.0)
+    pf = Portfolio(total_cash=0, holdings={"QLD": 1}, current_prices={"QLD": 100.0})
+    factors = self.engine.decision_factors(self.market_data, MarketRegime.BULL, 1.0,
+                                           self.signal, pf)
+    by_key = {f.key: f for f in factors}
+    self.assertEqual(factors[0].key, "gap_ma20")
+    self.assertAlmostEqual(by_key["gap_ma20"].value, 100.0 / 98.0 - 1.0)
+    self.assertAlmostEqual(by_key["rsi"].value, 45.0)
+    self.assertEqual(by_key["armed_triggers"].value, "4/4")
+
+def test_지표_NaN이면_해당_요소_생략(self):
+    self.engine.dip_signals = DipBuySignals(date="", price=float("nan"),
+                                            ma20=float("nan"), ma60=float("nan"),
+                                            ma120=float("nan"), rsi=float("nan"))
+    pf = Portfolio(total_cash=0, holdings={}, current_prices={})
+    factors = self.engine.decision_factors(self.market_data, MarketRegime.BULL, 1.0,
+                                           self.signal, pf)
+    keys = [f.key for f in factors]
+    self.assertEqual(keys, ["armed_triggers"])
+```
+
+**Step 2: Run** → FAIL
+
+**Step 3: Implementation** — `DipBuyEngine`에 추가:
+
+```python
+    def decision_factors(self, market_data, regime, exposure, signal, portfolio):
+        """눌림목 분할매수: MA 이격·RSI·트리거 무장 상태가 결정요소다."""
+        factors: List[DecisionFactor] = []
+        s = self.dip_signals
+        price = portfolio.current_prices.get(self._ticker, 0.0)
+        if s is not None:
+            if price <= 0 and not math.isnan(s.price):
+                price = s.price
+            for key, ma, label in (("ma20", s.ma20, "MA20 이격"),
+                                   ("ma60", s.ma60, "MA60 이격"),
+                                   ("ma120", s.ma120, "MA120 이격")):
+                if price > 0 and not math.isnan(ma) and ma > 0:
+                    factors.append(DecisionFactor(f"gap_{key}", label,
+                                                  price / ma - 1.0, "percent",
+                                                  threshold=self.BAND))
+            if not math.isnan(s.rsi):
+                factors.append(DecisionFactor("rsi", "RSI(14)", s.rsi, "number",
+                                              threshold=70.0))
+        armed = self.dip_state.armed
+        armed_count = sum(1 for v in armed.values() if v)
+        factors.append(DecisionFactor("armed_triggers", "무장 트리거",
+                                      f"{armed_count}/{len(armed)}", "text"))
+        return factors
+```
+
+**Step 4: Run** `pytest tests/test_core_engine_dip_buy.py -v` → PASS
+
+**Step 5: Commit** `git commit -m "feat: DipBuy 결정요소를 눌림목 지표 중심으로 오버라이드"`
+
+---
+
+### Task 7: 전체 테스트 + 커버리지 검증
+
+**Step 1:** `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/` (live 테스트는 CI 기준과 동일하게 제외 설정이 conftest에 있으면 그대로)
+**Step 2:** 실패/커버리지 미달 시 수정 (특히 Fake repo 시그니처, `test_main_integration.py`)
+**Step 3:** Commit (수정분 있으면) `git commit -m "test: decision_factors 도입에 따른 테스트 정비"`
+
+---
+
+### Task 8: 프론트엔드 generic 렌더링
+
+**Files:**
+- Modify: `docs/js/ui.js` (`updateSummaryCards` [2] 섹션 교체 + 헬퍼 2개 추가)
+- Modify: `docs/index.html:119-131` (시장 국면 카드 → 전략 결정요소 카드), `:951` (`main.js ?v=` 갱신)
+- Modify: `docs/js/main.js` (ui.js import의 `?v=` 갱신)
+
+**Step 1: index.html 카드 교체** (기존 `regime-text`/`momentum-score` ID 제거):
+
+```html
+                    <!-- Decision Factors (엔진별 핵심 결정요소) -->
+                    <div class="col-md-6 col-lg-3">
+                        <div class="card h-100 border-0 shadow-sm">
+                            <div class="card-body">
+                                <h6 class="text-muted"><i class="fas fa-flag me-1"></i>전략 결정요소</h6>
+                                <div id="decision-factors">
+                                    <h3 class="fw-bold mb-0">-</h3>
+                                </div>
+                                <div id="trigger-reason" class="mt-1 small text-muted fst-italic"></div>
+                            </div>
+                        </div>
+                    </div>
+```
+
+**Step 2: ui.js** — `updateSummaryCards`의 [2]/[2-2] 블록을 `renderDecisionCard(strategy);` 호출로 교체하고 (trigger-reason [2-3] 블록은 유지), 파일에 헬퍼 추가:
+
+```js
+/** DecisionFactor 값 포맷팅 (format: percent | number | text) */
+function formatFactorValue(f) {
+    if (typeof f.value === 'number') {
+        if (f.format === 'percent') return (f.value * 100).toFixed(2) + '%';
+        if (f.format === 'number') return f.value.toFixed(2);
+    }
+    return String(f.value ?? '-');
+}
+
+/** threshold 위반 여부: 음수 기준(MDD 등)은 이하, 양수 기준(VIX/이격도)은 이상 */
+function isFactorBreached(f) {
+    if (f.threshold == null || typeof f.value !== 'number') return false;
+    return f.threshold < 0 ? f.value <= f.threshold : f.value >= f.threshold;
+}
+
+/**
+ * 전략 결정요소 카드 렌더링.
+ * 엔진이 저장한 decision_factors 배열을 그대로 그린다 (첫 항목 = 대표 요소).
+ * 배열이 없는 구버전 status.json은 기존 국면+모멘텀 표시로 폴백.
+ */
+export function renderDecisionCard(strategy) {
+    const container = document.getElementById('decision-factors');
+    if (!container) return;
+
+    const factors = strategy.decision_factors;
+    if (!Array.isArray(factors) || factors.length === 0) {
+        const regime = strategy.regime.replace('_', ' ');
+        container.innerHTML =
+            `<h3 class="fw-bold mb-0 ${getRegimeColorClass(strategy.regime)}">${regime}</h3>` +
+            `<div class="mt-1 text-muted small">모멘텀: ${(strategy.market_score.spy_momentum * 100).toFixed(2)}%</div>`;
+        return;
+    }
+
+    const [head, ...rest] = factors;
+    const headClass = head.key === 'regime'
+        ? getRegimeColorClass(String(head.value)) : 'text-dark';
+    const headValue = head.key === 'regime'
+        ? String(head.value).replace('_', ' ') : formatFactorValue(head);
+    const rows = rest.slice(0, 3).map(f =>
+        `<div class="d-flex justify-content-between align-items-center small">` +
+        `<span class="text-muted">${f.label}</span>` +
+        `<span class="fw-bold ${isFactorBreached(f) ? 'text-danger' : ''}">${formatFactorValue(f)}</span>` +
+        `</div>`
+    ).join('');
+    container.innerHTML =
+        `<div class="text-muted small">${head.label}</div>` +
+        `<h3 class="fw-bold mb-0 ${headClass}">${headValue}</h3>` +
+        (rows ? `<div class="mt-1">${rows}</div>` : '');
+}
+```
+
+**Step 3: 캐시 버전 갱신** (CLAUDE.md 규칙)
+- `docs/js/main.js`: `from './ui.js?v=...'` → `?v=20260714-1`
+- `docs/index.html`: `js/main.js?v=...` → `?v=20260714-1`
+- ui.js를 import하는 다른 파일이 있는지 `grep -rn "ui.js?v" docs/` 로 확인 후 전부 갱신
+
+**Step 4: 수동 검증** — `python3 -m http.server -d docs` 후 index.html 로드, my_isa(구버전 status.json) 폴백 렌더링 확인. 새 포맷은 임시로 status.json에 `decision_factors` 배열을 주입해 확인.
+
+**Step 5: Commit** `git commit -m "feat: 대시보드 전략 결정요소 카드 generic 렌더링 (+캐시 버전 갱신)"`
+
+---
+
+### Task 9: 푸시 + PR
+
+```bash
+git push -u origin claude/engine-decision-factors-uff0n0
+```
+
+PR 생성: 제목 "엔진별 결정요소(DecisionFactor) 자기서술 구조 도입". 본문에 아키텍처 요약(엔진 훅 → repo pass-through → 프론트 generic 렌더), 엔진별 요소 매트릭스, 하위호환(폴백) 설명 포함.

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -509,3 +509,38 @@ class FullExposureEngine(TradingEngine):
             )
 
         return regime, exposure, nan_fields
+
+    def decision_factors(
+        self,
+        market_data: MarketData,
+        regime: MarketRegime,
+        exposure: float,
+        signal: TradeSignal,
+        portfolio: Portfolio,
+    ) -> List[DecisionFactor]:
+        """Full Exposure 계열: 국면이 아니라 목표 비율 대비 이격도가 결정요소다."""
+        groups = self.rebalancer.groups
+        val_a = portfolio.get_group_value(groups.get('A', []))
+        val_b = portfolio.get_group_value(groups.get('B', []))
+        val_risky = val_a + val_b
+        # 신호에 담긴 진단값 우선 (그 시점의 실제 판단 기준), 없으면 현재 설정값
+        eff_a, threshold = self.rebalancer.get_target_params(regime)
+        target_a = signal.target_ratio_a if signal.target_ratio_a is not None else eff_a
+        rebalance_threshold = signal.rebalance_threshold \
+            if signal.rebalance_threshold is not None else threshold
+
+        factors = [
+            DecisionFactor("target_ratio_a", "목표 A그룹 비율", target_a, "percent"),
+        ]
+        if val_risky > 0:
+            current_a = val_a / val_risky
+            factors.append(DecisionFactor("current_ratio_a", "현재 A그룹 비율",
+                                          current_a, "percent"))
+            if target_a > 0:
+                rel_dev = abs(current_a - target_a) / target_a
+                factors.append(DecisionFactor("group_deviation", "A그룹 상대이탈",
+                                              rel_dev, "percent",
+                                              threshold=rebalance_threshold))
+        factors.append(DecisionFactor("rebalance_threshold", "리밸런싱 임계치",
+                                      rebalance_threshold, "percent"))
+        return factors

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -8,7 +8,7 @@ import pandas as pd
 from src.core.interfaces import IDataProvider, IBrokerAdapter, IRepository, ILogger, INotifier
 from src.core.models import (
     MarketData, MarketRegime, Portfolio, TradeSignal, TradeExecution, DayResult,
-    ExecutionStatus,
+    ExecutionStatus, DecisionFactor,
 )
 from src.core.logic import RegimeAnalyzer, VolatilityTargeter, Rebalancer
 from src.utils.calculator import IndicatorCalculator
@@ -212,6 +212,29 @@ class TradingEngine:
 
         return regime, exposure, nan_fields
 
+    def decision_factors(
+        self,
+        market_data: MarketData,
+        regime: MarketRegime,
+        exposure: float,
+        signal: TradeSignal,
+        portfolio: Portfolio,
+    ) -> List[DecisionFactor]:
+        """이 엔진의 의사결정 핵심 요소 목록 (Step 6에서 저장, 대시보드 표시용).
+
+        첫 항목이 대시보드 카드의 대표(헤드라인) 요소가 된다.
+        기본 전략은 국면 판단이 핵심이므로 국면 관련 지표를 반환하며,
+        서브클래스는 자기 전략의 실제 결정요소로 오버라이드한다.
+        """
+        return [
+            DecisionFactor("regime", "시장 국면", regime.value, "text"),
+            DecisionFactor("momentum", "SPY 모멘텀", market_data.spy_momentum, "percent"),
+            DecisionFactor("vix", "VIX", market_data.vix, "number", threshold=30.0),
+            DecisionFactor("mdd", "SPY MDD", market_data.spy_mdd, "percent", threshold=-0.20),
+            DecisionFactor("volatility", "실현변동성(21d)", market_data.spy_volatility,
+                           "percent", threshold=self.targeter.target_vol),
+        ]
+
     def get_portfolio(self) -> Portfolio:
         """Step 4: 포트폴리오 조회 후 실시간 가격 업데이트 + 벤치마크 현재가 수집."""
         portfolio = self.broker.get_portfolio()
@@ -382,14 +405,17 @@ class TradingEngine:
         """Step 6: 저장 3종 호출."""
         effective_record_date = record_date or sim_date or market_data.date
         rebalancing_date = effective_record_date if is_rebalancing else None
+        factors = self.decision_factors(market_data, regime, exposure, signal, final_pf)
         self.repo.save_daily_summary(market_data, signal, final_pf, regime,
                                      daily_dividend=daily_dividend, date_override=record_date,
-                                     benchmarks=benchmark_prices)
+                                     benchmarks=benchmark_prices,
+                                     decision_factors=factors)
         self.repo.save_trade_history(executions, final_pf, signal.reason, sim_date=sim_date)
         self.repo.update_status(
             regime, exposure, final_pf, market_data, signal.reason,
             sim_date=sim_date,
             rebalancing_date=rebalancing_date,
+            decision_factors=factors,
         )
 
     # ── Private helpers (NOT part of template) ────────────────────────────────

--- a/src/core/engine/dip_buy.py
+++ b/src/core/engine/dip_buy.py
@@ -21,6 +21,7 @@ from src.core.logic.dip_buy_indicators import DipBuyIndicatorCalculator
 from src.core.logic.dip_buy_planner import DipBuyPlanner, DipBuyState
 from src.core.models import (
     MarketData, MarketRegime, Portfolio, TradeSignal, TradeExecution, Order, OrderAction,
+    DecisionFactor,
 )
 
 
@@ -115,6 +116,37 @@ class DipBuyEngine(TradingEngine):
         self.repo.save_strategy_state(self.STATE_KEY, new_state.to_dict())
 
         return signal, executions, final_pf, is_rebalancing
+
+    def decision_factors(
+        self,
+        market_data: MarketData,
+        regime: MarketRegime,
+        exposure: float,
+        signal: TradeSignal,
+        portfolio: Portfolio,
+    ) -> List[DecisionFactor]:
+        """눌림목 분할매수: MA 이격·RSI·트리거 무장 상태가 결정요소다."""
+        factors: List[DecisionFactor] = []
+        s = self.dip_signals
+        price = portfolio.current_prices.get(self._ticker, 0.0)
+        if s is not None:
+            if price <= 0 and not math.isnan(s.price):
+                price = s.price
+            for key, ma, label in (("ma20", s.ma20, "MA20 이격"),
+                                   ("ma60", s.ma60, "MA60 이격"),
+                                   ("ma120", s.ma120, "MA120 이격")):
+                if price > 0 and not math.isnan(ma) and ma > 0:
+                    factors.append(DecisionFactor(f"gap_{key}", label,
+                                                  price / ma - 1.0, "percent",
+                                                  threshold=self.BAND))
+            if not math.isnan(s.rsi):
+                factors.append(DecisionFactor("rsi", "RSI(14)", s.rsi, "number",
+                                              threshold=70.0))
+        armed = self.dip_state.armed
+        armed_count = sum(1 for v in armed.values() if v)
+        factors.append(DecisionFactor("armed_triggers", "무장 트리거",
+                                      f"{armed_count}/{len(armed)}", "text"))
+        return factors
 
     # ── 현금 저수지(SHV) 관리 ──────────────────────────────────────────────
     def _deployable_cash(self, pf: Portfolio) -> float:

--- a/src/core/engine/volmanaged.py
+++ b/src/core/engine/volmanaged.py
@@ -14,7 +14,7 @@ from src.core.engine.base import TradingEngine
 from src.core.engine.registry import register_engine
 from src.core.interfaces import IDataProvider
 from src.core.logic.volatility_targeter import VolatilityTargeter
-from src.core.models import MarketData, MarketRegime
+from src.core.models import DecisionFactor, MarketData, MarketRegime, Portfolio, TradeSignal
 
 
 @register_engine(color="#6f42c1")
@@ -124,6 +124,25 @@ class VolManagedEngine(TradingEngine):
             )
 
         return regime, exposure, nan_fields
+
+    def decision_factors(
+        self,
+        market_data: MarketData,
+        regime: MarketRegime,
+        exposure: float,
+        signal: TradeSignal,
+        portfolio: Portfolio,
+    ) -> List[DecisionFactor]:
+        """변동성 관리: 실현변동성 → 실효 레버리지 사이징이 결정요소다."""
+        L = self._applied_L if self._applied_L is not None \
+            else exposure + self.rebalancer.ratio_a
+        return [
+            DecisionFactor("realized_vol", "실현변동성(21d)", market_data.spy_volatility,
+                           "percent", threshold=self.TARGET_VOL),
+            DecisionFactor("target_vol", "목표 변동성", self.TARGET_VOL, "percent"),
+            DecisionFactor("effective_leverage", "실효 레버리지(x)", L, "number"),
+            DecisionFactor("cash_weight", "현금 비중", max(1.0 - exposure, 0.0), "percent"),
+        ]
 
 
 @register_engine(color="#d63384", market_type="domestic", backtest=False)

--- a/src/core/engine/voltarget.py
+++ b/src/core/engine/voltarget.py
@@ -18,6 +18,7 @@ from src.core.interfaces import IDataProvider
 from src.core.logic.volatility_targeter import VolatilityTargeter
 from src.core.models import (
     MarketData, MarketRegime, Portfolio, TradeSignal, TradeExecution,
+    DecisionFactor,
 )
 
 
@@ -105,3 +106,21 @@ class VolTargetLeverageEngine(FullExposureEngine):
             )
         return super().execute_cycle(market_data, portfolio, regime, exposure,
                                      nan_fields, sim_date, record_date)
+
+    def decision_factors(
+        self,
+        market_data: MarketData,
+        regime: MarketRegime,
+        exposure: float,
+        signal: TradeSignal,
+        portfolio: Portfolio,
+    ) -> List[DecisionFactor]:
+        """변동성 타겟: 실현변동성 → QLD/QQQ 블렌드 레버리지가 결정요소다."""
+        w = self.rebalancer.ratio_a          # QLD 비중 = L - 1
+        return [
+            DecisionFactor("realized_vol", "실현변동성(21d)", market_data.spy_volatility,
+                           "percent", threshold=self.TARGET_VOL),
+            DecisionFactor("target_vol", "목표 변동성", self.TARGET_VOL, "percent"),
+            DecisionFactor("effective_leverage", "실효 레버리지(x)", 1.0 + w, "number"),
+            DecisionFactor("leveraged_weight", "QLD 비중", w, "percent"),
+        ]

--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Dict, Optional
 import pandas as pd
-from src.core.models import Portfolio, Order, MarketData, TradeSignal, MarketRegime, TradeExecution
+from src.core.models import Portfolio, Order, MarketData, TradeSignal, MarketRegime, TradeExecution, DecisionFactor
 
 class IDataProvider(ABC):
     @abstractmethod
@@ -80,7 +80,8 @@ class IRepository(ABC):
     def save_daily_summary(self, market_data: MarketData, signal: TradeSignal,
                            portfolio: Portfolio, regime: MarketRegime,
                            daily_dividend: float = 0.0,
-                           date_override: Optional[str] = None) -> None: ...
+                           date_override: Optional[str] = None,
+                           decision_factors: Optional[List[DecisionFactor]] = None) -> None: ...
     @abstractmethod
     def save_trade_history(self, executions: List[TradeExecution], portfolio: Portfolio,
                            reason: str, sim_date: Optional[str] = None) -> None: ...
@@ -88,7 +89,8 @@ class IRepository(ABC):
     def update_status(self, regime: MarketRegime, exposure: float, portfolio: Portfolio,
                       market_data: MarketData, reason: str,
                       sim_date: Optional[str] = None,
-                      rebalancing_date: Optional[str] = None) -> None: ...
+                      rebalancing_date: Optional[str] = None,
+                      decision_factors: Optional[List[DecisionFactor]] = None) -> None: ...
 
     # ── 전략 상태 영속화 (선택적 기능, 기본 안전 degrade) ──────────────
     # 상태형 엔진(예: DipBuyEngine의 트랜치 큐)이 프로세스 수명을 넘는 상태를

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -97,6 +97,22 @@ class TradeExecution:
     status: ExecutionStatus
     reason: str = "" # 거부 사유 등
 
+@dataclass(frozen=True)
+class DecisionFactor:
+    """엔진의 의사결정 핵심 요소 한 항목 (자기서술적 — 프론트가 그대로 렌더링).
+
+    key: 안정적 식별자 (summary.json 시계열 키로도 사용)
+    label: 표시명
+    value: 요소 값 (수치 또는 텍스트)
+    format: "number" | "percent" | "text" — 프론트 표시 형식
+    threshold: 판단 기준값 (있으면 프론트가 기준 대비 강조 표시)
+    """
+    key: str
+    label: str
+    value: float | str
+    format: str = "number"
+    threshold: Optional[float] = None
+
 @dataclass
 class DayResult:
     """하루치 트레이딩 사이클 실행 결과"""

--- a/src/infra/repo.py
+++ b/src/infra/repo.py
@@ -5,7 +5,7 @@ import os
 from typing import List, Dict, Optional
 from dataclasses import asdict
 from datetime import datetime, timezone, timedelta
-from src.core.models import MarketData, Portfolio, TradeSignal, MarketRegime, TradeExecution
+from src.core.models import MarketData, Portfolio, TradeSignal, MarketRegime, TradeExecution, DecisionFactor
 
 _KST = timezone(timedelta(hours=9))
 from src.core.interfaces import IRepository
@@ -62,7 +62,8 @@ class JsonRepository(IRepository):
     def save_daily_summary(self, market: MarketData, signal: TradeSignal, pf: Portfolio,
                            regime: MarketRegime, daily_dividend: float = 0.0,
                            date_override: Optional[str] = None,
-                           benchmarks: Optional[dict] = None):
+                           benchmarks: Optional[dict] = None,
+                           decision_factors: Optional[List[DecisionFactor]] = None):
         """일별 요약 저장 (Append 방식)"""
         # 각 그룹 순수 주식 평가액
         val_a = pf.get_group_value(self.asset_groups.get('A', []))
@@ -102,6 +103,9 @@ class JsonRepository(IRepository):
             # 이격도 시계열이 설정 변경과 무관하게 불변이 되도록 한다.
             "target_ratio_a": signal.target_ratio_a,
             "rebalance_threshold": signal.rebalance_threshold,
+
+            # [결정요소 시계열] 엔진이 선언한 key:value 축약본 (라벨/포맷은 status.json에만)
+            "factors": {f.key: f.value for f in (decision_factors or [])},
         }
 
         data = self._load_json(self.summary_file, default=[])
@@ -158,7 +162,8 @@ class JsonRepository(IRepository):
                       market_data: MarketData, # [필수] 데이터 매핑을 위해 필요
                       reason: str,
                       sim_date: str = None,          # [백테스트] 시뮬레이션 날짜 (없으면 현재 시각)
-                      rebalancing_date: str = None): # 리밸런싱 실행일 (None이면 기존 값 유지)
+                      rebalancing_date: str = None,  # 리밸런싱 실행일 (None이면 기존 값 유지)
+                      decision_factors: Optional[List[DecisionFactor]] = None):
 
         last_updated = sim_date if sim_date else datetime.now(_KST).strftime("%Y-%m-%d %H:%M:%S")
 
@@ -184,7 +189,9 @@ class JsonRepository(IRepository):
                     "spy_price": market_data.spy_price,
                     "spy_ma180": market_data.spy_ma180,
                     "spy_volatility": market_data.spy_volatility
-                }
+                },
+                # [결정요소] 엔진이 자기서술한 핵심 요소 목록 (프론트가 그대로 렌더링)
+                "decision_factors": [asdict(f) for f in (decision_factors or [])],
             },
 
             "portfolio": {

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -646,6 +646,49 @@ def test_run_one_cycle_day_result_contains_daily_dividend():
 
 
 # ─────────────────────────────────────────────────────────────────
+# 결정요소 (decision_factors)
+# ─────────────────────────────────────────────────────────────────
+
+def test_default_decision_factors_are_regime_centric():
+    """기본 엔진의 결정요소는 국면 중심 (대표 요소 = regime)."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    mocks["targeter"].target_vol = 0.15
+    md = _make_market_data()
+    signal = TradeSignal(0.9, [], "Bull (모니터링)")
+
+    factors = engine.decision_factors(md, MarketRegime.BULL, 0.9, signal, _make_portfolio())
+
+    keys = [f.key for f in factors]
+    assert keys[0] == "regime"  # 대표(헤드라인) 요소
+    assert {"momentum", "vix", "mdd", "volatility"} <= set(keys)
+    assert factors[0].value == "Bull"
+    assert factors[0].format == "text"
+    by_key = {f.key: f for f in factors}
+    assert by_key["vix"].threshold == 30.0
+    assert by_key["mdd"].threshold == -0.20
+    assert by_key["volatility"].threshold == 0.15
+
+
+def test_persist_passes_decision_factors_to_repo():
+    """run_one_cycle 통합 경로: persist가 결정요소를 repo 저장 2종에 전달."""
+    engine, mocks = _make_engine(repo_last_reb=None)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+    mocks["rebalancer"].generate_signal.return_value = TradeSignal(1.0, [], "Hold")
+
+    engine.run_one_cycle(mocks["data_provider"], sim_date="2026-07-14")
+
+    _, kwargs = mocks["repo"].update_status.call_args
+    factors = kwargs["decision_factors"]
+    assert factors and factors[0].key == "regime"
+    _, kwargs = mocks["repo"].save_daily_summary.call_args
+    assert kwargs["decision_factors"] == factors
+
+
+# ─────────────────────────────────────────────────────────────────
 # 거래 후 포트폴리오 조회 실패 → 거래 기록은 반드시 저장
 # ─────────────────────────────────────────────────────────────────
 

--- a/tests/test_core_engine_dip_buy.py
+++ b/tests/test_core_engine_dip_buy.py
@@ -153,3 +153,65 @@ def test_multi_day_cycle_executes_orders(tmp_path):
         engine.run_one_cycle(loader, sim_date=f"2023-10-{27 + i:02d}")
     # 적어도 한 번은 QLD를 보유하거나 현금이 변동했어야 함 (트리거 발동 시)
     assert broker.cash <= 10000.0
+
+
+# ─────────────────────────────────────────────────────────────────
+# 결정요소 (decision_factors)
+# ─────────────────────────────────────────────────────────────────
+
+def test_decision_factors_are_dip_indicator_centric(tmp_path):
+    """결정요소는 MA 이격·RSI·무장 트리거 (국면/이격도 아님)."""
+    from src.core.models import MarketData, MarketRegime, TradeSignal
+    engine, _, _ = _make_engine(tmp_path)
+    engine.dip_signals = DipBuySignals(date="2026-07-14", price=100.0,
+                                       ma20=98.0, ma60=95.0, ma120=90.0,
+                                       rsi=45.0, ma200=88.0)
+    pf = Portfolio(total_cash=0.0, holdings={"QLD": 1}, current_prices={"QLD": 100.0})
+    md = MarketData("2026-07-14", 100.0, 90.0, 0.2, 0.05, -0.05, 18.0)
+
+    factors = engine.decision_factors(md, MarketRegime.BULL, 1.0,
+                                      TradeSignal(1.0, [], "이유"), pf)
+
+    by_key = {f.key: f for f in factors}
+    assert factors[0].key == "gap_ma20"                     # 대표 요소
+    assert by_key["gap_ma20"].value == pytest.approx(100.0 / 98.0 - 1.0)
+    assert by_key["gap_ma20"].threshold == engine.BAND
+    assert by_key["gap_ma60"].value == pytest.approx(100.0 / 95.0 - 1.0)
+    assert by_key["gap_ma120"].value == pytest.approx(100.0 / 90.0 - 1.0)
+    assert by_key["rsi"].value == pytest.approx(45.0)
+    assert by_key["rsi"].threshold == 70.0
+    assert by_key["armed_triggers"].value == "4/4"
+    assert "regime" not in by_key
+
+
+def test_decision_factors_skip_nan_indicators(tmp_path):
+    """지표가 NaN이면 해당 요소는 생략하고 무장 상태만 반환."""
+    from src.core.models import MarketData, MarketRegime, TradeSignal
+    engine, _, _ = _make_engine(tmp_path)
+    engine.dip_signals = DipBuySignals(date="", price=float("nan"),
+                                       ma20=float("nan"), ma60=float("nan"),
+                                       ma120=float("nan"), rsi=float("nan"))
+    pf = Portfolio(total_cash=0.0, holdings={}, current_prices={})
+    md = MarketData("2026-07-14", 100.0, 90.0, 0.2, 0.05, -0.05, 18.0)
+
+    factors = engine.decision_factors(md, MarketRegime.BULL, 1.0,
+                                      TradeSignal(1.0, [], "이유"), pf)
+
+    assert [f.key for f in factors] == ["armed_triggers"]
+
+
+def test_decision_factors_price_falls_back_to_signals(tmp_path):
+    """포트폴리오에 현재가가 없으면 dip_signals의 종가로 이격을 계산."""
+    from src.core.models import MarketData, MarketRegime, TradeSignal
+    engine, _, _ = _make_engine(tmp_path)
+    engine.dip_signals = DipBuySignals(date="2026-07-14", price=110.0,
+                                       ma20=100.0, ma60=float("nan"),
+                                       ma120=float("nan"), rsi=float("nan"))
+    pf = Portfolio(total_cash=1000.0, holdings={}, current_prices={})
+    md = MarketData("2026-07-14", 100.0, 90.0, 0.2, 0.05, -0.05, 18.0)
+
+    factors = engine.decision_factors(md, MarketRegime.BULL, 1.0,
+                                      TradeSignal(1.0, [], "이유"), pf)
+
+    by_key = {f.key: f for f in factors}
+    assert by_key["gap_ma20"].value == pytest.approx(0.10)

--- a/tests/test_core_engine_volmanaged.py
+++ b/tests/test_core_engine_volmanaged.py
@@ -94,3 +94,40 @@ def test_nan_data_treated_as_crash(tmp_path):
     regime, exposure, nan_fields = eng.analyze_strategy(md)
     assert exposure == 0.0
     assert nan_fields
+
+
+def test_decision_factors_are_vol_leverage_centric(tmp_path):
+    """결정요소는 실현변동성 → 실효 레버리지 사이징 (국면 아님)."""
+    from src.core.models import MarketData, MarketRegime, Portfolio, TradeSignal
+    eng, _, _ = _make(tmp_path)
+    eng._applied_L = 1.3
+    md = MarketData("2026-07-14", 100.0, 90.0, 0.20, 0.05, -0.05, 18.0)
+    pf = Portfolio(0.0, {}, {})
+    signal = TradeSignal(1.0, [], "이유")
+
+    factors = eng.decision_factors(md, MarketRegime.BULL, 1.0, signal, pf)
+
+    by_key = {f.key: f for f in factors}
+    assert factors[0].key == "realized_vol"                 # 대표 요소
+    assert by_key["realized_vol"].value == pytest.approx(0.20)
+    assert by_key["realized_vol"].threshold == eng.TARGET_VOL
+    assert by_key["target_vol"].value == eng.TARGET_VOL
+    assert by_key["effective_leverage"].value == pytest.approx(1.3)
+    assert by_key["cash_weight"].value == pytest.approx(0.0)
+    assert "regime" not in by_key
+
+
+def test_decision_factors_before_first_cycle_uses_current_weights(tmp_path):
+    """_applied_L 미설정(첫 사이클 전)이면 현재 exposure+ratio_a로 L 산출."""
+    from src.core.models import MarketData, MarketRegime, Portfolio, TradeSignal
+    eng, _, _ = _make(tmp_path)
+    assert eng._applied_L is None
+    eng.rebalancer.ratio_a = 0.5
+    md = MarketData("2026-07-14", 100.0, 90.0, 0.20, 0.05, -0.05, 18.0)
+
+    factors = eng.decision_factors(md, MarketRegime.BULL, 0.8,
+                                   TradeSignal(0.8, [], "이유"), Portfolio(0.0, {}, {}))
+
+    by_key = {f.key: f for f in factors}
+    assert by_key["effective_leverage"].value == pytest.approx(1.3)  # 0.8 + 0.5
+    assert by_key["cash_weight"].value == pytest.approx(0.2)

--- a/tests/test_core_engine_voltarget.py
+++ b/tests/test_core_engine_voltarget.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import pandas as pd
 
 from src.core.engine.voltarget import VolTargetLeverageEngine
@@ -89,3 +90,24 @@ def test_cycle_runs_and_invests(tmp_path):
     assert res.signal is not None
     # 첫 투자 → QLD/QQQ 매수 발생
     assert any(o.ticker in ("QLD", "QQQ") for o in res.signal.orders)
+
+
+def test_decision_factors_are_vol_leverage_centric(tmp_path):
+    """결정요소는 실현변동성 → QLD/QQQ 블렌드 레버리지 (이격도 아님)."""
+    from src.core.models import MarketData, Portfolio, TradeSignal
+    eng, _, _ = _make(tmp_path)
+    eng.rebalancer.ratio_a = 0.4   # L = 1.4
+    md = MarketData("2026-07-14", 100.0, 90.0, 0.25, 0.05, -0.05, 18.0)
+    pf = Portfolio(0.0, {}, {})
+    signal = TradeSignal(1.0, [], "이유")
+
+    factors = eng.decision_factors(md, MarketRegime.BULL, 1.0, signal, pf)
+
+    by_key = {f.key: f for f in factors}
+    assert factors[0].key == "realized_vol"                 # 대표 요소
+    assert by_key["realized_vol"].value == pytest.approx(0.25)
+    assert by_key["realized_vol"].threshold == eng.TARGET_VOL
+    assert by_key["target_vol"].value == eng.TARGET_VOL
+    assert by_key["effective_leverage"].value == pytest.approx(1.4)
+    assert by_key["leveraged_weight"].value == pytest.approx(0.4)
+    assert "group_deviation" not in by_key

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,6 +1,8 @@
 import math
+from dataclasses import asdict
+
 import pytest
-from src.core.models import MarketData, Portfolio
+from src.core.models import DecisionFactor, MarketData, Portfolio
 
 # ==========================================
 # 1. MarketData 테스트 (경계값 검증)
@@ -140,3 +142,26 @@ def test_nan_fields_multiple_nan():
     assert 'spy_volatility' in result
     assert 'vix' in result
     assert len(result) == 3
+
+
+# ==========================================
+# 4. DecisionFactor 테스트
+# ==========================================
+
+def test_decision_factor_defaults():
+    """format 기본값 number, threshold 기본값 None"""
+    f = DecisionFactor(key="vix", label="VIX", value=17.2)
+    assert f.format == "number"
+    assert f.threshold is None
+
+def test_decision_factor_serialization():
+    """asdict로 JSON 저장 가능한 dict가 나와야 한다"""
+    f = DecisionFactor(key="mdd", label="SPY MDD", value=-0.07,
+                       format="percent", threshold=-0.20)
+    assert asdict(f) == {"key": "mdd", "label": "SPY MDD", "value": -0.07,
+                         "format": "percent", "threshold": -0.20}
+
+def test_decision_factor_text_value():
+    """국면 같은 텍스트 값도 담을 수 있어야 한다"""
+    f = DecisionFactor(key="regime", label="시장 국면", value="Bull", format="text")
+    assert f.value == "Bull"

--- a/tests/test_full_exposure_engine.py
+++ b/tests/test_full_exposure_engine.py
@@ -215,3 +215,63 @@ def test_full_exposure_nan_end_to_end():
     assert result.is_rebalancing is False
     assert result.executions == []
     mocks["rebalancer"].generate_signal.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────
+# 결정요소 (decision_factors)
+# ─────────────────────────────────────────────────────────────────
+
+def test_decision_factors_are_ratio_deviation_centric():
+    """Full Exposure 결정요소는 국면이 아니라 목표 비율 대비 이격도."""
+    engine, mocks = _make_engine()
+    mocks["rebalancer"].groups = {'A': ['SSO', 'QLD'], 'B': ['IEF', 'GLD'], 'C': ['SHV']}
+    md = _make_market_data()
+    # A=600 (SSO 6주), B=400 (IEF 4주) → 현재 A비율 0.6, 목표 0.5 → 상대이탈 0.2
+    pf = Portfolio(total_cash=0.0, holdings={"SSO": 6, "IEF": 4},
+                   current_prices={"SSO": 100.0, "IEF": 100.0})
+    signal = TradeSignal(1.0, [], "이유", target_ratio_a=0.5, rebalance_threshold=0.075)
+
+    factors = engine.decision_factors(md, MarketRegime.BULL, 1.0, signal, pf)
+
+    by_key = {f.key: f for f in factors}
+    assert factors[0].key == "target_ratio_a"          # 대표 요소
+    assert by_key["target_ratio_a"].value == 0.5
+    assert by_key["current_ratio_a"].value == pytest.approx(0.6)
+    assert by_key["group_deviation"].value == pytest.approx(0.2)
+    assert by_key["group_deviation"].threshold == 0.075
+    assert by_key["rebalance_threshold"].value == 0.075
+    assert "regime" not in by_key                       # 국면은 결정요소 아님
+
+
+def test_decision_factors_skip_deviation_when_no_risky_assets():
+    """위험자산 평가액 0이면 현재비율/이격도 요소는 생략."""
+    engine, mocks = _make_engine()
+    mocks["rebalancer"].groups = {'A': ['SSO'], 'B': ['IEF']}
+    md = _make_market_data()
+    pf = Portfolio(total_cash=1000.0, holdings={}, current_prices={})
+    signal = TradeSignal(1.0, [], "이유", target_ratio_a=0.5, rebalance_threshold=0.075)
+
+    factors = engine.decision_factors(md, MarketRegime.BULL, 1.0, signal, pf)
+
+    keys = [f.key for f in factors]
+    assert "target_ratio_a" in keys
+    assert "current_ratio_a" not in keys
+    assert "group_deviation" not in keys
+
+
+def test_decision_factors_fallback_to_rebalancer_params():
+    """signal에 진단값이 없으면(모니터링 외 경로) rebalancer 목표 파라미터 사용."""
+    engine, mocks = _make_engine()
+    mocks["rebalancer"].groups = {'A': ['SSO'], 'B': ['IEF']}
+    mocks["rebalancer"].get_target_params.return_value = (0.3, 0.05)
+    md = _make_market_data()
+    pf = Portfolio(total_cash=0.0, holdings={"SSO": 3, "IEF": 7},
+                   current_prices={"SSO": 100.0, "IEF": 100.0})
+    signal = TradeSignal(1.0, [], "이유")  # target_ratio_a=None
+
+    factors = engine.decision_factors(md, MarketRegime.BULL, 1.0, signal, pf)
+
+    by_key = {f.key: f for f in factors}
+    assert by_key["target_ratio_a"].value == 0.3
+    assert by_key["group_deviation"].value == pytest.approx(0.0)
+    assert by_key["group_deviation"].threshold == 0.05

--- a/tests/test_infra_repo.py
+++ b/tests/test_infra_repo.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import os
 from src.infra.repo import JsonRepository
-from src.core.models import MarketData, Portfolio, TradeSignal, MarketRegime, Order, TradeExecution, OrderAction, ExecutionStatus
+from src.core.models import DecisionFactor, MarketData, Portfolio, TradeSignal, MarketRegime, Order, TradeExecution, OrderAction, ExecutionStatus
 
 @pytest.fixture
 def repo(tmp_path):
@@ -71,6 +71,51 @@ def test_load_last_regime_returns_none_on_missing_key(repo):
     with open(repo.status_file, 'w') as f:
         json.dump(incomplete_status, f)
     assert repo.load_last_regime() is None
+
+
+def test_update_status_decision_factors_저장(repo, dummy_portfolio, dummy_market_data):
+    """엔진이 넘긴 결정요소가 status.json strategy.decision_factors에 그대로 직렬화됨."""
+    factors = [DecisionFactor("vix", "VIX", 17.2, "number", threshold=30.0),
+               DecisionFactor("regime", "시장 국면", "Bull", "text")]
+    repo.update_status(MarketRegime.BULL, 0.9, dummy_portfolio, dummy_market_data, "이유",
+                       decision_factors=factors)
+    with open(repo.status_file) as f:
+        status = json.load(f)
+    saved = status["strategy"]["decision_factors"]
+    assert len(saved) == 2
+    assert saved[0] == {"key": "vix", "label": "VIX", "value": 17.2,
+                        "format": "number", "threshold": 30.0}
+    assert saved[1]["value"] == "Bull"
+
+
+def test_update_status_decision_factors_미전달시_빈배열(repo, dummy_portfolio, dummy_market_data):
+    """decision_factors 미전달(구버전 호출) 시 빈 배열로 저장 (프론트 폴백 경로)."""
+    repo.update_status(MarketRegime.BULL, 0.9, dummy_portfolio, dummy_market_data, "이유")
+    with open(repo.status_file) as f:
+        status = json.load(f)
+    assert status["strategy"]["decision_factors"] == []
+
+
+def test_save_daily_summary_factors_시계열(repo, dummy_portfolio, dummy_market_data):
+    """summary.json에는 key:value 축약본만 저장 (시계열용)."""
+    signal = TradeSignal(1.0, [], "test")
+    factors = [DecisionFactor("group_deviation", "A그룹 상대이탈", 0.03, "percent", 0.075)]
+    repo.save_daily_summary(dummy_market_data, signal, dummy_portfolio, MarketRegime.BULL,
+                            decision_factors=factors)
+    with open(repo.summary_file) as f:
+        data = json.load(f)
+    assert data[-1]["factors"] == {"group_deviation": 0.03}
+
+
+def test_save_daily_summary_factors_NaN은_null로(repo, dummy_portfolio, dummy_market_data):
+    """NaN 값은 _sanitize_for_json에 의해 null로 저장되어야 한다."""
+    signal = TradeSignal(1.0, [], "test")
+    factors = [DecisionFactor("x", "X", float("nan"), "number")]
+    repo.save_daily_summary(dummy_market_data, signal, dummy_portfolio, MarketRegime.BULL,
+                            decision_factors=factors)
+    with open(repo.summary_file) as f:
+        data = json.load(f)
+    assert data[-1]["factors"]["x"] is None
 
 
 def test_save_daily_summary_date_override(repo, dummy_portfolio):


### PR DESCRIPTION
## 배경

기존에는 모든 엔진이 국면(regime) 중심 지표만 docs에 저장해서, 국면과 무관한 Full Exposure 계열 엔진도 대시보드에 동일한 국면요소만 표시됐다. "무엇이 결정요소인가"라는 전략 지식이 엔진 밖(repo의 `market_score` 고정 키, 프론트의 하드코딩 ID)에 흩어져 있던 것이 원인.

## 아키텍처

**엔진 훅 → repo pass-through → 프론트 generic 렌더링** 3단 구조로, 결정요소의 소유자를 엔진으로 일원화했다.

- `core/models.py`: 자기서술적 `DecisionFactor` 모델 추가 (key/label/value/format/threshold)
- `core/engine/base.py`: Template Method 훅 `TradingEngine.decision_factors()` 추가, `persist()`가 결과를 repo에 전달. 서브클래스가 자기 전략의 실제 결정요소로 오버라이드
- `infra/repo.py`: 내용 해석 없이 직렬화만 수행 — `status.json`의 `strategy.decision_factors`(표시용 전체), `summary.json`의 `factors`(시계열용 key:value 축약)
- `docs/js/ui.js`: 배열을 엔진 분기 없이 렌더링 (첫 항목 = 헤드라인, threshold 위반 시 빨간 강조). 배열이 없는 구버전 status.json은 기존 국면+모멘텀 표시로 폴백

## 엔진별 결정요소

| 엔진 | 핵심 요소 |
|---|---|
| `TradingEngine` (기본) | 국면, 모멘텀, VIX, MDD, 실현변동성 |
| `FullExposureEngine` 계열 | 목표/현재 A그룹 비율, 상대이탈 vs 임계치 |
| `QldSdyShv`/`QldQqqShvRegime` | 기본 구현 사용 (국면이 실제 핵심 결정요소) |
| `VolManagedEngine` | 실현변동성 vs 목표, 실효 레버리지, 현금비중 |
| `VolTargetLeverageEngine` | 실현변동성 vs 목표, 실효 레버리지, QLD 비중 |
| `DipBuyEngine`(+Gated) | MA20/60/120 이격, RSI, 무장 트리거 수 |

## 하위호환

- `summary.json`의 기존 `spy_*`/`regime` 필드와 `TradeSignal.target_ratio_a`/`rebalance_threshold`는 유지 (기존 비교 차트 소비자 보존)
- 프론트는 `decision_factors` 부재 시 기존 표시로 폴백 — 봇이 새 데이터를 쓰기 전에도 대시보드 정상 동작
- CLAUDE.md 규칙대로 `ui.js`/`main.js` 참조의 `?v=20260714-1` 갱신

## 검증

- `pytest --cov=src --cov-fail-under=80` (CI 동일 제외 조건): **735 passed, 커버리지 93.94%**
- 엔진별 결정요소 훅 단위 테스트 + repo 직렬화(NaN→null 포함) 테스트 추가
- Playwright 헤드리스 브라우저로 대시보드 실렌더링 확인: 구버전 status.json 폴백 / 신규 포맷(이격도 임계치 초과 시 빨간 강조) 모두 정상

설계 문서: `docs/plans/2026-07-14-decision-factors.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XS6KbSxbPLH3uRWZtLVUP

---
_Generated by [Claude Code](https://claude.ai/code/session_019XS6KbSxbPLH3uRWZtLVUP)_