### PR TITLE
feat(dashboard): 계좌 개요에 비활성(조회 전용) 배지 표시

### DIFF
--- a/docs/js/portfolio-allocation.js
+++ b/docs/js/portfolio-allocation.js
@@ -4,7 +4,7 @@ import {
     formatAmount,
     getTickerAlias, getAssetGroup,
     ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES,
-} from './utils.js?v=20260624-5';
+} from './utils.js?v=20260715-3';
 
 const CASH_KEY = '__CASH__';
 const CASH_COLOR = '#dee2e6';

--- a/docs/js/portfolio-cards.js
+++ b/docs/js/portfolio-cards.js
@@ -122,7 +122,7 @@ function buildCard(id, data, marketType) {
         <div class="col-sm-6 col-lg-4 col-xl-3">
             <div class="card h-100 border-0 shadow-sm" style="border-top: 3px solid ${color} !important;">
                 <div class="card-body d-flex flex-column">
-                    <div class="d-flex align-items-center mb-2 flex-wrap">
+                    <div class="d-flex align-items-center mb-2 flex-wrap row-gap-1">
                         <span class="fw-bold">${id}</span>
                         ${inactiveBadge}
                         ${dailyBadge}

--- a/docs/js/portfolio-cards.js
+++ b/docs/js/portfolio-cards.js
@@ -1,9 +1,9 @@
 // docs/js/portfolio-cards.js
 import {
     formatAmount,
-    ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES,
+    ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES, ACCOUNT_IS_ACTIVE,
     getRegimeColorClass
-} from './utils.js?v=20260624-5';
+} from './utils.js?v=20260715-3';
 
 /**
  * 통화별 합산 배너 렌더링
@@ -111,12 +111,20 @@ function buildCard(id, data, marketType) {
 
     const regimeClass = getRegimeColorClass(regime);
 
+    // 비활성(조회 전용) 계좌 배지 — is_active === false 일 때만 표시
+    const inactiveBadge = ACCOUNT_IS_ACTIVE[id] === false
+        ? `<span class="badge rounded-pill bg-secondary ms-2" title="비활성 계좌 — 매매 없이 조회만 수행(자산평가는 계속 갱신)">
+               <i class="fas fa-lock me-1"></i>조회 전용
+           </span>`
+        : '';
+
     return `
         <div class="col-sm-6 col-lg-4 col-xl-3">
             <div class="card h-100 border-0 shadow-sm" style="border-top: 3px solid ${color} !important;">
                 <div class="card-body d-flex flex-column">
-                    <div class="d-flex align-items-center mb-2">
+                    <div class="d-flex align-items-center mb-2 flex-wrap">
                         <span class="fw-bold">${id}</span>
+                        ${inactiveBadge}
                         ${dailyBadge}
                     </div>
                     <div class="fs-5 fw-bold mb-1">${formatAmount(totalValue, marketType)}</div>

--- a/docs/js/portfolio-charts.js
+++ b/docs/js/portfolio-charts.js
@@ -1,5 +1,5 @@
 // docs/js/portfolio-charts.js
-import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260624-5';
+import { ACCOUNT_COLORS, filterByDateRange } from './utils.js?v=20260715-3';
 
 let comparisonChart = null;
 

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,8 +1,8 @@
 // docs/js/portfolio-main.js
-import { loadAccountsMeta } from './utils.js?v=20260624-5';
-import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260621-1';
-import { renderAllocationSections } from './portfolio-allocation.js?v=20260715-2';
-import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=2';
+import { loadAccountsMeta } from './utils.js?v=20260715-3';
+import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260715-3';
+import { renderAllocationSections } from './portfolio-allocation.js?v=20260715-3';
+import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=20260715-3';
 
 document.addEventListener('DOMContentLoaded', async () => {
     const base = 'data/';

--- a/docs/js/portfolio-main.js
+++ b/docs/js/portfolio-main.js
@@ -1,6 +1,6 @@
 // docs/js/portfolio-main.js
 import { loadAccountsMeta } from './utils.js?v=20260715-3';
-import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260715-3';
+import { renderCurrencySummary, renderAccountSections } from './portfolio-cards.js?v=20260715-4';
 import { renderAllocationSections } from './portfolio-allocation.js?v=20260715-3';
 import { renderComparisonChart, updateChartRange } from './portfolio-charts.js?v=20260715-3';
 

--- a/docs/js/utils.js
+++ b/docs/js/utils.js
@@ -362,7 +362,13 @@ export const ACCOUNT_COLORS = {};
 export const ACCOUNT_MARKET_TYPES = {};
 
 /**
- * accounts_meta.json을 fetch하여 ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES를 채운다.
+ * 계좌별 매매 활성화 여부 런타임 맵. false면 조회 전용(비활성) 계좌.
+ * accounts_meta.json에 값이 없으면(구버전 데이터) 기본 활성(true)으로 간주한다.
+ */
+export const ACCOUNT_IS_ACTIVE = {};
+
+/**
+ * accounts_meta.json을 fetch하여 ACCOUNT_COLORS, ACCOUNT_MARKET_TYPES, ACCOUNT_IS_ACTIVE를 채운다.
  * loadLiveMode() 시작 시 먼저 호출된다.
  * @param {string} basePath - accounts_meta.json이 있는 경로 (예: 'data/')
  */
@@ -374,6 +380,8 @@ export async function loadAccountsMeta(basePath) {
         for (const [id, info] of Object.entries(meta)) {
             ACCOUNT_COLORS[id] = info.color;
             ACCOUNT_MARKET_TYPES[id] = info.market_type || 'overseas';
+            // is_active 미기재(구버전 데이터)는 활성으로 간주
+            ACCOUNT_IS_ACTIVE[id] = info.is_active !== false;
         }
     } catch (e) {
         console.warn('accounts_meta.json 로드 실패 — 폴백 색상(#6c757d) 사용');

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -69,6 +69,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-    <script type="module" src="js/portfolio-main.js?v=20260715-2"></script>
+    <script type="module" src="js/portfolio-main.js?v=20260715-3"></script>
 </body>
 </html>

--- a/docs/portfolio.html
+++ b/docs/portfolio.html
@@ -69,6 +69,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
-    <script type="module" src="js/portfolio-main.js?v=20260715-3"></script>
+    <script type="module" src="js/portfolio-main.js?v=20260715-4"></script>
 </body>
 </html>


### PR DESCRIPTION
## 개요
정적 대시보드(`portfolio.html`)의 계좌 개요 카드에서 **비활성(조회 전용) 계좌를 한눈에 구분**할 수 있도록 배지를 추가합니다. 데이터(`is_active`)는 이미 `accounts_meta.json`에 저장되고 있었으나 프론트가 표시하지 않던 부분을 채웁니다.

## 동작
- `accounts_meta.json`의 `is_active`가 `false`인 계좌 카드에 `🔒 조회 전용` 배지 표시
- `is_active` 필드가 없는 구버전 데이터는 **활성으로 간주**(배지 미표시) — 하위 호환
- 상세 페이지(`index.html`)는 이미 상태 배너의 `trigger_reason`("… 비활성 — 조회 전용")으로 노출되고 있어 별도 변경 불필요

## 변경 파일
- `docs/js/utils.js` — `loadAccountsMeta`가 `ACCOUNT_IS_ACTIVE` 맵을 채우도록 추가·export
- `docs/js/portfolio-cards.js` — `buildCard`에서 `is_active === false`일 때 배지 렌더
- `docs/js/portfolio-allocation.js`, `docs/js/portfolio-charts.js`, `docs/js/portfolio-main.js`, `docs/portfolio.html` — ESM 캐시 버전(`?v=`) 갱신

## ESM 버전 관리
`utils.js`는 여러 모듈이 `import`하므로, 같은 페이지에서 **단일 모듈 인스턴스**를 공유하도록 portfolio 페이지 그래프(main/cards/allocation/charts)의 `utils.js` import 버전을 `20260715-3`으로 **일괄** 갱신했습니다. portfolio 전용 모듈이라 다른 페이지(index/compare)에는 영향이 없습니다. 진입 스크립트(`portfolio-main.js`)와 그 하위 import 버전도 함께 갱신했습니다.

## 검증
- Playwright로 `portfolio.html` 렌더: `my_isa`(is_active=false) 카드에만 "조회 전용" 배지가 뜨고 `my_test`(활성)엔 없음, 페이지 에러 없음 확인
- 편집한 JS 5개 `node --check` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpmE1136WaugBBST5MXuAT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpmE1136WaugBBST5MXuAT)_