### PR TITLE
feat(account): 계좌 활성화/비활성화 기능

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ accounts.yaml            # 멀티 계정 설정 (accounts.yaml.example 참고)
 - `is_live` - 실거래 여부 (true/false)
 - `engine` - 사용할 엔진 이름 (레지스트리 키)
 - `kis_env_prefix` - 환경변수 prefix (예: "ACC1" → `ACC1_KIS_APP_KEY`)
+- `is_active` - 매매 활성화 여부 (선택, 기본값 true). false면 조회·국면분석·요약 저장까지만
+  하고 매매(주문 실행)는 스킵한다. 조회는 계속되어 최신 자산평가가 유지되므로 IRP(주문 API
+  불가) 계좌나 일시 정지에 사용. 비활성 시 history.json(매매 내역)은 기록되지 않고
+  summary.json/status.json만 갱신된다.
 
 ## 기간 결산 (net_deposit)
 - 봇이 매 실행 시 summary.json 레코드에 `net_deposit`(순입금 역산치)을 기록한다:

--- a/accounts.yaml.example
+++ b/accounts.yaml.example
@@ -9,6 +9,12 @@
 # 예: QldSHVEngine, QldSdyEngine, QqqSdyEngine, SpyEngine, QqqEngine, Asset5Engine,
 #     DomesticAsset5Engine, QldSdyShvEngine, QldQqqShvRegimeEngine, VolManagedEngine,
 #     DomesticVolManagedEngine
+#
+# is_active (선택, 기본값 true):
+#   true  - 정상 매매 (조회 → 국면분석 → 매매 → 저장)
+#   false - 매매 비활성. 조회·국면분석·요약 저장까지만 하고 주문은 스킵한다.
+#           최신 자산평가는 계속 갱신되므로 IRP처럼 주문 API가 불가한 계좌나
+#           일시적으로 매매를 멈추고 싶은 계좌에 사용한다.
 
 accounts:
   - id: my_pension
@@ -34,3 +40,10 @@ accounts:
     is_live: true
     engine: DomesticAsset5Engine
     kis_env_prefix: SPOUSE_ISA
+
+  - id: my_irp
+    market_type: domestic
+    is_live: true
+    is_active: false           # IRP — 조회만 수행, 매매 스킵
+    engine: DomesticVolManagedEngine
+    kis_env_prefix: MY_IRP

--- a/src/account_config.py
+++ b/src/account_config.py
@@ -25,6 +25,7 @@ class AccountConfig:
     app_key: str
     app_secret: str
     acc_no: str
+    is_active: bool = True     # False면 조회만 수행하고 매매는 스킵 (IRP/일시정지)
 
     def __post_init__(self):
         mt = (self.market_type or "").lower()
@@ -88,6 +89,7 @@ def load_accounts(path: str = "accounts.yaml") -> List[AccountConfig]:
                 id=acc_id,
                 market_type=raw.get("market_type", "overseas"),
                 is_live=bool(raw.get("is_live", False)),
+                is_active=bool(raw.get("is_active", True)),
                 engine_name=engine_name,
                 app_key=app_key,
                 app_secret=app_secret,

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -155,7 +155,7 @@ class TradingEngine:
             )
         else:
             signal, executions, final_pf, is_rebalancing = self.deactivated_cycle(
-                portfolio, regime, exposure, record_date
+                portfolio, regime, exposure, nan_fields, record_date
             )
 
         # Step 6: 저장 (NaN 데이터 품질 이상 시 전체 스킵 — step 4 API 오류와 동일 처리)
@@ -404,16 +404,53 @@ class TradingEngine:
         portfolio: Portfolio,
         regime: MarketRegime,
         exposure: float,
+        nan_fields: List[str],
         record_date: str,
     ) -> Tuple[TradeSignal, List[TradeExecution], Portfolio, bool]:
         """비활성 계좌용 Step 5: 매매 없이 조회 결과만 확정한다.
 
-        신호 생성(rebalancer)·주문 실행을 모두 건너뛰되, decision_factors 렌더링에
-        필요한 target_ratio_a/rebalance_threshold는 활성 분기와 동일하게 채워
-        대시보드 결정요소가 비지 않도록 한다. 반환 후 Step 6 persist가 조회한
-        포트폴리오를 그대로 저장하므로 최신 자산평가·국면이 갱신된다.
+        매매(execute_orders)·신호 생성(rebalancer)은 건너뛰지만, 자산평가 정확성이
+        비활성 모드의 목적이므로 활성 경로와 동일한 데이터 품질 검증(NaN / 보유 종목
+        0가격)은 유지해 문제 발생 시 Slack 경고를 보낸다. 검증 통과 시 조회 전용
+        신호를 만들고, decision_factors 렌더링에 필요한 target_ratio_a/
+        rebalance_threshold는 활성 분기와 동일하게 채운다. 반환 후 Step 6 persist가
+        조회한 포트폴리오를 저장하므로 최신 자산평가·국면이 갱신된다.
         """
         target_ratio_a, rebalance_threshold = self.rebalancer.get_target_params(regime)
+
+        # 데이터 품질 이상(NaN): Step 6에서 저장이 스킵되므로 알림만 보내 문제를 알린다.
+        if nan_fields:
+            signal = TradeSignal(0.0, [], f"데이터 이상 - NaN: {', '.join(nan_fields)}",
+                                 target_ratio_a=target_ratio_a, rebalance_threshold=rebalance_threshold)
+            msg = (
+                f"⚠️ Data Quality Alert (비활성) — 조회 결과 저장 중단\n"
+                f"날짜: {record_date}\n"
+                f"NaN 필드: {', '.join(nan_fields)}\n"
+                f"데이터 품질 이상으로 이번 조회 결과는 저장하지 않습니다."
+            )
+            self.logger.error(msg)
+            self._notify_alert(msg, detail=self._cycle_detail())
+            return signal, [], portfolio, False
+
+        # 보유 종목 가격 조회 실패(0.0 또는 누락): 저장되는 자산평가가 왜곡되므로 경고한다.
+        zero_price_tickers = [
+            t for t, q in portfolio.holdings.items()
+            if q > 0 and portfolio.current_prices.get(t, 0) <= 0
+        ]
+        if zero_price_tickers:
+            display_names = [ticker_display(t) for t in zero_price_tickers]
+            signal = TradeSignal(0.0, [], f"가격 조회 실패 — 자산평가 왜곡 가능: {', '.join(display_names)}",
+                                 target_ratio_a=target_ratio_a, rebalance_threshold=rebalance_threshold)
+            msg = (
+                f"⚠️ Price Data Alert (비활성) — 자산평가 왜곡 가능성\n"
+                f"날짜: {record_date}\n"
+                f"가격 조회 실패 종목: {', '.join(display_names)}\n"
+                f"보유 종목 가격 이상으로 저장되는 자산평가가 과소평가될 수 있습니다."
+            )
+            self.logger.error(msg)
+            self._notify_alert(msg, detail=self._cycle_detail())
+            return signal, [], portfolio, False
+
         signal = TradeSignal(
             exposure, [], f"{regime.value} (비활성 — 조회 전용)",
             target_ratio_a=target_ratio_a, rebalance_threshold=rebalance_threshold,

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -44,6 +44,7 @@ class TradingEngine:
         is_live_trading: bool = False,
         benchmarks: Optional[dict] = None,
         account_label: Optional[str] = None,
+        is_active: bool = True,
     ):
         # 클래스 속성 우선, 없으면 파라미터 사용
         groups = getattr(type(self), 'ASSET_GROUPS', asset_groups)
@@ -71,6 +72,9 @@ class TradingEngine:
         self.trading_interval_days = trading_interval_days
         self.notifier = notifier
         self.is_live_trading = is_live_trading
+        # 비활성(False) 계좌는 조회·국면분석·저장까지만 수행하고 매매(execute_orders)는 스킵한다.
+        # IRP처럼 주문 API가 불가하거나 일시 정지하려는 계좌에 사용. 조회는 계속되어 최신 자산평가 유지.
+        self.is_active = is_active
         # 멀티 계좌 Slack 알림에서 계좌를 구분하기 위한 라벨 (예: accounts.yaml의 id)
         self.account_label = account_label
 
@@ -143,9 +147,16 @@ class TradingEngine:
         )
 
         # Step 5: 조건 분기 & 실행
-        signal, executions, final_pf, is_rebalancing = self.execute_cycle(
-            market_data, portfolio, regime, exposure, nan_fields, sim_date, record_date
-        )
+        # 비활성 계좌는 매매를 하지 않는다. execute_cycle이 엔진별로 오버라이드되어 있어
+        # 게이트를 각 구현에 넣지 않고 상속 공통 지점인 이곳에서 한 번만 분기한다.
+        if self.is_active:
+            signal, executions, final_pf, is_rebalancing = self.execute_cycle(
+                market_data, portfolio, regime, exposure, nan_fields, sim_date, record_date
+            )
+        else:
+            signal, executions, final_pf, is_rebalancing = self.deactivated_cycle(
+                portfolio, regime, exposure, record_date
+            )
 
         # Step 6: 저장 (NaN 데이터 품질 이상 시 전체 스킵 — step 4 API 오류와 동일 처리)
         self.logger.info(">>> Step 6: Archiving Data")
@@ -387,6 +398,32 @@ class TradingEngine:
                 )
 
         return signal, executions, final_pf, is_rebalancing
+
+    def deactivated_cycle(
+        self,
+        portfolio: Portfolio,
+        regime: MarketRegime,
+        exposure: float,
+        record_date: str,
+    ) -> Tuple[TradeSignal, List[TradeExecution], Portfolio, bool]:
+        """비활성 계좌용 Step 5: 매매 없이 조회 결과만 확정한다.
+
+        신호 생성(rebalancer)·주문 실행을 모두 건너뛰되, decision_factors 렌더링에
+        필요한 target_ratio_a/rebalance_threshold는 활성 분기와 동일하게 채워
+        대시보드 결정요소가 비지 않도록 한다. 반환 후 Step 6 persist가 조회한
+        포트폴리오를 그대로 저장하므로 최신 자산평가·국면이 갱신된다.
+        """
+        target_ratio_a, rebalance_threshold = self.rebalancer.get_target_params(regime)
+        signal = TradeSignal(
+            exposure, [], f"{regime.value} (비활성 — 조회 전용)",
+            target_ratio_a=target_ratio_a, rebalance_threshold=rebalance_threshold,
+        )
+        self.logger.info(">>> Step 5: Deactivated (조회 전용, 매매 스킵)")
+        self._notify_message(
+            f"🔒 비활성 계좌 — 조회만 수행. {regime.value} | ${portfolio.total_value:,.0f}",
+            detail=self._cycle_detail(),
+        )
+        return signal, [], portfolio, False
 
     def persist(
         self,

--- a/src/main.py
+++ b/src/main.py
@@ -77,7 +77,8 @@ class TradingBot:
         for acc in accounts:
             self.logger.info(
                 f"[{acc.id}] engine={acc.engine_name} market={acc.market_type} "
-                f"mode={'LIVE' if acc.is_live else 'PAPER'}"
+                f"mode={'LIVE' if acc.is_live else 'PAPER'} "
+                f"state={'ACTIVE' if acc.is_active else 'INACTIVE(조회전용)'}"
             )
             engine_cls = _resolve_engine_class(acc.engine_name)
             asset_groups = getattr(engine_cls, "ASSET_GROUPS", self.strategy.ASSET_GROUPS)
@@ -101,6 +102,7 @@ class TradingBot:
                 is_live_trading=acc.is_live,
                 benchmarks=BENCHMARKS_BY_MARKET.get(acc.market_type, {}),
                 account_label=acc.id,
+                is_active=acc.is_active,
             )
             self.runners.append(AccountRunner(acc, engine, broker, repo))
 
@@ -121,6 +123,7 @@ class TradingBot:
                 "engine_name": r.account.engine_name,
                 "color": _ENGINE_COLORS.get(r.account.engine_name, "#6c757d"),
                 "is_live": r.account.is_live,
+                "is_active": r.account.is_active,
             }
             for r in self.runners
         }

--- a/tests/test_account_config.py
+++ b/tests/test_account_config.py
@@ -45,6 +45,44 @@ def test_load_accounts_happy(yaml_file, monkeypatch):
     assert accounts[1].is_live is False
 
 
+def test_load_accounts_is_active_defaults_true(yaml_file, monkeypatch):
+    """is_active 필드를 생략하면 기본값 True (하위 호환)."""
+    _set_env(monkeypatch, "ACC1")
+    _set_env(monkeypatch, "ACC2")
+    accounts = load_accounts(yaml_file)
+    assert accounts[0].is_active is True
+    assert accounts[1].is_active is True
+
+
+def test_load_accounts_is_active_false(tmp_path, monkeypatch):
+    """is_active: false를 명시하면 False로 파싱된다."""
+    p = tmp_path / "irp.yaml"
+    p.write_text(
+        """
+accounts:
+  - id: irp
+    market_type: domestic
+    is_live: true
+    is_active: false
+    engine: DomesticAsset5Engine
+    kis_env_prefix: IRP
+""",
+        encoding="utf-8",
+    )
+    _set_env(monkeypatch, "IRP")
+    accounts = load_accounts(str(p))
+    assert accounts[0].is_active is False
+
+
+def test_account_config_is_active_default():
+    """AccountConfig dataclass 기본값도 True."""
+    acc = AccountConfig(
+        id="x", market_type="overseas", is_live=False,
+        engine_name="SpyEngine", app_key="k", app_secret="s", acc_no="n",
+    )
+    assert acc.is_active is True
+
+
 def test_load_accounts_missing_file():
     with pytest.raises(FileNotFoundError):
         load_accounts("/nonexistent/accounts.yaml")

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -43,6 +43,7 @@ def _make_engine(
     notifier=None,
     trading_interval_days=5,
     is_live_trading=False,
+    is_active=True,
 ):
     """공통 TradingEngine Mock 조립."""
     broker = MagicMock()
@@ -75,6 +76,7 @@ def _make_engine(
             trading_interval_days=trading_interval_days,
             notifier=notifier,
             is_live_trading=is_live_trading,
+            is_active=is_active,
         )
 
     return engine, {
@@ -276,6 +278,84 @@ def test_zero_price_non_holding_does_not_abort():
     # 보유 종목(SSO)은 가격 정상 → 리밸런싱 실행돼야 함
     assert result.is_rebalancing is True
     mocks["rebalancer"].generate_signal.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────
+# 시나리오 5b: 비활성 계좌 (is_active=False) → 조회만, 매매 스킵
+# ─────────────────────────────────────────────────────────────────
+
+def test_inactive_account_skips_trading():
+    """is_active=False → 인터벌 충족·BULL이어도 매매/신호생성 스킵, 저장은 수행."""
+    engine, mocks = _make_engine(repo_last_reb=None, is_active=False)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    # 매매·신호 생성 모두 스킵
+    mocks["rebalancer"].generate_signal.assert_not_called()
+    mocks["broker"].execute_orders.assert_not_called()
+    assert result.is_rebalancing is False
+    assert result.executions == []
+    assert result.signal.orders == []
+    assert "비활성" in result.signal.reason
+
+
+def test_inactive_account_still_queries_and_persists_summary():
+    """비활성이어도 포트폴리오 조회는 하고 summary/status는 저장(최신 자산평가 유지).
+    단, 매매 내역(save_trade_history)은 executions가 비어 실질적으로 기록 안 됨."""
+    engine, mocks = _make_engine(repo_last_reb=None, is_active=False)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    # 조회는 수행
+    mocks["broker"].get_portfolio.assert_called()
+    # 저장(자산평가/상태) 수행
+    mocks["repo"].save_daily_summary.assert_called_once()
+    mocks["repo"].update_status.assert_called_once()
+    # save_trade_history는 빈 executions로 호출되어 실제 기록은 남지 않음
+    _, s_kwargs = mocks["repo"].save_daily_summary.call_args
+    assert s_kwargs.get("executions") == []
+
+
+def test_inactive_account_persists_target_ratio_for_factors():
+    """비활성 신호에도 target_ratio_a/rebalance_threshold가 채워져 결정요소가 비지 않는다."""
+    engine, mocks = _make_engine(repo_last_reb=None, is_active=False)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    # _make_engine의 rebalancer.get_target_params → (0.5, 0.075)
+    assert result.signal.target_ratio_a == 0.5
+    assert result.signal.rebalance_threshold == 0.075
+
+
+def test_inactive_account_sends_notification():
+    """비활성 계좌도 매 실행 시 조회 완료 알림을 보낸다."""
+    notifier = MagicMock()
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=notifier, is_active=False)
+    md = _make_market_data()
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    calls = [str(c) for c in notifier.send_message.call_args_list]
+    assert any("비활성" in c for c in calls)
 
 
 # ─────────────────────────────────────────────────────────────────

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -358,6 +358,54 @@ def test_inactive_account_sends_notification():
     assert any("비활성" in c for c in calls)
 
 
+def test_inactive_account_nan_sends_alert_and_skips_persist():
+    """비활성 계좌라도 NaN 데이터 시 alert 발송 + Step 6 저장 스킵(활성 경로와 동일)."""
+    notifier = MagicMock()
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=notifier, is_active=False)
+    md = _make_market_data(nan_vol=True)  # spy_volatility = NaN
+
+    mocks["calculator"].calculate.return_value = md
+
+    engine.run_one_cycle(mocks["data_provider"])
+
+    notifier.send_alert.assert_called_once()
+    msg = notifier.send_alert.call_args[0][0]
+    assert "Data Quality Alert (비활성)" in msg
+    assert "spy_volatility" in msg
+    # NaN → 저장 스킵
+    mocks["repo"].save_daily_summary.assert_not_called()
+    mocks["repo"].update_status.assert_not_called()
+
+
+def test_inactive_account_zero_price_holding_sends_alert():
+    """비활성 계좌에서 보유 종목 가격 조회 실패(0가격) 시 왜곡 경고 alert 발송."""
+    notifier = MagicMock()
+    engine, mocks = _make_engine(repo_last_reb=None, notifier=notifier, is_active=False)
+    md = _make_market_data()
+
+    # SSO 보유 중인데 가격이 0.0 (fetch 실패)
+    portfolio_with_zero = Portfolio(
+        total_cash=10000.0,
+        holdings={"SSO": 10},
+        current_prices={"SSO": 0.0},
+    )
+    mocks["broker"].get_portfolio.return_value = portfolio_with_zero
+    mocks["broker"].fetch_current_prices.return_value = {"SSO": 0.0}
+
+    mocks["calculator"].calculate.return_value = md
+    mocks["analyzer"].analyze.return_value = MarketRegime.BULL
+    mocks["targeter"].calculate_exposure.return_value = 1.0
+
+    result = engine.run_one_cycle(mocks["data_provider"])
+
+    notifier.send_alert.assert_called_once()
+    msg = notifier.send_alert.call_args[0][0]
+    assert "Price Data Alert (비활성)" in msg
+    assert "SSO" in result.signal.reason
+    # 매매는 여전히 없음
+    mocks["broker"].execute_orders.assert_not_called()
+
+
 # ─────────────────────────────────────────────────────────────────
 # 시나리오 6: 최초 실행 (last_rebalancing_date=None → is_due=True)
 # ─────────────────────────────────────────────────────────────────

--- a/tests/test_main_multi_account.py
+++ b/tests/test_main_multi_account.py
@@ -175,4 +175,5 @@ def test_multi_account_save_accounts_meta_writes_all_accounts(mock_multi_account
     assert set(accounts_meta.keys()) == {"acc1", "acc2"}
     assert accounts_meta["acc1"]["market_type"] == "overseas"
     assert accounts_meta["acc1"]["is_live"] is False
+    assert accounts_meta["acc1"]["is_active"] is True  # 기본값 True
     assert accounts_meta["acc2"]["market_type"] == "domestic"


### PR DESCRIPTION
## 개요
계좌별 **활성화/비활성화** 상태를 도입합니다. `accounts.yaml`의 `is_active` 필드(기본값 `true`)로 제어하며, `false`인 계좌는 **데이터 수집 → 국면 분석 → 포트폴리오 조회 → 요약 저장**까지만 수행하고 **매매(`execute_orders`)만 스킵**합니다.

조회는 계속되므로 최신 자산평가·국면이 유지됩니다. IRP처럼 주문 API가 불가한 계좌나, 일시적으로 매매를 멈추고 싶은 계좌에 사용합니다.

## 동작
| 항목 | 활성(`is_active: true`) | 비활성(`is_active: false`) |
|------|:---:|:---:|
| 데이터/국면 분석 | ✅ | ✅ |
| 포트폴리오 조회 | ✅ | ✅ |
| 신호 생성·매매 실행 | ✅ | ❌ 스킵 |
| `summary.json`/`status.json` 저장 | ✅ | ✅ (자산평가 갱신) |
| `history.json`(매매 내역) | ✅ | ❌ (매매 없음) |
| Slack 알림 | ✅ | ✅ (조회 완료 알림) |

## 설계 포인트
- 실제 매매(`broker.execute_orders`)는 `execute_cycle` 안에서 일어나고 이 메서드는 엔진별(base/voltarget/dip_buy)로 오버라이드됩니다. 게이트를 각 구현이 아니라 **모든 엔진이 상속하는 단일 지점인 `run_one_cycle`(Step 5)** 에 두어, 엔진 종류·추가와 무관하게 자동 적용되도록 했습니다.
- `deactivated_cycle`은 매매·신호 생성을 건너뛰되, 대시보드 결정요소가 비지 않도록 `target_ratio_a`/`rebalance_threshold`는 활성 분기와 동일하게 채웁니다.
- `is_active`는 기본값 `true` → 기존 계좌는 동작 변화 없음(하위 호환).

## 변경 파일
- `src/account_config.py` — `AccountConfig.is_active` 필드 + YAML 파싱
- `src/core/engine/base.py` — 생성자 `is_active`, `run_one_cycle` 게이트, `deactivated_cycle()`
- `src/main.py` — 엔진에 `is_active` 전달, 실행 로그 `ACTIVE/INACTIVE`, `accounts_meta.json`에 `is_active` 노출(프론트 배지용)
- `accounts.yaml.example`, `CLAUDE.md` — 문서화 + IRP 예시
- `tests/` — 계정 파싱/비활성 사이클 테스트 추가

## 테스트
- 단위 테스트 789 passed, 커버리지 94.42% (게이트 80% 충족)
- 실패한 11건은 `test_infra_data_live.py`(실제 yfinance API 호출, CI 제외 대상)로 이 변경과 무관한 환경 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpmE1136WaugBBST5MXuAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpmE1136WaugBBST5MXuAT)_