### PR TITLE
fix(broker): 호가 조회 시 토큰 갱신 실패도 예외 처리에 포함

### DIFF
--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -361,10 +361,8 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             "FID_INPUT_ISCD": _to_kis_code(ticker)
         }
         try:
-            # 토큰 갱신(_ensure_token)도 try 안에서 수행 — 매도 체결 후 매수 단계에서
-            # 토큰 재발급이 실패하면 예외가 그대로 전파되어 사이클 전체가 중단되고
-            # 이미 체결된 매도 내역까지 저장되지 않는 위험이 있었음
-            self._ensure_token()
+            # 헤더 생성 과정에서 토큰 갱신(_ensure_token)이 함께 수행되므로,
+            # 이를 try 블록 내부로 이동하여 토큰 재발급 실패 예외도 함께 처리합니다.
             headers = self._get_header(self.ASKING_PRICE_TR_ID)
             time.sleep(0.1)
             res = _pkg.requests.get(url, headers=headers, params=params, timeout=_pkg.KIS_HTTP_TIMEOUT)

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -355,14 +355,17 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
     def _fetch_asking_price(self, ticker: str) -> tuple:
         """국내주식 호가 조회: (best_bid, best_ask) 반환. 실패 시 (0.0, 0.0)"""
-        self._ensure_token()
         url = f"{self.base_url}/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
         params = {
             "FID_COND_MRKT_DIV_CODE": "J",
             "FID_INPUT_ISCD": _to_kis_code(ticker)
         }
-        headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
+            # 토큰 갱신(_ensure_token)도 try 안에서 수행 — 매도 체결 후 매수 단계에서
+            # 토큰 재발급이 실패하면 예외가 그대로 전파되어 사이클 전체가 중단되고
+            # 이미 체결된 매도 내역까지 저장되지 않는 위험이 있었음
+            self._ensure_token()
+            headers = self._get_header(self.ASKING_PRICE_TR_ID)
             time.sleep(0.1)
             res = _pkg.requests.get(url, headers=headers, params=params, timeout=_pkg.KIS_HTTP_TIMEOUT)
             res.raise_for_status()

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -423,12 +423,15 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
     def _fetch_asking_price(self, ticker: str) -> tuple:
         """호가 조회: (best_bid, best_ask) 반환. 실패 시 (0.0, 0.0)"""
-        self._ensure_token()
         url = f"{self.base_url}/uapi/overseas-price/v1/quotations/inquire-asking-price"
         exch = self._get_exchange_code(ticker)
         params = {"AUTH": "", "EXCD": exch, "SYMB": ticker}
-        headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
+            # 토큰 갱신(_ensure_token)도 try 안에서 수행 — 매도 체결 후 매수 단계에서
+            # 토큰 재발급이 실패하면 예외가 그대로 전파되어 사이클 전체가 중단되고
+            # 이미 체결된 매도 내역까지 저장되지 않는 위험이 있었음
+            self._ensure_token()
+            headers = self._get_header(self.ASKING_PRICE_TR_ID)
             time.sleep(0.1)
             res = _pkg.requests.get(url, headers=headers, params=params, timeout=_pkg.KIS_HTTP_TIMEOUT)
             res.raise_for_status()

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -427,10 +427,8 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         exch = self._get_exchange_code(ticker)
         params = {"AUTH": "", "EXCD": exch, "SYMB": ticker}
         try:
-            # 토큰 갱신(_ensure_token)도 try 안에서 수행 — 매도 체결 후 매수 단계에서
-            # 토큰 재발급이 실패하면 예외가 그대로 전파되어 사이클 전체가 중단되고
-            # 이미 체결된 매도 내역까지 저장되지 않는 위험이 있었음
-            self._ensure_token()
+            # 헤더 생성 과정에서 토큰 갱신(_ensure_token)이 함께 수행되므로,
+            # 이를 try 블록 내부로 이동하여 토큰 재발급 실패 예외도 함께 처리합니다.
             headers = self._get_header(self.ASKING_PRICE_TR_ID)
             time.sleep(0.1)
             res = _pkg.requests.get(url, headers=headers, params=params, timeout=_pkg.KIS_HTTP_TIMEOUT)


### PR DESCRIPTION
## 배경

멀티 계좌 실행에서 한 계좌의 KIS API 오류가 다른 계좌 저장을 막지 않도록 수정한 뒤, 위험성을 재검토하다가 별도의 기존 위험을 발견했다.

`_fetch_asking_price()`는 자체 `try` 블록에 진입하기 전에 `self._ensure_token()`과 `self._get_header()`를 호출하고 있었다. 매수 루프(`kis_base.py`의 `execute_orders`)에서 매도 주문이 이미 체결된 후 매수 단계에 진입했을 때, 이 호출 지점에서 토큰 재발급이 실패(네트워크 오류 등)하면 예외가 `try/except`에 걸리지 않고 그대로 `execute_orders` → `execute_cycle` → `run_one_cycle`까지 전파되어 사이클 전체가 중단된다. 이 경우 Step 6(persist)이 스킵되어 **이미 체결된 매도 내역이 저장되지 않는** 위험이 있었다.

## 변경 내용

`src/infra/broker/kis_domestic.py`, `src/infra/broker/kis_overseas.py`의 `_fetch_asking_price()`에서 `_ensure_token()` / `_get_header()` 호출을 기존 `try` 블록 안으로 이동. 토큰 갱신 실패도 기존 실패 처리 경로(`(0.0, 0.0)` 반환 + 경고 로그)로 흡수되어, 호출자(주문 루프)는 "호가 조회 실패"로 처리하고 해당 주문만 스킵한 뒤 사이클을 계속 진행한다.

## 테스트

- `pytest tests/test_infra_broker_kis.py tests/test_infra_broker_kis_domestic.py -q --no-cov` → 139 passed
- `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/ --ignore=tests/test_infra_broker_kis_domestic_live.py --ignore=tests/test_infra_data_live.py` (CI와 동일 조건) → 전체 통과, 커버리지 94%


---
_Generated by [Claude Code](https://claude.ai/code/session_01EekkRz6Qg8Qwj2WydRNdnh)_