### PR TITLE
feat(dashboard): 포트폴리오 탭에 계좌별/종목별 비중 테이블 추가

### DIFF
--- a/docs/js/portfolio-allocation.js
+++ b/docs/js/portfolio-allocation.js
@@ -39,12 +39,15 @@ export function buildAllocation(accountsData) {
         }
         entry.value += addValue;
         // 아직 한글명 미해석(name === ticker)이면 이 계좌 설정으로 시도
+        // (헬퍼가 유효값을 반환할 때만 덮어써 방어)
         if (entry.name === ticker) {
-            entry.name = getTickerAlias(ticker, groupConfig);
+            const alias = getTickerAlias(ticker, groupConfig);
+            if (alias) entry.name = alias;
         }
         // 아직 그룹색 미해석이면 이 계좌 설정으로 시도
         if (entry.color === FALLBACK_COLOR) {
-            entry.color = getAssetGroup(ticker, groupConfig).color;
+            const group = getAssetGroup(ticker, groupConfig);
+            if (group && group.color) entry.color = group.color;
         }
     };
 
@@ -147,6 +150,9 @@ function buildTable(rowsHtml) {
 
 function buildRow(name, value, pct, color, marketType) {
     const pctStr = pct.toFixed(1);
+    // 음수(미수금 등)/100 초과 값이 CSS width를 깨뜨리지 않도록 바 너비만 [0,100]으로 제한.
+    // 텍스트 라벨(pctStr)은 실제 값을 그대로 표시한다.
+    const widthPct = Math.max(0, Math.min(100, pct));
     return `
         <tr>
             <td style="min-width: 120px;">
@@ -157,7 +163,7 @@ function buildRow(name, value, pct, color, marketType) {
             <td style="width: 38%;">
                 <div class="d-flex align-items-center gap-2">
                     <div class="progress flex-grow-1" style="height: 6px;">
-                        <div class="progress-bar" style="width: ${pctStr}%; background-color: ${color};"></div>
+                        <div class="progress-bar" style="width: ${widthPct}%; background-color: ${color};"></div>
                     </div>
                     <span class="small fw-semibold text-nowrap" style="min-width: 44px; text-align: right;">${pctStr}%</span>
                 </div>

--- a/docs/js/portfolio-allocation.js
+++ b/docs/js/portfolio-allocation.js
@@ -1,0 +1,167 @@
+// docs/js/portfolio-allocation.js
+// 통화 그룹별 비중 테이블 (계좌별 / 종목별)
+import {
+    formatAmount,
+    getTickerAlias, getAssetGroup,
+    ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES,
+} from './utils.js?v=20260624-5';
+
+const CASH_KEY = '__CASH__';
+const CASH_COLOR = '#dee2e6';
+const FALLBACK_COLOR = '#adb5bd';
+
+/**
+ * 통화 그룹(domestic/overseas)별 비중 집계 (순수 함수)
+ *
+ * 통화가 다르면 금액을 합산할 수 없으므로 그룹별로 따로 계산한다.
+ * - 계좌 비중 = 계좌 total_value / 그룹 총자산
+ * - 종목 비중 = 종목별 합산 평가금액 / 그룹 총자산 (현금은 '현금' 행으로 포함)
+ * 같은 티커가 여러 계좌에 걸쳐 있으면 합산하고, 한글명(alias)/그룹색은
+ * 해당 티커를 아는 계좌의 asset_groups.json에서 병합 조회한다.
+ *
+ * @param {Map<string, {status:Object, groupConfig:Object|null}>} accountsData
+ * @returns {Array<{marketType, total, accounts, tickers}>} total>0 그룹만
+ */
+export function buildAllocation(accountsData) {
+    const groups = new Map(); // marketType -> { total, accounts, tickerMap }
+
+    const groupOf = (mt) => {
+        if (!groups.has(mt)) groups.set(mt, { total: 0, accounts: [], tickerMap: new Map() });
+        return groups.get(mt);
+    };
+
+    // 종목 티커 항목을 얻거나 만들고, 이름/색을 최대한 해석한다.
+    const upsertTicker = (g, ticker, addValue, groupConfig) => {
+        let entry = g.tickerMap.get(ticker);
+        if (!entry) {
+            entry = { ticker, name: ticker, color: FALLBACK_COLOR, value: 0 };
+            g.tickerMap.set(ticker, entry);
+        }
+        entry.value += addValue;
+        // 아직 한글명 미해석(name === ticker)이면 이 계좌 설정으로 시도
+        if (entry.name === ticker) {
+            entry.name = getTickerAlias(ticker, groupConfig);
+        }
+        // 아직 그룹색 미해석이면 이 계좌 설정으로 시도
+        if (entry.color === FALLBACK_COLOR) {
+            entry.color = getAssetGroup(ticker, groupConfig).color;
+        }
+    };
+
+    for (const [id, data] of accountsData) {
+        const mt = ACCOUNT_MARKET_TYPES[id] || 'overseas';
+        const g = groupOf(mt);
+        const portfolio = data.status?.portfolio || {};
+        const totalValue = portfolio.total_value ?? 0;
+
+        g.total += totalValue;
+        g.accounts.push({ id, value: totalValue });
+
+        for (const h of portfolio.holdings || []) {
+            upsertTicker(g, h.ticker, h.value ?? 0, data.groupConfig);
+        }
+        const cash = portfolio.cash_balance ?? 0;
+        if (cash) {
+            let entry = g.tickerMap.get(CASH_KEY);
+            if (!entry) {
+                entry = { ticker: CASH_KEY, name: '현금', color: CASH_COLOR, value: 0 };
+                g.tickerMap.set(CASH_KEY, entry);
+            }
+            entry.value += cash;
+        }
+    }
+
+    const result = [];
+    for (const [marketType, g] of groups) {
+        if (g.total <= 0 || g.accounts.length === 0) continue;
+        const pct = (v) => (g.total > 0 ? (v / g.total) * 100 : 0);
+
+        const accounts = g.accounts
+            .map(a => ({ ...a, pct: pct(a.value), color: ACCOUNT_COLORS[a.id] || '#6c757d' }))
+            .sort((a, b) => b.value - a.value);
+
+        const tickers = [...g.tickerMap.values()]
+            .map(t => ({ ...t, pct: pct(t.value) }))
+            .sort((a, b) => b.value - a.value);
+
+        result.push({ marketType, total: g.total, accounts, tickers });
+    }
+    // KRW(domestic) 먼저, USD(overseas) 다음
+    result.sort((a, b) => (a.marketType === 'domestic' ? -1 : 1) - (b.marketType === 'domestic' ? -1 : 1));
+    return result;
+}
+
+/**
+ * 비중 테이블 섹션 렌더링 (계좌별 / 종목별 좌우 배치)
+ * @param {Map} accountsData
+ */
+export function renderAllocationSections(accountsData) {
+    const el = document.getElementById('allocation-sections');
+    if (!el) return;
+
+    const groups = buildAllocation(accountsData);
+    if (groups.length === 0) { el.innerHTML = ''; return; }
+
+    el.innerHTML = groups.map(g => {
+        const title = g.marketType === 'domestic' ? '🇰🇷 KRW 비중' : '🇺🇸 USD 비중';
+        const accountRows = g.accounts
+            .map(a => buildRow(a.id, a.value, a.pct, a.color, g.marketType))
+            .join('');
+        const tickerRows = g.tickers
+            .map(t => buildRow(t.name, t.value, t.pct, t.color, g.marketType))
+            .join('');
+
+        return `
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-header bg-white py-3">
+                    <h5 class="mb-0"><i class="fas fa-chart-pie me-2"></i>${title}</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-4">
+                        <div class="col-lg-6">
+                            <div class="text-muted small fw-bold mb-2">
+                                <i class="fas fa-wallet me-1"></i>계좌별 비중
+                            </div>
+                            ${buildTable(accountRows)}
+                        </div>
+                        <div class="col-lg-6">
+                            <div class="text-muted small fw-bold mb-2">
+                                <i class="fas fa-coins me-1"></i>종목별 비중
+                            </div>
+                            ${buildTable(tickerRows)}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `;
+    }).join('');
+}
+
+function buildTable(rowsHtml) {
+    return `
+        <table class="table table-sm align-middle mb-0">
+            <tbody>${rowsHtml}</tbody>
+        </table>
+    `;
+}
+
+function buildRow(name, value, pct, color, marketType) {
+    const pctStr = pct.toFixed(1);
+    return `
+        <tr>
+            <td style="min-width: 120px;">
+                <span style="color:${color};">■</span>
+                <span class="ms-1">${name}</span>
+            </td>
+            <td class="text-end text-nowrap text-muted small">${formatAmount(value, marketType)}</td>
+            <td style="width: 38%;">
+                <div class="d-flex align-items-center gap-2">
+                    <div class="progress flex-grow-1" style="height: 6px;">
+                        <div class="progress-bar" style="width: ${pctStr}%; background-color: ${color};"></div>
+                    </div>
+                    <span class="small fw-semibold text-nowrap" style="min-width: 44px; text-align: right;">${pctStr}%</span>
+                </div>
+            </td>
+        </tr>
+    `;
+}

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,6 +1,7 @@
 // docs/js/portfolio-main.js
 import { loadAccountsMeta } from './utils.js?v=20260624-5';
 import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260621-1';
+import { renderAllocationSections } from './portfolio-allocation.js?v=20260715-1';
 import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -32,6 +33,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // 렌더링
         renderCurrencySummary(accountsData);
+        renderAllocationSections(accountsData);
         renderAccountSections(accountsData);
         renderComparisonChart(accountsData);
         setupRangeSelector(accountsData);

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,7 +1,7 @@
 // docs/js/portfolio-main.js
 import { loadAccountsMeta } from './utils.js?v=20260624-5';
 import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260621-1';
-import { renderAllocationSections } from './portfolio-allocation.js?v=20260715-1';
+import { renderAllocationSections } from './portfolio-allocation.js?v=20260715-2';
 import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -69,6 +69,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-    <script type="module" src="js/portfolio-main.js?v=20260715-1"></script>
+    <script type="module" src="js/portfolio-main.js?v=20260715-2"></script>
 </body>
 </html>

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -34,6 +34,11 @@
             <!-- portfolio-main.js가 채움 -->
         </div>
 
+        <!-- 비중 테이블 섹션 (계좌별 / 종목별) -->
+        <div id="allocation-sections">
+            <!-- portfolio-main.js가 채움 -->
+        </div>
+
         <!-- 계좌 카드 섹션 (KRW / USD 순서) -->
         <div id="account-sections">
             <div class="text-center text-muted py-5">
@@ -64,6 +69,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-    <script type="module" src="js/portfolio-main.js?v=20260621-1"></script>
+    <script type="module" src="js/portfolio-main.js?v=20260715-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## 개요
포트폴리오 탭의 통화 합산 배너 바로 아래에 **비중(allocation) 테이블**을 추가한다. 기존에는 국내/해외 총계좌 합산 금액만 보였는데, 이제 그 금액이 어떻게 분포되는지 계좌별·종목별로 직관적으로 확인할 수 있다.

## 변경 사항
- **`docs/js/portfolio-allocation.js`** (신규)
  - 순수 집계 함수 `buildAllocation(accountsData)`: 통화 그룹(KRW/USD)별로 계좌·종목 비중을 계산
  - 렌더 함수 `renderAllocationSections(accountsData)`: 통화 그룹마다 카드 1개, 안에 계좌별/종목별 테이블을 좌우 배치. 각 행에 진행바로 비중 시각화
- **`docs/portfolio.html`**: 통화 합산 배너와 계좌 카드 섹션 사이에 `#allocation-sections` 컨테이너 추가
- **`docs/js/portfolio-main.js`**: 새 모듈 import 후 `renderAllocationSections` 호출

## 집계 규칙
- 통화가 다르면 금액을 합산할 수 없으므로 **통화 그룹별로 따로** 계산 (기존 `renderCurrencySummary`와 동일한 구조)
- **계좌별 비중** = 계좌 `total_value` / 그룹 총자산 (예: my_isa 92.3%, my_test 7.7%)
- **종목별 비중** = 같은 티커를 계좌 간 합산한 평가금액 / 그룹 총자산
  - 현금(`cash_balance`)은 `현금` 행으로 포함 → 분모가 계좌별 비중과 동일해 직접 비교 가능, 합계 100%
  - 한글명(alias)과 그룹색은 각 계좌 `asset_groups.json`에서 병합 조회
  - 비중 내림차순 정렬

## 설계
- 집계 로직을 순수 함수로 분리해 `portfolio-cards.js`는 손대지 않음 (SRP 유지)
- 프론트 캐시 무효화 규칙에 따라 신규 파일 `?v=20260715-1`, `portfolio-main.js`의 `?v`를 `portfolio.html`에서 갱신

## 검증
- 실제 `docs/data` 데이터로 `buildAllocation` 수치 대조: 계좌 비중 합 100%, 종목 비중 합 100%, 크로스 계좌 티커 합산 정상(`133690.KS` = 788,780 + 46,935,980 = 47,724,760)
- Chromium(Playwright)으로 `portfolio.html` 렌더 확인 — `🇰🇷 KRW 비중` 섹션에 계좌별/종목별 테이블과 현금 행이 올바르게 표시됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYMbxVrXRzhG3fgopn5rgR)_