### PR TITLE
fix(test): 백테스트 비교 테스트의 실데이터 오염 격리

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,9 +37,12 @@ def isolate_backtest_filesystem(tmp_path, monkeypatch):
     #      docs/data 하위 상대 경로는 삭제를 건너뛴다. (tmp_path 등 절대 경로는 통과)
     import shutil as _shutil
     _real_rmtree = _shutil.rmtree
+    # 절대 경로로 docs/data를 가리키는 경우까지 차단하기 위해 abspath로 비교
+    _protected_root = os.path.abspath("docs/data")
 
     def _guarded_rmtree(path, *args, **kwargs):
-        if str(path).replace(os.sep, "/").startswith("docs/data"):
+        abs_path = os.path.abspath(str(path))
+        if abs_path == _protected_root or abs_path.startswith(_protected_root + os.sep):
             return
         return _real_rmtree(path, *args, **kwargs)
 
@@ -52,11 +55,14 @@ def isolate_backtest_filesystem(tmp_path, monkeypatch):
         def __init__(self, root_path=None, **kwargs):
             if root_path is None:
                 root_path = backtest_tmp
-            elif root_path.startswith("docs/data/backtest"):
-                # 하위 경로(compare/<엔진> 등)도 디렉토리 구조를 유지한 채 임시
-                # 경로로 리다이렉트한다. 기존의 정확 일치(==) 조건은 compare
-                # 하위 경로를 놓쳐 실제 커밋 데이터가 테스트로 덮어써졌다.
-                root_path = backtest_tmp + root_path[len("docs/data/backtest"):]
+            else:
+                # Path 객체/Windows 구분자(\)가 와도 판정되도록 정규화
+                norm = str(root_path).replace(os.sep, "/")
+                if norm.startswith("docs/data/backtest"):
+                    # 하위 경로(compare/<엔진> 등)도 디렉토리 구조를 유지한 채 임시
+                    # 경로로 리다이렉트한다. 기존의 정확 일치(==) 조건은 compare
+                    # 하위 경로를 놓쳐 실제 커밋 데이터가 테스트로 덮어써졌다.
+                    root_path = backtest_tmp + norm[len("docs/data/backtest"):]
             super().__init__(root_path, **kwargs)
 
     monkeypatch.setattr(runner_mod, "JsonRepository", _TmpBacktestRepo)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,13 +31,32 @@ def isolate_backtest_filesystem(tmp_path, monkeypatch):
     # 1. Path.iterdir no-op → 실제 backtest JSON 삭제 방지
     monkeypatch.setattr("pathlib.Path.iterdir", lambda self: iter([]))
 
+    # 1-b. shutil.rmtree 가드: run_compare_backtest는 실행 전 엔진 출력 디렉토리를
+    #      통째로 삭제한다 (runner.py의 shutil.rmtree(eng_path)). output_dir 기본값
+    #      ("docs/data/backtest/compare")으로 실행되면 실제 커밋 데이터가 삭제되므로
+    #      docs/data 하위 상대 경로는 삭제를 건너뛴다. (tmp_path 등 절대 경로는 통과)
+    import shutil as _shutil
+    _real_rmtree = _shutil.rmtree
+
+    def _guarded_rmtree(path, *args, **kwargs):
+        if str(path).replace(os.sep, "/").startswith("docs/data"):
+            return
+        return _real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(_shutil, "rmtree", _guarded_rmtree)
+
     # 2. JsonRepository가 backtest 경로 요청 시 임시 경로로 리다이렉트
     backtest_tmp = str(tmp_path / "backtest")
 
     class _TmpBacktestRepo(JsonRepository):
         def __init__(self, root_path=None, **kwargs):
-            if root_path is None or root_path == "docs/data/backtest":
+            if root_path is None:
                 root_path = backtest_tmp
+            elif root_path.startswith("docs/data/backtest"):
+                # 하위 경로(compare/<엔진> 등)도 디렉토리 구조를 유지한 채 임시
+                # 경로로 리다이렉트한다. 기존의 정확 일치(==) 조건은 compare
+                # 하위 경로를 놓쳐 실제 커밋 데이터가 테스트로 덮어써졌다.
+                root_path = backtest_tmp + root_path[len("docs/data/backtest"):]
             super().__init__(root_path, **kwargs)
 
     monkeypatch.setattr(runner_mod, "JsonRepository", _TmpBacktestRepo)

--- a/tests/test_backtest_compare.py
+++ b/tests/test_backtest_compare.py
@@ -37,12 +37,13 @@ def mock_compare_fetcher():
 
 @patch("src.backtest.runner.download_historical_data")
 @patch("src.backtest.runner.plt.savefig")
-def test_run_compare_backtest_returns_all_engines(mock_savefig, mock_download, mock_compare_fetcher):
+def test_run_compare_backtest_returns_all_engines(mock_savefig, mock_download, mock_compare_fetcher, tmp_path):
     """[Compare] 비교 백테스트가 4개 엔진 모두의 결과를 반환해야 한다."""
     mock_download.return_value = mock_compare_fetcher
 
     result = run_compare_backtest(
         start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+        output_dir=str(tmp_path / "compare"),
     )
 
     assert result is not None
@@ -53,12 +54,13 @@ def test_run_compare_backtest_returns_all_engines(mock_savefig, mock_download, m
 
 @patch("src.backtest.runner.download_historical_data")
 @patch("src.backtest.runner.plt.savefig")
-def test_run_compare_single_data_download(mock_savefig, mock_download, mock_compare_fetcher):
+def test_run_compare_single_data_download(mock_savefig, mock_download, mock_compare_fetcher, tmp_path):
     """[Compare] 데이터 다운로드가 정확히 1회만 호출되어야 한다."""
     mock_download.return_value = mock_compare_fetcher
 
     run_compare_backtest(
         start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+        output_dir=str(tmp_path / "compare"),
     )
 
     mock_download.assert_called_once()
@@ -73,12 +75,13 @@ def test_run_compare_single_data_download(mock_savefig, mock_download, mock_comp
 
 @patch("src.backtest.runner.download_historical_data")
 @patch("src.backtest.runner.plt.savefig")
-def test_run_compare_independent_portfolios(mock_savefig, mock_download, mock_compare_fetcher):
+def test_run_compare_independent_portfolios(mock_savefig, mock_download, mock_compare_fetcher, tmp_path):
     """[Compare] 각 엔진의 BacktestResult가 독립적이어야 한다."""
     mock_download.return_value = mock_compare_fetcher
 
     result = run_compare_backtest(
         start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+        output_dir=str(tmp_path / "compare"),
     )
 
     assert result is not None
@@ -92,12 +95,13 @@ def test_run_compare_independent_portfolios(mock_savefig, mock_download, mock_co
 
 @patch("src.backtest.runner.download_historical_data")
 @patch("src.backtest.runner.plt.savefig")
-def test_run_compare_chart_saved(mock_savefig, mock_download, mock_compare_fetcher):
+def test_run_compare_chart_saved(mock_savefig, mock_download, mock_compare_fetcher, tmp_path):
     """[Compare] 비교 차트가 저장되어야 한다."""
     mock_download.return_value = mock_compare_fetcher
 
     result = run_compare_backtest(
         start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+        output_dir=str(tmp_path / "compare"),
     )
 
     assert result is not None
@@ -107,7 +111,7 @@ def test_run_compare_chart_saved(mock_savefig, mock_download, mock_compare_fetch
 
 
 @patch("src.backtest.runner.download_historical_data")
-def test_run_compare_returns_none_on_missing_tickers(mock_download):
+def test_run_compare_returns_none_on_missing_tickers(mock_download, tmp_path):
     """[Compare] 티커 누락 시 None을 반환해야 한다."""
     # SPY만 있는 데이터 → 다른 티커 누락
     dates = pd.date_range(start="2022-01-01", end="2023-02-15")
@@ -122,6 +126,7 @@ def test_run_compare_returns_none_on_missing_tickers(mock_download):
 
     result = run_compare_backtest(
         start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+        output_dir=str(tmp_path / "compare"),
     )
 
     assert result is None
@@ -129,12 +134,13 @@ def test_run_compare_returns_none_on_missing_tickers(mock_download):
 
 @patch("src.backtest.runner.download_historical_data")
 @patch("src.backtest.runner.plt.savefig")
-def test_run_compare_spy_cagr_present(mock_savefig, mock_download, mock_compare_fetcher):
+def test_run_compare_spy_cagr_present(mock_savefig, mock_download, mock_compare_fetcher, tmp_path):
     """[Compare] SPY 데이터가 있으면 spy_cagr이 계산되어야 한다."""
     mock_download.return_value = mock_compare_fetcher
 
     result = run_compare_backtest(
         start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+        output_dir=str(tmp_path / "compare"),
     )
 
     assert result is not None
@@ -184,3 +190,37 @@ def test_stale_status_json_does_not_block_rebalancing(mock_savefig, mock_downloa
         assert br.final_value != br.initial_cash, (
             f"{name}: final_value가 initial_cash와 같음 — 리밸런싱이 실행되지 않았음"
         )
+
+
+@patch("src.backtest.runner.download_historical_data")
+@patch("src.backtest.runner.plt.savefig")
+def test_default_output_dir_isolated_from_real_data(mock_savefig, mock_download, mock_compare_fetcher):
+    """[격리] output_dir 기본값으로 실행해도 실제 docs/data/backtest 파일은 변하지 않는다.
+
+    conftest의 isolate_backtest_filesystem 픽스처가 compare 하위 경로까지
+    임시 디렉토리로 리다이렉트하는지 검증하는 회귀 가드.
+    (pathlib.Path.iterdir가 픽스처에서 no-op 처리되므로 os.walk로 스냅샷을 뜬다.)
+    """
+    import hashlib
+    import os
+
+    def snapshot(root):
+        state = {}
+        for dirpath, _, files in os.walk(root):
+            for fn in files:
+                path = os.path.join(dirpath, fn)
+                with open(path, "rb") as f:
+                    state[path] = hashlib.md5(f.read()).hexdigest()
+        return state
+
+    real_root = "docs/data/backtest"
+    before = snapshot(real_root)
+    mock_download.return_value = mock_compare_fetcher
+
+    run_compare_backtest(
+        start_date="2023-01-02", end_date="2023-01-05", initial_cash=10000.0,
+    )
+
+    assert snapshot(real_root) == before, (
+        "output_dir 기본값 실행이 실제 docs/data/backtest 파일을 수정했습니다"
+    )


### PR DESCRIPTION
## 문제
전체 pytest 실행 시 저장소에 커밋된 운영 데이터 `docs/data/backtest/compare/<엔진>/**`(7개 엔진의 summary/history/status 등)가 테스트 산출물로 **삭제·덮어쓰기** 되던 격리 결함입니다. CI는 결과를 커밋하지 않아 무해하지만, 로컬에서 테스트 후 `git add -A` 계열로 커밋하면 실데이터가 유실됩니다 (#357 작업 중 두 차례 수동 원복으로 발견).

## 원인 (2중 누출)
1. **JsonRepository 리다이렉트 조건이 정확 일치**: conftest의 `isolate_backtest_filesystem`이 `root_path == "docs/data/backtest"`만 임시 경로로 돌려서, `run_compare_backtest`가 만드는 `docs/data/backtest/compare/<엔진>` 하위 경로는 그대로 실제 디렉토리에 기록됨
2. **디렉토리 삭제 가드 부재**: `run_compare_backtest`는 실행 전 엔진 출력 디렉토리를 `shutil.rmtree(eng_path)`로 통째로 삭제하는데, 기존 `Path.iterdir` no-op 패치는 현재 구현(`eng_path.exists()` + `rmtree`)을 막지 못함
3. `tests/test_backtest_compare.py`의 6개 테스트가 `output_dir` 기본값(실제 경로)에 의존

## 수정
- **conftest**: 리다이렉트 조건을 `startswith("docs/data/backtest")`로 확대하고 하위 디렉토리 구조를 유지한 채 임시 경로로 매핑 (엔진별 출력이 섞이지 않음)
- **conftest**: `shutil.rmtree` 가드 추가 — `docs/data` 하위 상대 경로 삭제는 건너뛰고, `tmp_path` 등 절대 경로는 정상 삭제 (stale-status 테스트의 정리 동작 유지)
- **test_backtest_compare**: 6개 테스트에 `output_dir=str(tmp_path / "compare")` 명시 전달 — conftest 매직 없이도 전역 상태에 의존하지 않음
- **회귀 가드**: `output_dir` 기본값으로 실행해도 실제 `docs/data/backtest` 파일이 변하지 않음을 os.walk 스냅샷으로 검증하는 canary 테스트 추가 (수정 전에는 실패, 수정 후 통과 확인)

## 검증
- canary 테스트가 수정 전 코드에서 실제로 실패(파일 삭제 감지)함을 확인 후 수정 적용
- `pytest --cov=src --cov-fail-under=80 tests/`: **762 passed, 커버리지 93.8%** (`_live` 제외 실행)
- 전체 스위트 실행 후 `git status`에 docs/data 변경 없음 확인 (이 결함 발견 이후 처음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELiCopSJj2AC2UzF3i6feC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELiCopSJj2AC2UzF3i6feC)_