### PR TITLE
fix: 기초/기말 레코드가 null이면 가장 가까운 유효 레코드를 사용 (MagicSplit #260 순이식)

### DIFF
--- a/src/core/settlement.py
+++ b/src/core/settlement.py
@@ -94,30 +94,44 @@ def compute_settlement(records: List[dict], start: str, end: str) -> SettlementR
             twr_pct=None, record_count=0, missing_net_deposit_count=0,
         )
 
-    # 기초자산: start 직전 마지막 레코드. 없으면 기간 첫 레코드를 기초로 사용.
+    # 기초/기말 레코드 선택: total_value가 null(시세조회 실패 등)인 레코드를
+    # 기초/기말로 쓰면 자산이 0으로 잡혀 손익이 크게 왜곡되므로, 가장 가까운
+    # "유효한"(값이 있는) 레코드를 선택한다.
+    #   기초: start 직전의 마지막 유효 레코드. 없으면 기간 내 첫 유효 레코드.
+    #   기말: 기간 내 마지막 유효 레코드.
+    # 유효 레코드가 하나도 없으면 기존 위치(기간 첫/끝)로 강등하고 금액은 0 처리.
+    def _valid(r):
+        return _finite(r.get("total_value")) is not None
+
     prior = [r for r in recs if r["date"][:10] < start]
-    if prior:
-        base = prior[-1]
-        # 기간 내 모든 순입금이 base 이후 발생분
-        contrib = in_range
-        twr_seq = [base] + in_range
+    valid_prior = [r for r in prior if _valid(r)]
+    valid_in_range = [r for r in in_range if _valid(r)]
+
+    if valid_prior:
+        base = valid_prior[-1]
+    elif valid_in_range:
+        base = valid_in_range[0]
     else:
         base = in_range[0]
-        # 첫 레코드 값에는 그날까지의 입금이 이미 반영 -> 그 이후 분만 합산
-        contrib = in_range[1:]
-        twr_seq = in_range
+    end_rec = valid_in_range[-1] if valid_in_range else in_range[-1]
 
-    # total_value가 null(시세조회 실패 등)이어도 결산 전체가 중단되지 않도록 방어
+    # 결산 창은 (base, end_rec]: 항등식(손익 = 기말 - 기초 - 순입금)이 유지되도록
+    # base 이후 ~ end_rec까지 발생한 순입금만 합산한다. base가 null 레코드를
+    # 건너뛰어 기간 밖 과거로 이동했다면 그 사이 순입금도 포함하고, end_rec이
+    # 기간 끝보다 앞이라면 그 이후 순입금은 제외한다.
+    pos = {id(r): i for i, r in enumerate(recs)}
+    window = recs[pos[id(base)] + 1: pos[id(end_rec)] + 1]
+
     start_asset = _finite(base.get("total_value")) or 0.0
-    end_asset = _finite(in_range[-1].get("total_value")) or 0.0
-    net_deposit = round(sum(float(r.get("net_deposit") or 0.0) for r in contrib), 2)
+    end_asset = _finite(end_rec.get("total_value")) or 0.0
+    net_deposit = round(sum(float(r.get("net_deposit") or 0.0) for r in window), 2)
     profit = round(end_asset - start_asset - net_deposit, 2)
-    twr_pct = _twr_pct(twr_seq)
-    missing = sum(1 for r in contrib if r.get("net_deposit") is None)
+    twr_pct = _twr_pct([base] + window)
+    missing = sum(1 for r in window if r.get("net_deposit") is None)
 
     return SettlementResult(
         start_date=start, end_date=end,
-        base_date=base["date"][:10], last_date=in_range[-1]["date"][:10],
+        base_date=base["date"][:10], last_date=end_rec["date"][:10],
         start_asset=round(start_asset, 2), end_asset=round(end_asset, 2),
         net_deposit=net_deposit, profit=profit,
         twr_pct=twr_pct, record_count=len(in_range),

--- a/tests/test_core_settlement.py
+++ b/tests/test_core_settlement.py
@@ -180,16 +180,48 @@ class TestComputeSettlement:
         r = compute_settlement(recs, "2026-06-01", "2026-06-28")
         assert r.twr_pct is None
 
-    def test_null_total_value_at_boundaries_does_not_crash(self):
-        """기초/기말 레코드의 total_value가 null이어도 결산이 중단되지 않는다."""
+    def test_null_boundaries_resolve_to_nearest_valid_record(self):
+        """기초/기말 레코드가 null이면 가장 가까운 유효 레코드를 기초/기말로 쓴다."""
         recs = [
             {"date": "2026-06-01", "total_value": None, "net_deposit": 0.0},
             _rec("2026-06-15", 1000.0),
             {"date": "2026-06-28", "total_value": None, "net_deposit": 0.0},
         ]
         r = compute_settlement(recs, "2026-06-01", "2026-06-30")
-        assert r.start_asset == 0.0
-        assert r.end_asset == 0.0
+        assert r.start_asset == 1000.0
+        assert r.end_asset == 1000.0
+        assert r.base_date == "2026-06-15"
+        assert r.last_date == "2026-06-15"
+        assert r.profit == 0.0
+
+    def test_null_end_record_uses_last_valid_and_excludes_later_deposits(self):
+        """기말이 null이면 마지막 유효 레코드가 기말이 되고, 그 이후 순입금은 제외된다."""
+        recs = [
+            _rec("2026-05-31", 1000.0),
+            _rec("2026-06-15", 1200.0, net_deposit=100.0),
+            # 마지막 날 시세조회 실패 + 입금 500: 기말은 6/15, 500은 합산 제외
+            {"date": "2026-06-28", "total_value": None, "net_deposit": 500.0},
+        ]
+        r = compute_settlement(recs, "2026-06-01", "2026-06-30")
+        assert r.last_date == "2026-06-15"
+        assert r.end_asset == 1200.0
+        assert r.net_deposit == 100.0
+        assert r.profit == 100.0  # 1200 - 1000 - 100
+
+    def test_null_prior_base_walks_back_and_keeps_identity(self):
+        """직전 레코드가 null이면 그 이전 유효 레코드가 기초가 되고,
+        그 사이(기간 밖) 순입금도 합산해 항등식이 유지된다."""
+        recs = [
+            _rec("2026-05-28", 1000.0),
+            # start 직전 레코드가 비정상이지만 200 입금이 기록됨
+            {"date": "2026-05-31", "total_value": None, "net_deposit": 200.0},
+            _rec("2026-06-15", 1300.0),
+        ]
+        r = compute_settlement(recs, "2026-06-01", "2026-06-30")
+        assert r.base_date == "2026-05-28"
+        assert r.start_asset == 1000.0
+        assert r.net_deposit == 200.0
+        assert r.profit == 100.0  # 1300 - 1000 - 200
 
     def test_records_sorted_defensively(self):
         """저장 순서가 뒤섞여 있어도 날짜순으로 정렬해 계산한다"""


### PR DESCRIPTION
## 개요
[MagicSplit#260](https://github.com/Junghyun99/MagicSplit/pull/260) 리뷰에서 추가된 결산 경계값 개선을 StockAsset의 `compute_settlement`에 순이식합니다. 두 저장소의 결산 로직이 다시 동일해집니다.

## 문제
기초/기말 레코드의 `total_value`가 null(시세조회 실패 등)이면 기존 `_finite(...) or 0.0` 방어가 자산을 0으로 보고합니다. 예를 들어 기말 레코드 하루만 null이어도 기말자산 0 → 전 자산이 공중분해된 것 같은 손실로 오표기됩니다 (크래시는 막았지만 조용히 틀린 값).

## 수정
가장 가까운 **유효 레코드**를 기초/기말로 선택합니다:
- 기초: start 직전의 마지막 유효 레코드 (없으면 기간 내 첫 유효 레코드)
- 기말: 기간 내 마지막 유효 레코드
- 결산 항등식(손익 = 기말 - 기초 - 순입금)이 유지되도록 **순입금 합산 창과 TWR 시퀀스도 선택된 (기초, 기말] 구간으로 함께 조정** — 기초가 null을 건너뛰어 과거로 밀리면 그 사이 순입금 포함, 기말이 앞으로 당겨지면 그 이후 순입금 제외
- 리포트의 기초자산일/기말자산일도 실제 측정 시점을 표시
- 유효 레코드가 전혀 없는 퇴화 케이스만 기존 0.0 강등 유지

## 검증
- `pytest --cov=src --cov-fail-under=80 tests/`: **761 passed, 커버리지 93.8%** (`_live` 테스트 제외 실행)
- 테스트: 경계 null 기대값 갱신 + 항등식 유지 검증 2건(기말 이후 입금 제외 / 기초 이전 입금 포함) 추가
- MagicSplit#260에 동일 로직이 CI 통과 후 머지됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELiCopSJj2AC2UzF3i6feC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELiCopSJj2AC2UzF3i6feC)_